### PR TITLE
UPBGE: Allow alpha support for mathutils.Color.

### DIFF
--- a/source/blender/freestyle/intern/python/BPy_StrokeAttribute.cpp
+++ b/source/blender/freestyle/intern/python/BPy_StrokeAttribute.cpp
@@ -519,7 +519,7 @@ PyDoc_STRVAR(StrokeAttribute_color_doc,
 
 static PyObject *StrokeAttribute_color_get(BPy_StrokeAttribute *self, void *UNUSED(closure))
 {
-	return Color_CreatePyObject_cb((PyObject *)self, StrokeAttribute_mathutils_cb_index, MATHUTILS_SUBTYPE_COLOR);
+	return Color_CreatePyObject_cb((PyObject *)self, 3, StrokeAttribute_mathutils_cb_index, MATHUTILS_SUBTYPE_COLOR);
 }
 
 static int StrokeAttribute_color_set(BPy_StrokeAttribute *self, PyObject *value, void *UNUSED(closure))

--- a/source/blender/python/intern/bpy_rna.c
+++ b/source/blender/python/intern/bpy_rna.c
@@ -724,12 +724,12 @@ PyObject *pyrna_math_object_from_array(PointerRNA *ptr, PropertyRNA *prop)
 			case PROP_COLOR_GAMMA:
 				if (len == 3) { /* color */
 					if (is_thick) {
-						ret = Color_CreatePyObject(NULL, NULL);
+						ret = Color_CreatePyObject(NULL, 3, NULL);
 						RNA_property_float_get_array(ptr, prop, ((ColorObject *)ret)->col);
 					}
 					else {
 						PyObject *col_cb = Color_CreatePyObject_cb(
-						        ret, mathutils_rna_array_cb_index, MATHUTILS_CB_SUBTYPE_COLOR);
+						        ret, 3, mathutils_rna_array_cb_index, MATHUTILS_CB_SUBTYPE_COLOR);
 						Py_DECREF(ret); /* the color owns now */
 						ret = col_cb; /* return the color instead */
 					}

--- a/source/blender/python/mathutils/mathutils.c
+++ b/source/blender/python/mathutils/mathutils.c
@@ -211,7 +211,7 @@ int mathutils_array_parse(float *array, int array_min, int array_max, PyObject *
 }
 
 /* on error, -1 is returned and no allocation is made */
-int mathutils_array_parse_alloc(float **array, int array_min, PyObject *value, const char *error_prefix)
+int mathutils_array_parse_alloc(float **array, int array_min, int array_max, PyObject *value, const char *error_prefix)
 {
 	int size;
 
@@ -226,10 +226,17 @@ int mathutils_array_parse_alloc(float **array, int array_min, PyObject *value, c
 			return -1;
 		}
 
-		if (size < array_min) {
-			PyErr_Format(PyExc_ValueError,
-			             "%.200s: sequence size is %d, expected > %d",
-			             error_prefix, size, array_min);
+		if (size > array_max || size < array_min) {
+			if (array_max == array_min) {
+				PyErr_Format(PyExc_ValueError,
+				             "%.200s: sequence size is %d, expected %d",
+				             error_prefix, size, array_max);
+			}
+			else {
+				PyErr_Format(PyExc_ValueError,
+				             "%.200s: sequence size is %d, expected [%d - %d]",
+				             error_prefix, size, array_min, array_max);
+			}
 			return -1;
 		}
 

--- a/source/blender/python/mathutils/mathutils.h
+++ b/source/blender/python/mathutils/mathutils.h
@@ -153,7 +153,7 @@ void _BaseMathObject_RaiseNotFrozenExc(const BaseMathObject *self);
 
 /* utility func */
 int mathutils_array_parse(float *array, int array_min, int array_max, PyObject *value, const char *error_prefix);
-int mathutils_array_parse_alloc(float **array, int array_min, PyObject *value, const char *error_prefix);
+int mathutils_array_parse_alloc(float **array, int array_min, int array_max, PyObject *value, const char *error_prefix);
 int mathutils_array_parse_alloc_v(float **array, int array_dim, PyObject *value, const char *error_prefix);
 int mathutils_any_to_rotmat(float rmat[3][3], PyObject *value, const char *error_prefix);
 

--- a/source/blender/python/mathutils/mathutils_Color.h
+++ b/source/blender/python/mathutils/mathutils_Color.h
@@ -35,6 +35,8 @@ extern PyTypeObject color_Type;
 
 typedef struct {
 	BASE_MATH_MEMBERS(col);
+
+	int size; /* color size 3 or 4 (alpha) */
 } ColorObject;
 
 /* struct data contains a pointer to the actual data that the
@@ -44,15 +46,15 @@ typedef struct {
 
 /* prototypes */
 PyObject *Color_CreatePyObject(
-        const float col[3],
+        const float *col, int size,
         PyTypeObject *base_type
         ) ATTR_WARN_UNUSED_RESULT;
 PyObject *Color_CreatePyObject_wrap(
-        float col[3],
+        float *col, int size,
         PyTypeObject *base_type
         ) ATTR_WARN_UNUSED_RESULT ATTR_NONNULL(1);
 PyObject *Color_CreatePyObject_cb(
-        PyObject *cb_user,
+        PyObject *cb_user, int size,
         unsigned char cb_type, unsigned char cb_subtype
         ) ATTR_WARN_UNUSED_RESULT;
 

--- a/source/blender/python/mathutils/mathutils_Vector.c
+++ b/source/blender/python/mathutils/mathutils_Vector.c
@@ -87,7 +87,7 @@ static PyObject *Vector_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 			copy_vn_fl(vec, size, 0.0f);
 			break;
 		case 1:
-			if ((size = mathutils_array_parse_alloc(&vec, 2, PyTuple_GET_ITEM(args, 0), "mathutils.Vector()")) == -1) {
+			if ((size = mathutils_array_parse_alloc(&vec, 2, INT_MAX, PyTuple_GET_ITEM(args, 0), "mathutils.Vector()")) == -1) {
 				return NULL;
 			}
 			break;
@@ -302,7 +302,7 @@ static PyObject *C_Vector_Repeat(PyObject *cls, PyObject *args)
 		return NULL;
 	}
 
-	if ((value_size = mathutils_array_parse_alloc(&iter_vec, 2, value,
+	if ((value_size = mathutils_array_parse_alloc(&iter_vec, 2, INT_MAX, value,
 	                                              "Vector.Repeat(vector, size), invalid 'vector' arg")) == -1)
 	{
 		return NULL;
@@ -951,7 +951,7 @@ static PyObject *Vector_dot(VectorObject *self, PyObject *value)
 	if (BaseMath_ReadCallback(self) == -1)
 		return NULL;
 
-	if (mathutils_array_parse_alloc(&tvec, self->size, value, "Vector.dot(other), invalid 'other' arg") == -1) {
+	if (mathutils_array_parse_alloc(&tvec, self->size, INT_MAX, value, "Vector.dot(other), invalid 'other' arg") == -1) {
 		return NULL;
 	}
 
@@ -1183,7 +1183,7 @@ static PyObject *Vector_lerp(VectorObject *self, PyObject *args)
 		return NULL;
 	}
 
-	if (mathutils_array_parse_alloc(&tvec, size, value, "Vector.lerp(other), invalid 'other' arg") == -1) {
+	if (mathutils_array_parse_alloc(&tvec, size, INT_MAX, value, "Vector.lerp(other), invalid 'other' arg") == -1) {
 		return NULL;
 	}
 
@@ -1484,7 +1484,7 @@ static int Vector_ass_slice(VectorObject *self, int begin, int end, PyObject *se
 	begin = MIN2(begin, end);
 
 	size = (end - begin);
-	if (mathutils_array_parse_alloc(&vec, size, seq, "vector[begin:end] = [...]") == -1) {
+	if (mathutils_array_parse_alloc(&vec, size, INT_MAX, seq, "vector[begin:end] = [...]") == -1) {
 		return -1;
 	}
 

--- a/source/gameengine/Ketsji/KX_BlenderMaterial.cpp
+++ b/source/gameengine/Ketsji/KX_BlenderMaterial.cpp
@@ -744,7 +744,7 @@ int KX_BlenderMaterial::pyattr_set_specular_intensity(EXP_PyObjectPlus *self_v, 
 PyObject *KX_BlenderMaterial::pyattr_get_specular_color(EXP_PyObjectPlus *self_v, const EXP_PYATTRIBUTE_DEF *attrdef)
 {
 #ifdef USE_MATHUTILS
-	return Color_CreatePyObject_cb(EXP_PROXY_FROM_REF(self_v), mathutils_kxblendermaterial_color_cb_index, MATHUTILS_COL_CB_MATERIAL_SPECULAR_COLOR);
+	return Color_CreatePyObject_cb(EXP_PROXY_FROM_REF(self_v), 3, mathutils_kxblendermaterial_color_cb_index, MATHUTILS_COL_CB_MATERIAL_SPECULAR_COLOR);
 #else
 	KX_BlenderMaterial *self = static_cast<KX_BlenderMaterial *>(self_v);
 	Material *mat = self->GetBlenderMaterial();
@@ -792,7 +792,7 @@ int KX_BlenderMaterial::pyattr_set_diffuse_intensity(EXP_PyObjectPlus *self_v, c
 PyObject *KX_BlenderMaterial::pyattr_get_diffuse_color(EXP_PyObjectPlus *self_v, const EXP_PYATTRIBUTE_DEF *attrdef)
 {
 #ifdef USE_MATHUTILS
-	return Color_CreatePyObject_cb(EXP_PROXY_FROM_REF(self_v), mathutils_kxblendermaterial_color_cb_index, MATHUTILS_COL_CB_MATERIAL_DIFFUSE_COLOR);
+	return Color_CreatePyObject_cb(EXP_PROXY_FROM_REF(self_v), 3, mathutils_kxblendermaterial_color_cb_index, MATHUTILS_COL_CB_MATERIAL_DIFFUSE_COLOR);
 #else
 	KX_BlenderMaterial *self = static_cast<KX_BlenderMaterial *>(self_v);
 	Material *mat = self->GetBlenderMaterial();

--- a/source/gameengine/Ketsji/KX_PyMath.cpp
+++ b/source/gameengine/Ketsji/KX_PyMath.cpp
@@ -98,7 +98,7 @@ PyObject *PyObjectFrom(const mt::quat &qrot)
 PyObject *PyColorFromVector(const mt::vec3 &vec)
 {
 #ifdef USE_MATHUTILS
-	return Color_CreatePyObject(vec.Data(), nullptr);
+	return Color_CreatePyObject(vec.Data(), 3, nullptr);
 #else
 	return PyObjectFrom(vec);
 #endif

--- a/source/gameengine/Ketsji/KX_PythonInit.cpp
+++ b/source/gameengine/Ketsji/KX_PythonInit.cpp
@@ -2004,6 +2004,7 @@ static void addSubModule(PyObject *modules, PyObject *mod, PyObject *submod, con
 PyMODINIT_FUNC initBGE()
 {
 	PyObject *modules = PyThreadState_GET()->interp->modules;
+
 	PyObject *mod = PyModule_Create(&BGE_module_def);
 
 	addSubModule(modules, mod, initApplicationPythonBinding(), "bge.app");
@@ -2097,8 +2098,7 @@ void initGamePython(Main *main, PyObject *pyGlobalDict)
 	EXP_PyObjectPlus::NullDeprecationWarning();
 
 	PyObject *gameLogic = PyDict_GetItemString(modules, "GameLogic");
-	PyDict_SetItemString(PyModule_GetDict(gameLogic), "globalDict", pyGlobalDict);
-	Py_DECREF(gameLogic);
+	PyModule_AddObject(gameLogic, "globalDict", pyGlobalDict);
 }
 
 void exitGamePython()

--- a/source/gameengine/Ketsji/KX_WorldInfo.cpp
+++ b/source/gameengine/Ketsji/KX_WorldInfo.cpp
@@ -535,7 +535,7 @@ PyObject *KX_WorldInfo::pyattr_get_mist_color(EXP_PyObjectPlus *self_v, const EX
 {
 #ifdef USE_MATHUTILS
 	return Color_CreatePyObject_cb(
-		EXP_PROXY_FROM_REF_BORROW(self_v),
+		EXP_PROXY_FROM_REF_BORROW(self_v), 3,
 		mathutils_world_color_cb_index, MATHUTILS_COL_CB_MIST_COLOR);
 #else
 	KX_WorldInfo *self = static_cast<KX_WorldInfo *>(self_v);
@@ -584,7 +584,7 @@ PyObject *KX_WorldInfo::pyattr_get_background_color(EXP_PyObjectPlus *self_v, co
 {
 #ifdef USE_MATHUTILS
 	return Color_CreatePyObject_cb(
-		EXP_PROXY_FROM_REF_BORROW(self_v),
+		EXP_PROXY_FROM_REF_BORROW(self_v), 3,
 		mathutils_world_color_cb_index, MATHUTILS_COL_CB_BACK_COLOR);
 #else
 	KX_WorldInfo *self = static_cast<KX_WorldInfo *>(self_v);
@@ -633,7 +633,7 @@ PyObject *KX_WorldInfo::pyattr_get_ambient_color(EXP_PyObjectPlus *self_v, const
 {
 #ifdef USE_MATHUTILS
 	return Color_CreatePyObject_cb(
-		EXP_PROXY_FROM_REF_BORROW(self_v),
+		EXP_PROXY_FROM_REF_BORROW(self_v), 3,
 		mathutils_world_color_cb_index, MATHUTILS_COL_CB_AMBIENT_COLOR);
 #else
 	KX_WorldInfo *self = static_cast<KX_WorldInfo *>(self_v);


### PR DESCRIPTION
mathutils.Color can now optionally support the alpha channel by passing
a four elements tuple to its python constructor or passing the size
to the Color_CreatePyObject* functions.

The size fo the color can only be 3 or 4 as the fonction
mathutils_array_parse_alloc is checking. This size is stored into ColorObject
and used at every place COLOR_SIZE was used.

Operation between color of different size is disallowed same as vector.