### PR TITLE
UPBGE: Restore a simplified version of ImageRender

### DIFF
--- a/source/blender/draw/intern/DRW_render.h
+++ b/source/blender/draw/intern/DRW_render.h
@@ -81,6 +81,7 @@ typedef struct DRWPass DRWPass;
 typedef struct DRWShadingGroup DRWShadingGroup;
 typedef struct DRWUniform DRWUniform;
 typedef struct DRWView DRWView;
+typedef struct GPUViewport GPUViewport;
 
 /* TODO Put it somewhere else? */
 typedef struct BoundSphere {
@@ -691,7 +692,7 @@ typedef struct DRWContextState {
 const DRWContextState *DRW_context_state_get(void);
 
 /*****************************GAME ENGINE***********************************/
-struct GPUTexture *DRW_game_render_loop(struct Main *bmain, struct Scene *scene, struct Object *maincam,
+struct GPUTexture *DRW_game_render_loop(GPUViewport *viewport, struct Main *bmain, struct Scene *scene, struct Object *maincam,
 	float view[4][4], float viewinv[4][4], float proj[4][4], float pers[4][4], float persinv[4][4],
   int v[4], bool called_from_constructor, bool reset_taa_samples);
 void DRW_game_render_loop_finish(void);

--- a/source/blender/draw/intern/draw_manager.c
+++ b/source/blender/draw/intern/draw_manager.c
@@ -3198,7 +3198,7 @@ void DRW_game_render_loop_finish()
 
 void DRW_game_render_loop_end()
 {
-  GPU_viewport_free(DST.viewport);
+  //GPU_viewport_free(DST.viewport);
 
   eevee_game_view_layer_data_free();
   draw_engine_eevee_type.engine_free();

--- a/source/blender/draw/intern/draw_manager.c
+++ b/source/blender/draw/intern/draw_manager.c
@@ -3198,7 +3198,7 @@ void DRW_game_render_loop_finish()
 
 void DRW_game_render_loop_end()
 {
-  //GPU_viewport_free(DST.viewport);
+  GPU_viewport_free(DST.viewport);
 
   eevee_game_view_layer_data_free();
   draw_engine_eevee_type.engine_free();

--- a/source/gameengine/Ketsji/KX_Scene.cpp
+++ b/source/gameengine/Ketsji/KX_Scene.cpp
@@ -567,8 +567,6 @@ void KX_Scene::RenderAfterCameraSetup(bool calledFromConstructor)
   GPU_framebuffer_texture_detach(output->GetFrameBuffer(), m_2dfiltersDepthTex);
 
   DRW_game_render_loop_finish();
-  GPU_viewport_free(m_gpuViewport);
-  m_gpuViewport = nullptr;
   GPU_framebuffer_restore();
 }
 

--- a/source/gameengine/Ketsji/KX_Scene.cpp
+++ b/source/gameengine/Ketsji/KX_Scene.cpp
@@ -593,7 +593,7 @@ GPUTexture *KX_Scene::RenderAfterCameraSetupImageRender(RAS_Rasterizer *rasty, G
 
   int viewportsize[2] = {v[2], v[3]};
 
-  GPUTexture *finaltex = DRW_game_render_loop(m_gpuViewport,
+  GPUTexture *finaltex = DRW_game_render_loop(viewport,
                                               bmain,
                                               scene,
                                               maincam,

--- a/source/gameengine/Ketsji/KX_Scene.cpp
+++ b/source/gameengine/Ketsji/KX_Scene.cpp
@@ -107,6 +107,7 @@ extern "C" {
 #include "BKE_camera.h"
 #include "BKE_collection.h"
 #include "BKE_layer.h"
+#include "BKE_library.h"
 #include "BKE_main.h"
 #include "BKE_object.h"
 #include "depsgraph/DEG_depsgraph_query.h"
@@ -303,7 +304,7 @@ KX_Scene::~KX_Scene()
 
   LayerCollection *layer_collection = BKE_layer_collection_get_active(view_layer);
   BKE_collection_object_remove(bmain, layer_collection->collection, m_gameDefaultCamera, false);
-  BKE_object_free(m_gameDefaultCamera);
+  BKE_id_free(bmain, m_gameDefaultCamera);
   m_gameDefaultCamera = nullptr;
   DEG_relations_tag_update(bmain);
 

--- a/source/gameengine/Ketsji/KX_Scene.cpp
+++ b/source/gameengine/Ketsji/KX_Scene.cpp
@@ -596,8 +596,6 @@ GPUTexture *KX_Scene::RenderAfterCameraSetupImageRender(RAS_Rasterizer *rasty, G
   m.pers.getValue(&pers[0][0]);
   m.persinv.getValue(&persinv[0][0]);
 
-  int viewportsize[2] = {v[2], v[3]};
-
   GPUTexture *finaltex = DRW_game_render_loop(viewport,
                                               bmain,
                                               scene,

--- a/source/gameengine/Ketsji/KX_Scene.h
+++ b/source/gameengine/Ketsji/KX_Scene.h
@@ -138,6 +138,8 @@ protected:
 	bool m_resetTaaSamples;
   Object *m_lastReplicatedParentObject;
   Object *m_gameDefaultCamera;
+  struct GPUViewport *m_gpuViewport;
+  struct GPUOffScreen *m_gpuOffScreen;
 	/*************************************************/
 
 	RAS_BucketManager*	m_bucketmanager;

--- a/source/gameengine/Ketsji/KX_Scene.h
+++ b/source/gameengine/Ketsji/KX_Scene.h
@@ -322,7 +322,7 @@ public:
 	std::vector<Object *>m_hiddenObjectsDuringRuntime;
 
 	void RenderAfterCameraSetup(bool calledFromConstructor);
-	void RenderAfterCameraSetupImageRender(KX_Camera *cam, GPUTexture *finaltex, int *viewport);
+	GPUTexture *RenderAfterCameraSetupImageRender(RAS_Rasterizer *rasty, struct GPUViewport *viewport, KX_Camera *cam, int *viewport_size);
 
   void SetLastReplicatedParentObject(Object *ob);
   Object *GetLastReplicatedParentObject();

--- a/source/gameengine/VideoTexture/ImageRender.cpp
+++ b/source/gameengine/VideoTexture/ImageRender.cpp
@@ -152,8 +152,6 @@ void ImageRender::calcViewport (unsigned int texId, double ts, unsigned int form
 	GPU_framebuffer_texture_detach(m_targetfb, m_gpuTexture);
 
 	DRW_game_render_loop_finish();
-	GPU_viewport_free(m_gpuViewport);
-	m_gpuViewport = nullptr;
 
 	GPU_framebuffer_restore();
 }

--- a/source/gameengine/VideoTexture/ImageRender.cpp
+++ b/source/gameengine/VideoTexture/ImageRender.cpp
@@ -143,6 +143,10 @@ void ImageRender::calcViewport (unsigned int texId, double ts, unsigned int form
 	}
 	m_done = false;
 
+	const RAS_Rect *viewport = &m_canvas->GetViewportArea();
+	m_rasterizer->SetViewport(viewport->GetLeft(), viewport->GetBottom(), viewport->GetWidth(), viewport->GetHeight());
+	m_rasterizer->SetScissor(viewport->GetLeft(), viewport->GetBottom(), viewport->GetWidth(), viewport->GetHeight());
+
 	GPU_framebuffer_texture_attach(m_targetfb, m_gpuTexture, 0, 0);
 	GPU_framebuffer_bind(m_targetfb);
 

--- a/source/gameengine/VideoTexture/ImageRender.cpp
+++ b/source/gameengine/VideoTexture/ImageRender.cpp
@@ -244,7 +244,7 @@ bool ImageRender::Render()
 	m_rasterizer->SetScissor(viewport[0], viewport[1], viewport[2], viewport[3]);
 
 	if (!m_gpuViewport) {
-		m_gpuOffScreen = GPU_offscreen_create(m_canvas->GetWidth() + 1, m_canvas->GetHeight() + 1, 0, true, false, nullptr);
+		m_gpuOffScreen = GPU_offscreen_create(viewport[2], viewport[3], 0, true, false, nullptr);
 		m_gpuViewport = GPU_viewport_create_from_offscreen(m_gpuOffScreen);
 	}
 

--- a/source/gameengine/VideoTexture/ImageRender.cpp
+++ b/source/gameengine/VideoTexture/ImageRender.cpp
@@ -141,16 +141,7 @@ void ImageRender::calcViewport (unsigned int texId, double ts, unsigned int form
 	// get image from viewport (or FBO)
 	ImageViewport::calcViewport(texId, ts, format);
 
-	/*const RAS_Rect& viewport = m_canvas->GetViewportArea();
-	m_rasterizer->SetViewport(viewport.GetLeft(), viewport.GetBottom(), viewport.GetWidth() + 1, viewport.GetHeight() + 1);
-	m_rasterizer->SetScissor(viewport.GetLeft(), viewport.GetBottom(), viewport.GetWidth() + 1, viewport.GetHeight() + 1);*/
-
-	if (m_gpuTexture) {
-		DRW_transform_none(m_gpuTexture);
-	}
-
 	GPU_framebuffer_restore();
-	DRW_game_render_loop_finish();
 }
 
 bool ImageRender::Render()
@@ -246,6 +237,7 @@ bool ImageRender::Render()
 	if (!m_gpuViewport) {
 		m_gpuOffScreen = GPU_offscreen_create(viewport[2], viewport[3], 0, true, false, nullptr);
 		m_gpuViewport = GPU_viewport_create_from_offscreen(m_gpuOffScreen);
+		GPU_viewport_engine_data_create(m_gpuViewport, &draw_engine_eevee_type);
 	}
 
 	m_rasterizer->Clear(RAS_Rasterizer::RAS_DEPTH_BUFFER_BIT);
@@ -337,6 +329,12 @@ bool ImageRender::Render()
 	m_engine->UpdateAnimations(m_scene);
 
 	m_gpuTexture = m_scene->RenderAfterCameraSetupImageRender(m_rasterizer, m_gpuViewport, m_camera, viewport);
+
+	DRW_transform_none(m_gpuTexture);
+
+	DRW_game_render_loop_finish();
+    GPU_viewport_free(m_gpuViewport);
+    m_gpuViewport = nullptr;
 
 	m_canvas->EndFrame();
 

--- a/source/gameengine/VideoTexture/ImageRender.h
+++ b/source/gameengine/VideoTexture/ImageRender.h
@@ -84,6 +84,8 @@ protected:
 	bool m_owncamera;
 
 	GPUTexture *m_gpuTexture;
+  struct GPUViewport *m_gpuViewport;
+  struct GPUOffScreen *m_gpuOffScreen;
 
 	/// for mirror operation
 	KX_GameObject * m_observer;

--- a/source/gameengine/VideoTexture/ImageRender.h
+++ b/source/gameengine/VideoTexture/ImageRender.h
@@ -87,6 +87,8 @@ protected:
   struct GPUViewport *m_gpuViewport;
   struct GPUOffScreen *m_gpuOffScreen;
 
+  GPUFrameBuffer *m_targetfb;
+
 	/// for mirror operation
 	KX_GameObject * m_observer;
 	KX_GameObject * m_mirror;


### PR DESCRIPTION
Simplified because I don't think we can use Render to Offscreen with this implementation.
But we can render something to a texture and use the rendered texture bindId to do things with in a 2D filter if we want.

Else, contrarly to old bge, the rendered textures are shaded, which is great.

I hope i didn't do too much mistakes, but i did few tests and it seemed ok.

The test files links are in some of the commits I did