### PR TITLE
UPBGE: Optimize transparent mesh sorting.

### DIFF
--- a/source/gameengine/Rasterizer/CMakeLists.txt
+++ b/source/gameengine/Rasterizer/CMakeLists.txt
@@ -82,6 +82,7 @@ set(SRC
 	RAS_OffScreen.cpp
 	RAS_Query.cpp
 	RAS_Shader.cpp
+	RAS_SortedMeshSlot.cpp
 	RAS_Texture.cpp
 	RAS_TextureRenderer.cpp
 	RAS_TextUser.cpp
@@ -120,6 +121,7 @@ set(SRC
 	RAS_Query.h
 	RAS_Rect.h
 	RAS_Shader.h
+	RAS_SortedMeshSlot.h
 	RAS_Texture.h
 	RAS_TextureRenderer.h
 	RAS_TextUser.h

--- a/source/gameengine/Rasterizer/RAS_BoundingBox.cpp
+++ b/source/gameengine/Rasterizer/RAS_BoundingBox.cpp
@@ -128,8 +128,7 @@ RAS_MeshBoundingBox::RAS_MeshBoundingBox(RAS_BoundingBoxManager *manager, const 
 	:RAS_BoundingBox(manager)
 {
 	for (RAS_DisplayArray *array : displayArrayList) {
-		m_slots.push_back({array, {RAS_DisplayArray::POSITION_MODIFIED, RAS_DisplayArray::NONE_MODIFIED},
-		                   mt::zero3, mt::zero3});
+		m_slots.push_back({array, {RAS_DisplayArray::POSITION_MODIFIED, RAS_DisplayArray::NONE_MODIFIED}});
 	}
 
 	for (DisplayArraySlot& slot : m_slots) {
@@ -164,16 +163,7 @@ void RAS_MeshBoundingBox::Update(bool force)
 		}
 		modified = true;
 
-		slot.m_aabbMin = mt::vec3(FLT_MAX);
-		slot.m_aabbMax = mt::vec3(-FLT_MAX);
-
-		// For each vertex.
-		for (unsigned int i = 0, size = array->GetVertexCount(); i < size; ++i) {
-			const mt::vec3 vertPos(array->GetPosition(i));
-
-			slot.m_aabbMin = mt::vec3::Min(slot.m_aabbMin, vertPos);
-			slot.m_aabbMax = mt::vec3::Max(slot.m_aabbMax, vertPos);
-		}
+		array->UpdateAabb();
 	}
 
 	if (modified) {
@@ -181,8 +171,12 @@ void RAS_MeshBoundingBox::Update(bool force)
 		m_aabbMax = mt::vec3(-FLT_MAX);
 
 		for (const DisplayArraySlot& slot : m_slots) {
-			m_aabbMin = mt::vec3::Min(m_aabbMin, slot.m_aabbMin);
-			m_aabbMax = mt::vec3::Max(m_aabbMax, slot.m_aabbMax);
+			mt::vec3 aabbMin;
+			mt::vec3 aabbMax;
+			slot.m_displayArray->GetAabb(aabbMin, aabbMax);
+
+			m_aabbMin = mt::vec3::Min(m_aabbMin, aabbMin);
+			m_aabbMax = mt::vec3::Max(m_aabbMax, aabbMax);
 		}
 	}
 

--- a/source/gameengine/Rasterizer/RAS_BoundingBox.h
+++ b/source/gameengine/Rasterizer/RAS_BoundingBox.h
@@ -87,15 +87,10 @@ private:
 	{
 		RAS_DisplayArray *m_displayArray;
 		CM_UpdateClient<RAS_DisplayArray> m_arrayUpdateClient;
-		/// AABB minimum of only this display array.
-		mt::vec3 m_aabbMin;
-		/// AABB maximum of only this display array.
-		mt::vec3 m_aabbMax;
 	};
 
 	/// The sub AABB per display array.
-	// Use aligned allocator because DisplayArraySlot use aligned members.
-	std::vector<DisplayArraySlot, mt::simd_allocator<DisplayArraySlot> > m_slots;
+	std::vector<DisplayArraySlot> m_slots;
 
 public:
 	RAS_MeshBoundingBox(RAS_BoundingBoxManager *manager, const RAS_DisplayArrayList& displayArrayList);

--- a/source/gameengine/Rasterizer/RAS_BucketManager.h
+++ b/source/gameengine/Rasterizer/RAS_BucketManager.h
@@ -43,30 +43,6 @@ class RAS_BucketManager : public mt::SimdClassAllocator
 {
 public:
 	typedef std::vector<RAS_MaterialBucket *> BucketList;
-	class SortedMeshSlot
-	{
-	public:
-		/// depth
-		float m_z;
-
-		union {
-			RAS_MeshSlot *m_ms;
-			RAS_MeshSlotUpwardNode *m_node;
-		};
-
-		SortedMeshSlot() = default;
-		SortedMeshSlot(RAS_MeshSlot *ms, const mt::vec3& pnorm);
-		SortedMeshSlot(RAS_MeshSlotUpwardNode *node, const mt::vec3& pnorm);
-	};
-
-	struct backtofront
-	{
-		bool operator()(const SortedMeshSlot &a, const SortedMeshSlot &b);
-	};
-	struct fronttoback
-	{
-		bool operator()(const SortedMeshSlot &a, const SortedMeshSlot &b);
-	};
 
 protected:
 	enum BucketType {

--- a/source/gameengine/Rasterizer/RAS_DisplayArray.cpp
+++ b/source/gameengine/Rasterizer/RAS_DisplayArray.cpp
@@ -211,6 +211,38 @@ void RAS_DisplayArray::UpdateFrom(RAS_DisplayArray *other, int flag)
 	NotifyUpdate(flag);
 }
 
+void RAS_DisplayArray::GetAabb(mt::vec3& aabbMin, mt::vec3& aabbMax) const
+{
+	aabbMin = m_aabbMin;
+	aabbMax = m_aabbMax;
+}
+
+const mt::vec3& RAS_DisplayArray::GetAabbCenter() const
+{
+	return m_aabbCenter;
+}
+
+float RAS_DisplayArray::GetAabbRadius() const
+{
+	return m_aabbRadius;
+}
+
+void RAS_DisplayArray::UpdateAabb()
+{
+	m_aabbMin = mt::vec3(FLT_MAX);
+	m_aabbMax = mt::vec3(-FLT_MAX);
+
+	for (const mt::vec3_packed& pos : m_vertexData.positions) {
+		const mt::vec3 p(pos);
+
+		m_aabbMin = mt::vec3::Min(m_aabbMin, p);
+		m_aabbMax = mt::vec3::Max(m_aabbMax, p);
+	}
+
+	m_aabbCenter = (m_aabbMin + m_aabbMax) * 0.5f;
+	m_aabbRadius = (m_aabbMax - m_aabbMin).Length() * 0.5f;
+}
+
 const RAS_DisplayArray::Format& RAS_DisplayArray::GetFormat() const
 {
 	return m_format;

--- a/source/gameengine/Rasterizer/RAS_DisplayArray.h
+++ b/source/gameengine/Rasterizer/RAS_DisplayArray.h
@@ -44,7 +44,7 @@
 class RAS_BatchDisplayArray;
 class RAS_StorageVbo;
 
-class RAS_DisplayArray : public CM_UpdateServer<RAS_DisplayArray>
+class RAS_DisplayArray : public CM_UpdateServer<RAS_DisplayArray>, public mt::SimdClassAllocator
 {
 	friend RAS_BatchDisplayArray;
 	friend RAS_StorageVbo;
@@ -132,6 +132,12 @@ protected:
 	 * This list is stored here because we sort per array not per entire mesh.
 	 */
 	std::vector<mt::vec3, mt::simd_allocator<mt::vec3> > m_polygonCenters;
+
+	/// AABB used for culling or for sorting center.
+	mt::vec3 m_aabbMin;
+	mt::vec3 m_aabbMax;
+	mt::vec3 m_aabbCenter;
+	float m_aabbRadius;
 
 	/// The OpenGL data storage used for rendering.
 	RAS_DisplayArrayStorage m_storage;
@@ -294,6 +300,11 @@ public:
 	 * \param flag The flag coresponding to datas to copy.
 	 */
 	void UpdateFrom(RAS_DisplayArray *other, int flag);
+
+	void GetAabb(mt::vec3& aabbMin, mt::vec3& aabbMax) const;
+	const mt::vec3& GetAabbCenter() const;
+	float GetAabbRadius() const;
+	void UpdateAabb();
 
 	/// Return the primitive type used for indices.
 	PrimitiveType GetPrimitiveType() const;

--- a/source/gameengine/Rasterizer/RAS_DisplayArrayBucket.cpp
+++ b/source/gameengine/Rasterizer/RAS_DisplayArrayBucket.cpp
@@ -39,7 +39,7 @@
 #include "RAS_Deformer.h"
 #include "RAS_Rasterizer.h"
 #include "RAS_InstancingBuffer.h"
-#include "RAS_BucketManager.h"
+#include "RAS_SortedMeshSlot.h"
 
 #include <algorithm>
 
@@ -256,16 +256,7 @@ void RAS_DisplayArrayBucket::RunInstancingNode(const RAS_DisplayArrayNodeTuple& 
 	 * This code share the code used in RAS_BucketManager to do the sort.
 	 */
 	if (managerData->m_sort) {
-		std::vector<RAS_BucketManager::SortedMeshSlot> sortedMeshSlots(nummeshslots);
-
-		const mt::mat3x4& trans = managerData->m_trans;
-		const mt::vec3 pnorm(trans[2], trans[5], trans[8]);
-		std::transform(m_activeMeshSlots.begin(), m_activeMeshSlots.end(), sortedMeshSlots.end(),
-		               [&pnorm](RAS_MeshSlot *slot) {
-			return RAS_BucketManager::SortedMeshSlot(slot, pnorm);
-		});
-
-		std::sort(sortedMeshSlots.begin(), sortedMeshSlots.end(), RAS_BucketManager::backtofront());
+		const RAS_SortedMeshSlotList sortedMeshSlots = RAS_SortedMeshSlot::Sort(m_activeMeshSlots, managerData->m_trans);
 		RAS_MeshSlotList meshSlots(nummeshslots);
 		for (unsigned int i = 0; i < nummeshslots; ++i) {
 			meshSlots[i] = sortedMeshSlots[i].m_ms;
@@ -336,16 +327,8 @@ void RAS_DisplayArrayBucket::RunBatchingNode(const RAS_DisplayArrayNodeTuple& tu
 	 * This code share the code used in RAS_BucketManager to do the sort.
 	 */
 	if (managerData->m_sort) {
-		std::vector<RAS_BucketManager::SortedMeshSlot> sortedMeshSlots(nummeshslots);
+		const RAS_SortedMeshSlotList sortedMeshSlots = RAS_SortedMeshSlot::Sort(m_activeMeshSlots, managerData->m_trans);
 
-		const mt::mat3x4& trans = managerData->m_trans;
-		const mt::vec3 pnorm(trans[2], trans[5], trans[8]);
-		std::transform(m_activeMeshSlots.begin(), m_activeMeshSlots.end(), sortedMeshSlots.begin(),
-		               [&pnorm](RAS_MeshSlot *slot) {
-			return RAS_BucketManager::SortedMeshSlot(slot, pnorm);
-		});
-
-		std::sort(sortedMeshSlots.begin(), sortedMeshSlots.end(), RAS_BucketManager::backtofront());
 		for (unsigned int i = 0; i < nummeshslots; ++i) {
 			const short index = sortedMeshSlots[i].m_ms->m_batchPartIndex;
 			indices[i] = batchArray->GetPartIndexOffset(index);

--- a/source/gameengine/Rasterizer/RAS_SortedMeshSlot.cpp
+++ b/source/gameengine/Rasterizer/RAS_SortedMeshSlot.cpp
@@ -1,0 +1,132 @@
+#include "RAS_SortedMeshSlot.h"
+#include "RAS_MeshUser.h"
+#include "RAS_DisplayArrayBucket.h"
+#include "RAS_BoundingBox.h"
+
+#include "tbb/parallel_for.h"
+#include "tbb/parallel_sort.h"
+
+class InitLeafsTask
+{
+public:
+	const RAS_UpwardTreeLeafs& m_leafs;
+	mt::vec3 m_pnorm;
+	RAS_SortedMeshSlotList& m_result;
+
+	InitLeafsTask(const RAS_UpwardTreeLeafs& leafs, const mt::vec3& pnorm, RAS_SortedMeshSlotList& result)
+		:m_leafs(leafs),
+		m_pnorm(pnorm),
+		m_result(result)
+	{
+	}
+
+	void operator()(const tbb::blocked_range<size_t>& r) const
+	{
+		for (unsigned int i = r.begin(), end = r.end(); i < end; ++i) {
+			m_result[i] = RAS_SortedMeshSlot(m_leafs[i], m_pnorm);
+		}
+	}
+};
+
+class InitSlotsTask
+{
+public:
+	const RAS_MeshSlotList& m_slots;
+	mt::vec3 m_pnorm;
+	RAS_SortedMeshSlotList& m_result;
+
+	InitSlotsTask(const RAS_MeshSlotList& slots, const mt::vec3& pnorm, RAS_SortedMeshSlotList& result)
+		:m_slots(slots),
+		m_pnorm(pnorm),
+		m_result(result)
+	{
+	}
+
+	void operator()(const tbb::blocked_range<size_t>& r) const
+	{
+		for (unsigned int i = r.begin(), end = r.end(); i < end; ++i) {
+			m_result[i] = RAS_SortedMeshSlot(m_slots[i], m_pnorm);
+		}
+	}
+};
+
+
+RAS_SortedMeshSlot::RAS_SortedMeshSlot(RAS_MeshSlot *ms, const mt::vec3& pnorm)
+	:RAS_SortedMeshSlot(ms->m_meshUser, ms, pnorm)
+{
+	m_ms = ms;
+}
+
+RAS_SortedMeshSlot::RAS_SortedMeshSlot(RAS_MeshSlotUpwardNode *node, const mt::vec3& pnorm)
+	:RAS_SortedMeshSlot(node->GetOwner()->m_meshUser, node->GetOwner(), pnorm)
+{
+	m_node = node;
+}
+
+RAS_SortedMeshSlot::RAS_SortedMeshSlot(RAS_MeshUser *meshUser, RAS_MeshSlot *ms, const mt::vec3& pnorm)
+{
+	mt::vec3 center;
+	float radius;
+
+	RAS_DisplayArray *array = ms->m_displayArrayBucket->GetDisplayArray();
+	if (array) {
+		center = array->GetAabbCenter();
+		radius = array->GetAabbRadius();
+	}
+	else {
+		RAS_BoundingBox *boundingBox = meshUser->GetBoundingBox();
+		mt::vec3 aabbMin;
+		mt::vec3 aabbMax;
+		boundingBox->GetAabb(aabbMin, aabbMax);
+
+		center = (aabbMin + aabbMax) * 0.5f;
+		radius = 0.0f;
+	}
+
+	const mt::mat4& matrix = meshUser->GetMatrix();
+
+	const mt::vec3 pos = matrix * center;
+	const float shift = (matrix.ScaleVector3D() * (pnorm * radius)).Length();
+
+	/* Camera's near plane equation: pnorm.dot(point) + pval,
+	 * but we leave out pval since it's constant anyway */
+	m_z = mt::dot(pnorm, pos) + shift;
+}
+
+struct BackToFront
+{
+	inline bool operator()(RAS_SortedMeshSlot &a, RAS_SortedMeshSlot &b) const
+	{
+		return (a.m_z < b.m_z);
+	}
+};
+
+RAS_SortedMeshSlotList RAS_SortedMeshSlot::Sort(const RAS_UpwardTreeLeafs& leafs, const mt::mat3x4& trans)
+{
+	const mt::vec3 pnorm(trans[2], trans[5], trans[8]);
+	const unsigned int count = leafs.size();
+	RAS_SortedMeshSlotList result(count);
+
+	InitLeafsTask task(leafs, pnorm, result);
+	tbb::parallel_for(tbb::blocked_range<size_t>(0, count), task, tbb::static_partitioner());
+
+	return Sort(result);
+}
+
+RAS_SortedMeshSlotList RAS_SortedMeshSlot::Sort(const RAS_MeshSlotList& slots, const mt::mat3x4& trans)
+{
+	const mt::vec3 pnorm(trans[2], trans[5], trans[8]);
+	const unsigned int count = slots.size();
+	RAS_SortedMeshSlotList result(count);
+
+	InitSlotsTask task(slots, pnorm, result);
+	tbb::parallel_for(tbb::blocked_range<size_t>(0, count), task);
+
+	return Sort(result);
+}
+
+RAS_SortedMeshSlotList RAS_SortedMeshSlot::Sort(RAS_SortedMeshSlotList& slots)
+{
+	tbb::parallel_sort(slots, BackToFront());
+	return slots;
+}

--- a/source/gameengine/Rasterizer/RAS_SortedMeshSlot.h
+++ b/source/gameengine/Rasterizer/RAS_SortedMeshSlot.h
@@ -1,0 +1,29 @@
+#ifndef __RAS_SORTED_MESH_SLOT_H__
+#define __RAS_SORTED_MESH_SLOT_H__
+
+#include "RAS_MeshSlot.h" // For RAS_MeshSlotList.
+
+class RAS_SortedMeshSlot
+{
+public:
+	/// depth
+	float m_z;
+
+	union {
+		RAS_MeshSlot *m_ms;
+		RAS_MeshSlotUpwardNode *m_node;
+	};
+
+	RAS_SortedMeshSlot() = default;
+	RAS_SortedMeshSlot(RAS_MeshSlot *ms, const mt::vec3& pnorm);
+	RAS_SortedMeshSlot(RAS_MeshSlotUpwardNode *node, const mt::vec3& pnorm);
+	RAS_SortedMeshSlot(RAS_MeshUser *meshUser, RAS_MeshSlot *ms, const mt::vec3& pnorm);
+
+	static std::vector<RAS_SortedMeshSlot> Sort(const RAS_MeshSlotList& slots, const mt::mat3x4& trans);
+	static std::vector<RAS_SortedMeshSlot> Sort(const RAS_UpwardTreeLeafs& leafs, const mt::mat3x4& trans);
+	static std::vector<RAS_SortedMeshSlot> Sort(std::vector<RAS_SortedMeshSlot>& slots);
+};
+
+using RAS_SortedMeshSlotList = std::vector<RAS_SortedMeshSlot>;
+
+#endif  // __RAS_SORTED_MESH_SLOT_H__


### PR DESCRIPTION
The previous sorting of meshes was for each mesh slot (or node leaf)
computing the distance with the near plane of the camera and these
distances were used in std::sort.

This process can be improved by speed and accuracy, first the computation
of the distance and the sort could be parallelized thanks to TBB,
secondly the center of the object is not the most accurate for sorting
objects, the distance from camera to the center of the bounding box
+ the bounding box radius is more accurate.

The code managing the mesh sorting is moved in RAS_SortedMeshSlot.[h/cpp]
RAS_SortedMeshSlot is linking the distance to camera with a mesh slot,
its constructor is computing the distance using bounding box.

RAS_SortedMeshSlot::Sort is receiving a list of mesh slots or node leafs
and managing RAS_SortedMeshSlot creation and sorting. The creation is
using TBB and the task struct InitLeafsTask, then the RAS_SortedMeshSlot(s)
are sorted through tbb::parallel_sort.

To acces the bounding box, RAS_DisplayArray is using its own AABB
with the adjunction of a center and radius cache. These data are
computed into UpdateAabb called from RAS_MeshBoundingBox. In case
of test object the display array is null and the bounding box
(RAS_BoundingBox) from the mesh user is used.

Example file: 
[ge_mesh_sort.zip](https://github.com/UPBGE/blender/files/2278810/ge_mesh_sort.zip)
