### PR TITLE
UPBGE: Fix collision sensor drawing in debug build

### DIFF
--- a/source/blender/editors/space_logic/logic_window.c
+++ b/source/blender/editors/space_logic/logic_window.c
@@ -964,7 +964,7 @@ static void draw_sensor_collision(uiLayout *layout, PointerRNA *ptr, bContext *C
 	uiItemR(row, ptr, "use_pulse", UI_ITEM_R_TOGGLE, NULL, ICON_NONE);
 	uiItemR(row, ptr, "use_material", UI_ITEM_R_TOGGLE, NULL, ICON_NONE);
 
-	switch (RNA_enum_get(ptr, "use_material")) {
+	switch (RNA_boolean_get(ptr, "use_material")) {
 		case SENS_COLLISION_PROPERTY:
 			uiItemR(split, ptr, "property", 0, NULL, ICON_NONE);
 			break;


### PR DESCRIPTION
In the case of collision sensor, "use_material" is a boolean property. When collision sensor was drawn, an exception was raised in Debug mode because to get the property value, RNA_enum_get was called instead of RNA_boolean_get