### PR TITLE
UPBGE: Implement physics mesh refit.

### DIFF
--- a/extern/bullet/src/BulletCollision/Gimpact/btGImpactShape.h
+++ b/extern/bullet/src/BulletCollision/Gimpact/btGImpactShape.h
@@ -102,6 +102,15 @@ protected:
     	m_localAABB = m_box_set.getGlobalBox();
     }
 
+    virtual void calcLocalAABBRefit()
+    {
+		lockChildShapes();
+   		m_box_set.buildSet();
+    	unlockChildShapes();
+
+    	m_localAABB = m_box_set.getGlobalBox();
+    }
+
 
 public:
 	btGImpactShapeInterface()
@@ -124,6 +133,13 @@ public:
     {
     	if(!m_needs_update) return;
     	calcLocalAABB();
+    	m_needs_update  = false;
+    }
+
+    SIMD_FORCE_INLINE void refitTree()
+    {
+    	if(!m_needs_update) return;
+    	calcLocalAABBRefit();
     	m_needs_update  = false;
     }
 
@@ -910,6 +926,17 @@ protected:
     	while(i--)
     	{
     		m_mesh_parts[i]->updateBound();
+    		m_localAABB.merge(m_mesh_parts[i]->getLocalBox());
+    	}
+    }
+
+    virtual void calcLocalAABBRefit()
+    {
+    	m_localAABB.invalidate();
+    	int i = m_mesh_parts.size();
+    	while(i--)
+    	{
+    		m_mesh_parts[i]->refitTree();
     		m_localAABB.merge(m_mesh_parts[i]->getLocalBox());
     	}
     }

--- a/source/gameengine/Physics/Bullet/CcdPhysicsEnvironment.cpp
+++ b/source/gameengine/Physics/Bullet/CcdPhysicsEnvironment.cpp
@@ -730,6 +730,18 @@ void CcdPhysicsEnvironment::RemoveCcdGraphicController(CcdGraphicController *ctr
 	}
 }
 
+void CcdPhysicsEnvironment::RefitCcdPhysicsControllerShape(CcdShapeConstructionInfo *shapeInfo)
+{
+	for (CcdPhysicsController *ctrl : m_controllers) {
+		if (ctrl->GetShapeInfo() != shapeInfo) {
+			continue;
+		}
+
+		ctrl->RefitCollisionShape();
+		RefreshCcdPhysicsController(ctrl);
+	}
+}
+
 void CcdPhysicsEnvironment::UpdateCcdPhysicsControllerShape(CcdShapeConstructionInfo *shapeInfo)
 {
 	for (CcdPhysicsController *ctrl : m_controllers) {

--- a/source/gameengine/Physics/Bullet/CcdPhysicsEnvironment.h
+++ b/source/gameengine/Physics/Bullet/CcdPhysicsEnvironment.h
@@ -267,6 +267,8 @@ public:
 
 	void RemoveCcdGraphicController(CcdGraphicController *ctrl);
 
+	void RefitCcdPhysicsControllerShape(CcdShapeConstructionInfo *shapeInfo);
+
 	/**
 	 * Update all physics controllers shape which use the same shape construction info.
 	 * Call RecreateControllerShape on controllers which use the same shape


### PR DESCRIPTION
Bullet library is allowing for triangle mesh shapes (btBvhTriangleMeshShape
and btGImpactMeshShape) tree refit which is faster than rebuilding the whole
BVH tree.

To detect a possible refit we must check if only the vertices changed, to do so
we store information of the converted display arrays into struct MeshPart
during CcdShapeConstructionInfo::UpdateMesh.
Next call to CcdShapeConstructionInfo::UpdateMesh will compare the previous
mesh parts with the current one and if they are equivalent then only update the
vertices of the btTriangleIndexVertexArray. The vertices are always converted
from the display arrays and stored into m_vertexArray.

Finally CcdShapeConstructionInfo::UpdateMesh returns a flag to tell if physics
controllers need to recreate the shape (UPDATE_RECREATE) or update the shape
tree (UPDATE_REFIT). The last flag is making ReinstancePhysicsShape to call
CcdPhysicsEnvironment::RefitCcdPhysicsControllerShape which itself forward
to RefitCollisionShape of all the physics controllers using the same shape.
RefitCollisionShape is managing BVH shape and gimpact shape by calling
the proper functions for the both shape types.

Actually the tree is refit and not partially refit as it will request the user
to select a maximum AABB, the complete refit is a little bit more expensive
but much safer.
A new function in btGimpactMeshShape is added to refit the tree: refitTree.

Tested with 8192 triangles:
Static:
Before	Current
12.32ms	1.89ms

Rigid:
Before	Current
1.69ms	1.48ms