### PR TITLE
Fix error passing non-trivial type to variadic function

### DIFF
--- a/source/gameengine/Ketsji/KX_GameObject.cpp
+++ b/source/gameengine/Ketsji/KX_GameObject.cpp
@@ -2566,7 +2566,7 @@ PyObject *KX_GameObject::pyattr_get_is_suspend_dynamics(PyObjectPlus *self_v,
   KX_GameObject *self = static_cast<KX_GameObject *>(self_v);
 
   // Only objects with a physics controller can be suspended
-  PYTHON_CHECK_PHYSICS_CONTROLLER(self, attrdef->m_name, nullptr);
+  PYTHON_CHECK_PHYSICS_CONTROLLER(self, attrdef->m_name.c_str(), nullptr);
 
   return PyBool_FromLong(self->IsDynamicsSuspended());
 }


### PR DESCRIPTION
clang 8.0 reports error passing non-trivial type to variadic function
fix by using .c_str()

```
upbge-8fecba4e7005/source/gameengine/Ketsji/KX_GameObject.cpp:2567:3: error: cannot pass object of non-trivial type 'const std::string' (aka 'const basic_string<char, char_traits<char>, allocator<char> >') through variadic function; call will abort at runtime [-Wnon-pod-varargs]
  PYTHON_CHECK_PHYSICS_CONTROLLER(self, attrdef->m_name, nullptr);
  ^
upbge-8fecba4e7005/source/gameengine/Ketsji/KX_GameObject.cpp:1646:86: note: expanded from macro 'PYTHON_CHECK_PHYSICS_CONTROLLER'
          PyExc_AttributeError, "KX_GameObject.%s, is missing a physics controller", (attr)); \
                                                                                     ^
1 error generated.

```