### PR TITLE
UPBGE: Fix compound ray cast with triangle child shape.

### DIFF
--- a/extern/bullet/src/BulletCollision/CollisionDispatch/btCollisionWorld.cpp
+++ b/extern/bullet/src/BulletCollision/CollisionDispatch/btCollisionWorld.cpp
@@ -340,8 +340,8 @@ void	btCollisionWorld::rayTestSingleInternal(const btTransform& rayFromTrans,con
 						collisionObjectWrap->getCollisionObject(),
 						0,
 						castResult.m_normal,
-						castResult.m_fraction
-						);
+						castResult.m_fraction,
+						-1);
 
 					bool normalInWorldSpace = true;
 					resultCallback.addSingleResult(localRayResult, normalInWorldSpace);
@@ -386,7 +386,8 @@ void	btCollisionWorld::rayTestSingleInternal(const btTransform& rayFromTrans,con
 							(m_collisionObject,
 							&shapeInfo,
 							hitNormalWorld,
-							hitFraction);
+							hitFraction,
+							-1);
 
 						bool	normalInWorldSpace = true;
 						return m_resultCallback->addSingleResult(rayResult,normalInWorldSpace);
@@ -468,7 +469,8 @@ void	btCollisionWorld::rayTestSingleInternal(const btTransform& rayFromTrans,con
 							(m_collisionObject,
 							&shapeInfo,
 							hitNormalWorld,
-							hitFraction);
+							hitFraction,
+							-1);
 
 						bool	normalInWorldSpace = true;
 						return m_resultCallback->addSingleResult(rayResult,normalInWorldSpace);
@@ -509,11 +511,7 @@ void	btCollisionWorld::rayTestSingleInternal(const btTransform& rayFromTrans,con
 
 					virtual btScalar addSingleResult (btCollisionWorld::LocalRayResult &r, bool b)
 					{
-						btCollisionWorld::LocalShapeInfo shapeInfo;
-						shapeInfo.m_shapePart = -1;
-						shapeInfo.m_triangleIndex = m_i;
-						if (r.m_localShapeInfo == NULL)
-							r.m_localShapeInfo = &shapeInfo;
+						r.m_childIndex = m_i;
 
 						const btScalar result = m_userCallback->addSingleResult(r, b);
 						m_closestHitFraction = m_userCallback->m_closestHitFraction;

--- a/extern/bullet/src/BulletCollision/CollisionDispatch/btCollisionWorld.h
+++ b/extern/bullet/src/BulletCollision/CollisionDispatch/btCollisionWorld.h
@@ -188,11 +188,13 @@ public:
 		LocalRayResult(const btCollisionObject*	collisionObject, 
 			LocalShapeInfo*	localShapeInfo,
 			const btVector3&		hitNormalLocal,
-			btScalar hitFraction)
+			btScalar hitFraction,
+			int childIndex)
 		:m_collisionObject(collisionObject),
 		m_localShapeInfo(localShapeInfo),
 		m_hitNormalLocal(hitNormalLocal),
-		m_hitFraction(hitFraction)
+		m_hitFraction(hitFraction),
+		m_childIndex(childIndex)
 		{
 		}
 
@@ -200,7 +202,7 @@ public:
 		LocalShapeInfo*			m_localShapeInfo;
 		btVector3				m_hitNormalLocal;
 		btScalar				m_hitFraction;
-
+		int m_childIndex;
 	};
 
 	///RayResultCallback is used to report new raycast results

--- a/extern/bullet/src/BulletSoftBody/btSoftMultiBodyDynamicsWorld.cpp
+++ b/extern/bullet/src/BulletSoftBody/btSoftMultiBodyDynamicsWorld.cpp
@@ -317,7 +317,8 @@ void	btSoftMultiBodyDynamicsWorld::rayTestSingle(const btTransform& rayFromTrans
 						(collisionObject,
 						 &shapeInfo,
 						 normal,
-						 softResult.fraction);
+						 softResult.fraction,
+						 -1);
 					bool	normalInWorldSpace = true;
 					resultCallback.addSingleResult(rayResult,normalInWorldSpace);
 				}

--- a/extern/bullet/src/BulletSoftBody/btSoftRigidDynamicsWorld.cpp
+++ b/extern/bullet/src/BulletSoftBody/btSoftRigidDynamicsWorld.cpp
@@ -317,7 +317,8 @@ void	btSoftRigidDynamicsWorld::rayTestSingle(const btTransform& rayFromTrans,con
 						(collisionObject,
 						 &shapeInfo,
 						 normal,
-						 softResult.fraction);
+						 softResult.fraction,
+						 -1);
 					bool	normalInWorldSpace = true;
 					resultCallback.addSingleResult(rayResult,normalInWorldSpace);
 				}

--- a/extern/bullet/src/BulletSoftBody/btSoftRigidDynamicsWorldMt.cpp
+++ b/extern/bullet/src/BulletSoftBody/btSoftRigidDynamicsWorldMt.cpp
@@ -318,7 +318,8 @@ void	btSoftRigidDynamicsWorldMt::rayTestSingle(const btTransform& rayFromTrans,c
 						(collisionObject,
 						 &shapeInfo,
 						 normal,
-						 softResult.fraction);
+						 softResult.fraction,
+						 -1);
 					bool	normalInWorldSpace = true;
 					resultCallback.addSingleResult(rayResult,normalInWorldSpace);
 				}

--- a/source/gameengine/Physics/Bullet/CcdPhysicsController.cpp
+++ b/source/gameengine/Physics/Bullet/CcdPhysicsController.cpp
@@ -2142,6 +2142,11 @@ btCollisionShape *CcdShapeConstructionInfo::CreateBulletShape(btScalar margin, b
 			BLI_assert(false);
 		}
 	}
+
+	if (collisionShape) {
+		collisionShape->setUserPointer(this);
+	}
+
 	return collisionShape;
 }
 


### PR DESCRIPTION
Previously when a compound shape was hit by a ray cast the information about
the children triangles was inaccessible because of a lack from the bullet
API.

To fix this issue we have to keep the triangle index but add a child index
of the compound child shape hit. m_childIndex is dedicated for in LocalRayResult
and its value is set in rayTestSingleInternal, -1 for non compound shapes.

This value is catch from FilterClosestRayResultCallback and used in RayTest
to get the actual collision shape. To still get the shape construction info
of the children, each collision shape created has as user pointer the
shape costruction info. This object is get in RayTest to find the mesh
and polygon.

Tested with:
- mix of convex and concave shape in a compound shape.
- non compound concave and convex shape.

Example file:
[ge_compound.zip](https://github.com/UPBGE/blender/files/2237920/ge_compound.zip)
The hit polygon color is set to red. The compound shape is made of two triangle mesh (concave) and a box (convex), the fourth object is a non-compound triangle mesh (concave).