### PR TITLE
UPBGE: Small reorganisation of Render code an restore 2DFilterOffScreens

### DIFF
--- a/source/gameengine/Ketsji/KX_2DFilter.cpp
+++ b/source/gameengine/Ketsji/KX_2DFilter.cpp
@@ -118,7 +118,7 @@ PyMethodDef KX_2DFilter::Methods[] = {
 
 PyAttributeDef KX_2DFilter::Attributes[] = {
 	KX_PYATTRIBUTE_RW_FUNCTION("mipmap", KX_2DFilter, pyattr_get_mipmap, pyattr_set_mipmap),
-	KX_PYATTRIBUTE_RO_FUNCTION("frameBuffer", KX_2DFilter, pyattr_get_frameBuffer),
+	KX_PYATTRIBUTE_RO_FUNCTION("offScreen", KX_2DFilter, pyattr_get_frameBuffer), // Keep offScreen name for background compatibility
 	KX_PYATTRIBUTE_NULL // Sentinel
 };
 

--- a/source/gameengine/Ketsji/KX_2DFilter.cpp
+++ b/source/gameengine/Ketsji/KX_2DFilter.cpp
@@ -118,6 +118,7 @@ PyMethodDef KX_2DFilter::Methods[] = {
 
 PyAttributeDef KX_2DFilter::Attributes[] = {
 	KX_PYATTRIBUTE_RW_FUNCTION("mipmap", KX_2DFilter, pyattr_get_mipmap, pyattr_set_mipmap),
+	KX_PYATTRIBUTE_RO_FUNCTION("frameBuffer", KX_2DFilter, pyattr_get_frameBuffer),
 	KX_PYATTRIBUTE_RO_FUNCTION("offScreen", KX_2DFilter, pyattr_get_frameBuffer), // Keep offScreen name for background compatibility
 	KX_PYATTRIBUTE_NULL // Sentinel
 };

--- a/source/gameengine/Ketsji/KX_Scene.h
+++ b/source/gameengine/Ketsji/KX_Scene.h
@@ -133,7 +133,6 @@ protected:
 
 	std::vector<KX_GameObject *>m_staticObjects;
 
-	GPUTexture *m_2dfiltersDepthTex;
 	int m_taaSamplesBackup;
 	bool m_resetTaaSamples;
   Object *m_lastReplicatedParentObject;

--- a/source/gameengine/Launcher/LA_Launcher.cpp
+++ b/source/gameengine/Launcher/LA_Launcher.cpp
@@ -239,7 +239,7 @@ void LA_Launcher::InitEngine()
 	// Set the global settings (carried over if restart/load new files).
 	m_ketsjiEngine->SetGlobalSettings(m_globalSettings);
 
-	m_rasterizer->Init();
+	m_rasterizer->Init(m_canvas);
 	InitCamera();
 
 #ifdef WITH_PYTHON

--- a/source/gameengine/Rasterizer/RAS_2DFilterFrameBuffer.cpp
+++ b/source/gameengine/Rasterizer/RAS_2DFilterFrameBuffer.cpp
@@ -75,8 +75,8 @@ void RAS_2DFilterFrameBuffer::Construct()
 {
 	m_frameBuffer = new RAS_FrameBuffer(m_width, m_height, m_hdrType, RAS_Rasterizer::RAS_FRAMEBUFFER_CUSTOM);
 	/* TODO: RESTORE SUPPORT OF MULTIPLE COLOR ATTACHEMENTS IF NEEDED */
-	m_colorTextures[0] = GPU_framebuffer_color_texture(m_frameBuffer->GetFrameBuffer());
-	m_depthTexture = GPU_framebuffer_depth_texture(m_frameBuffer->GetFrameBuffer());
+	m_colorTextures[0] = m_frameBuffer->GetColorAttachment();
+	m_depthTexture = m_frameBuffer->GetDepthAttachment();
 }
 
 void RAS_2DFilterFrameBuffer::MipmapTexture()

--- a/source/gameengine/Rasterizer/RAS_FrameBuffer.cpp
+++ b/source/gameengine/Rasterizer/RAS_FrameBuffer.cpp
@@ -27,52 +27,67 @@
 #include "RAS_FrameBuffer.h"
 
 extern "C" {
-#  include "GPU_framebuffer.h"
-#  include "GPU_texture.h"
-#  include "DRW_render.h"
-#  include "eevee_private.h"
+#include "GPU_framebuffer.h"
+#include "GPU_texture.h"
+#include "DRW_render.h"
+#include "eevee_private.h"
 }
 
-RAS_FrameBuffer::RAS_FrameBuffer(unsigned int width, unsigned int height, RAS_Rasterizer::HdrType hdrtype, RAS_Rasterizer::FrameBufferType fbtype)
-	:m_frameBuffer(nullptr),
-	m_frameBufferType(fbtype),
-	m_hdrType(hdrtype)
+RAS_FrameBuffer::RAS_FrameBuffer(unsigned int width,
+                                 unsigned int height,
+                                 RAS_Rasterizer::HdrType hdrtype,
+                                 RAS_Rasterizer::FrameBufferType fbtype)
+    : m_frameBuffer(nullptr), m_frameBufferType(fbtype), m_hdrType(hdrtype)
 {
-	m_colorAttachment = nullptr;
-	m_depthAttachment = nullptr;
-	m_frameBuffer = GPU_framebuffer_create();
+  m_colorAttachment = GPU_texture_create_2d(width, height, GPU_RGBA16F, nullptr, nullptr);
+  m_depthAttachment = GPU_texture_create_2d(width, height, GPU_DEPTH24_STENCIL8, nullptr, nullptr);
+  m_frameBuffer = GPU_framebuffer_create();
+  GPU_framebuffer_texture_attach(m_frameBuffer, m_colorAttachment, 0, 0);
+  GPU_framebuffer_texture_attach(m_frameBuffer, m_depthAttachment, 0, 0);
 }
 
 RAS_FrameBuffer::RAS_FrameBuffer()
 {
-	m_frameBuffer = GPU_framebuffer_create();
-	m_frameBufferType = RAS_Rasterizer::FrameBufferType::RAS_FRAMEBUFFER_CUSTOM;
-	m_hdrType = RAS_Rasterizer::HdrType::RAS_HDR_HALF_FLOAT;
-	m_colorAttachment = nullptr;
-	m_depthAttachment = nullptr;
+  m_frameBuffer = GPU_framebuffer_create();
+  m_frameBufferType = RAS_Rasterizer::FrameBufferType::RAS_FRAMEBUFFER_CUSTOM;
+  m_hdrType = RAS_Rasterizer::HdrType::RAS_HDR_HALF_FLOAT;
+  m_colorAttachment = nullptr;
+  m_depthAttachment = nullptr;
 }
 
 RAS_FrameBuffer::~RAS_FrameBuffer()
 {
-	GPU_framebuffer_free(m_frameBuffer);
+  GPU_framebuffer_free(m_frameBuffer); //it detaches attachments
+  GPU_texture_free(m_colorAttachment);
+  GPU_texture_free(m_depthAttachment);
 }
 
 GPUFrameBuffer *RAS_FrameBuffer::GetFrameBuffer()
 {
-	return m_frameBuffer;
+  return m_frameBuffer;
 }
 
 unsigned int RAS_FrameBuffer::GetWidth() const
 {
-	return GPU_texture_width(m_colorAttachment);
+  return GPU_texture_width(m_colorAttachment);
 }
 
 unsigned int RAS_FrameBuffer::GetHeight() const
 {
-	return GPU_texture_height(m_colorAttachment);
+  return GPU_texture_height(m_colorAttachment);
+}
+
+GPUTexture *RAS_FrameBuffer::GetColorAttachment()
+{
+  return m_colorAttachment;
+}
+
+GPUTexture *RAS_FrameBuffer::GetDepthAttachment()
+{
+  return m_depthAttachment;
 }
 
 RAS_Rasterizer::FrameBufferType RAS_FrameBuffer::GetType() const
 {
-	return m_frameBufferType;
+  return m_frameBufferType;
 }

--- a/source/gameengine/Rasterizer/RAS_FrameBuffer.h
+++ b/source/gameengine/Rasterizer/RAS_FrameBuffer.h
@@ -41,6 +41,9 @@ private:
 	RAS_Rasterizer::FrameBufferType m_frameBufferType;
 	RAS_Rasterizer::HdrType m_hdrType;
 
+  GPUTexture *m_colorAttachment;
+  GPUTexture *m_depthAttachment;
+
 public:
 	RAS_FrameBuffer(unsigned int width, unsigned height, RAS_Rasterizer::HdrType hdrType, RAS_Rasterizer::FrameBufferType framebufferType);
 	RAS_FrameBuffer();
@@ -53,8 +56,8 @@ public:
 	unsigned GetWidth() const;
 	unsigned GetHeight() const;
 
-	GPUTexture *m_colorAttachment;
-	GPUTexture *m_depthAttachment;
+  GPUTexture *GetColorAttachment();
+  GPUTexture *GetDepthAttachment();
 
 	RAS_Rasterizer::FrameBufferType GetType() const;
 };

--- a/source/gameengine/Rasterizer/RAS_Rasterizer.cpp
+++ b/source/gameengine/Rasterizer/RAS_Rasterizer.cpp
@@ -287,7 +287,7 @@ void RAS_Rasterizer::SetAmbientColor(const MT_Vector3& color)
 	m_ambient = color;
 }
 
-void RAS_Rasterizer::Init()
+void RAS_Rasterizer::Init(RAS_ICanvas *canvas)
 {
 	GPU_state_init();
 
@@ -297,6 +297,8 @@ void RAS_Rasterizer::Init()
 	SetFrontFace(true);
 
 	SetColorMask(true, true, true, true);
+
+	m_frameBuffers.Update(canvas);
 }
 
 void RAS_Rasterizer::Exit()

--- a/source/gameengine/Rasterizer/RAS_Rasterizer.h
+++ b/source/gameengine/Rasterizer/RAS_Rasterizer.h
@@ -350,7 +350,7 @@ public:
 	/**
 	 * Init initializes the renderer.
 	 */
-	void Init();
+	void Init(RAS_ICanvas *canvas);
 
 	/**
 	 * Exit cleans up the renderer.


### PR DESCRIPTION
Test file for 2dfilter offscreens:

http://pasteall.org/blend/index.php?id=52710

Notes:

1. As in 2.8 branch we use framebuffers instead of offscreens, i renamed
files and many variables, functions.... frameBuffer instead of
offScreen.

KX_2DFilterOffScreen is now KX_2DFilterFrmaeBuffer
same for RAS_2DFilterOffScreen > RAS_2DFilterFrameBuffer

but on scripting side, I see no issue to keep "offScreen" name for backward
compatibility.

Anyway, i doubt there are many people who use this.

2. KX_2DFilterOffScreen supported several color attachments per
offscreen, but I restored only 1 color attachment because it's simpler