### PR TITLE
UPBGE: Support several engines drawing

### DIFF
--- a/source/blender/draw/engines/eevee/eevee_engine.c
+++ b/source/blender/draw/engines/eevee/eevee_engine.c
@@ -354,7 +354,16 @@ static void eevee_draw_background(void *vedata)
     bool use_render_settings = stl->g_data->use_color_render_settings;
 
     GPU_framebuffer_bind(dfbl->default_fb);
-    DRW_transform_to_display(stl->effects->final_tx, true, use_render_settings);
+    /* Game engine transition - ImageRender: avoid double tonemapping */
+    const DRWContextState *drw_ctx = DRW_context_state_get();
+    Scene *scene_eval = drw_ctx->scene;
+    if (!(scene_eval->flag & SCE_INTERACTIVE_IMAGE_RENDER)) {
+      DRW_transform_to_display(stl->effects->final_tx, true, use_render_settings);
+    }
+    else {
+      DRW_transform_to_display_image_render(stl->effects->final_tx);
+    }
+    /* End of Game engine transition */
 
     /* Draw checkerboard with alpha under. */
     EEVEE_draw_alpha_checker(vedata);

--- a/source/blender/draw/engines/eevee/eevee_engine.c
+++ b/source/blender/draw/engines/eevee/eevee_engine.c
@@ -354,11 +354,7 @@ static void eevee_draw_background(void *vedata)
     bool use_render_settings = stl->g_data->use_color_render_settings;
 
     GPU_framebuffer_bind(dfbl->default_fb);
-    const DRWContextState *draw_ctx = DRW_context_state_get();
-    Scene *scene = draw_ctx->scene;
-    if (!(scene->flag & SCE_INTERACTIVE)) {
-      DRW_transform_to_display(stl->effects->final_tx, true, use_render_settings);
-    }
+    DRW_transform_to_display(stl->effects->final_tx, true, use_render_settings);
 
     /* Draw checkerboard with alpha under. */
     EEVEE_draw_alpha_checker(vedata);

--- a/source/blender/draw/engines/eevee/eevee_lightprobes.c
+++ b/source/blender/draw/engines/eevee/eevee_lightprobes.c
@@ -336,11 +336,10 @@ void EEVEE_lightprobes_cache_init(EEVEE_ViewLayerData *sldata, EEVEE_Data *vedat
 
     const float *col = G_draw.block.colorBackground;
 
-    if (!(scene->flag & SCE_INTERACTIVE)) {
-      /* LookDev */
-      EEVEE_lookdev_cache_init(vedata, &grp, psl->probe_background, 1.0f, wo, pinfo);
-      /* END */
-    }
+    /* LookDev */
+    EEVEE_lookdev_cache_init(vedata, &grp, psl->probe_background, 1.0f, wo, pinfo);
+    /* END */
+
     if (!grp && wo) {
       col = &wo->horr;
 
@@ -764,7 +763,7 @@ void EEVEE_lightprobes_cache_finish(EEVEE_ViewLayerData *sldata, EEVEE_Data *ved
   /* If light-cache auto-update is enable we tag the relevant part
    * of the cache to update and fire up a baking job. */
   if (!DRW_state_is_image_render() && !DRW_state_is_opengl_render() &&
-      (pinfo->do_grid_update || pinfo->do_cube_update) && !(scene_eval->flag & SCE_INTERACTIVE)) {
+      (pinfo->do_grid_update || pinfo->do_cube_update)) {
     BLI_assert(draw_ctx->evil_C);
 
     if (draw_ctx->scene->eevee.flag & SCE_EEVEE_GI_AUTOBAKE) {

--- a/source/blender/draw/engines/eevee/eevee_materials.c
+++ b/source/blender/draw/engines/eevee/eevee_materials.c
@@ -938,10 +938,7 @@ void EEVEE_materials_cache_init(EEVEE_ViewLayerData *sldata, EEVEE_Data *vedata)
 
     const float *col = G_draw.block.colorBackground;
 
-    if (!(scene->flag & SCE_INTERACTIVE)) {
-      EEVEE_lookdev_cache_init(
-          vedata, &grp, psl->background_pass, stl->g_data->background_alpha, wo, NULL);
-    }
+    EEVEE_lookdev_cache_init(vedata, &grp, psl->background_pass, stl->g_data->background_alpha, wo, NULL);
 
     if (!grp && wo) {
       col = &wo->horr;

--- a/source/blender/draw/intern/DRW_render.h
+++ b/source/blender/draw/intern/DRW_render.h
@@ -692,11 +692,13 @@ typedef struct DRWContextState {
 const DRWContextState *DRW_context_state_get(void);
 
 /*****************************GAME ENGINE***********************************/
-struct GPUTexture *DRW_game_render_loop(struct bContext *C, GPUViewport *viewport, struct Main *bmain, struct Scene *scene,
+void DRW_game_render_loop(struct bContext *C, GPUViewport *viewport, struct Main *bmain, struct Scene *scene,
 	float view[4][4], float viewinv[4][4], float proj[4][4], float pers[4][4], float persinv[4][4],
-  bool called_from_constructor, bool reset_taa_samples);
+  bool called_from_constructor, bool reset_taa_samples, int v[4]);
 void DRW_game_render_loop_finish(void);
 void DRW_game_render_loop_end(void);
+void DRW_game_opengl_context_disable(void);
+void DRW_game_opengl_context_enable(void);
 /**************************END OF GAME ENGINE*******************************/
 
 #endif /* __DRW_RENDER_H__ */

--- a/source/blender/draw/intern/DRW_render.h
+++ b/source/blender/draw/intern/DRW_render.h
@@ -701,8 +701,9 @@ void DRW_game_render_loop(struct bContext *C,
   float proj[4][4],
   float pers[4][4],
   float persinv[4][4],
-  int window_size[4],
+  const struct rcti *window,
   bool called_from_constructor,
+  bool image_render,
   bool reset_taa_samples);
 
 void DRW_game_render_loop_finish(void);

--- a/source/blender/draw/intern/DRW_render.h
+++ b/source/blender/draw/intern/DRW_render.h
@@ -703,7 +703,6 @@ void DRW_game_render_loop(struct bContext *C,
   float persinv[4][4],
   const struct rcti *window,
   bool called_from_constructor,
-  bool use_aregion_size,
   bool reset_taa_samples);
 
 void DRW_game_render_loop_finish(void);

--- a/source/blender/draw/intern/DRW_render.h
+++ b/source/blender/draw/intern/DRW_render.h
@@ -703,7 +703,7 @@ void DRW_game_render_loop(struct bContext *C,
   float persinv[4][4],
   const struct rcti *window,
   bool called_from_constructor,
-  bool image_render,
+  bool use_aregion_size,
   bool reset_taa_samples);
 
 void DRW_game_render_loop_finish(void);

--- a/source/blender/draw/intern/DRW_render.h
+++ b/source/blender/draw/intern/DRW_render.h
@@ -692,9 +692,19 @@ typedef struct DRWContextState {
 const DRWContextState *DRW_context_state_get(void);
 
 /*****************************GAME ENGINE***********************************/
-void DRW_game_render_loop(struct bContext *C, GPUViewport *viewport, struct Main *bmain, struct Scene *scene,
-	float view[4][4], float viewinv[4][4], float proj[4][4], float pers[4][4], float persinv[4][4],
-  bool called_from_constructor, bool reset_taa_samples, int v[4]);
+void DRW_game_render_loop(struct bContext *C,
+  GPUViewport *viewport,
+  struct Main *bmain,
+  struct Scene *scene,
+  float view[4][4],
+  float viewinv[4][4],
+  float proj[4][4],
+  float pers[4][4],
+  float persinv[4][4],
+  int window_size[4],
+  bool called_from_constructor,
+  bool reset_taa_samples);
+
 void DRW_game_render_loop_finish(void);
 void DRW_game_render_loop_end(void);
 void DRW_game_opengl_context_disable(void);

--- a/source/blender/draw/intern/DRW_render.h
+++ b/source/blender/draw/intern/DRW_render.h
@@ -708,8 +708,8 @@ void DRW_game_render_loop(struct bContext *C,
 
 void DRW_game_render_loop_finish(void);
 void DRW_game_render_loop_end(void);
-void DRW_game_opengl_context_disable(void);
-void DRW_game_opengl_context_enable(void);
+
+void DRW_transform_to_display_image_render(struct GPUTexture *tex);
 /**************************END OF GAME ENGINE*******************************/
 
 #endif /* __DRW_RENDER_H__ */

--- a/source/blender/draw/intern/draw_manager.c
+++ b/source/blender/draw/intern/draw_manager.c
@@ -3027,7 +3027,7 @@ EEVEE_Data *EEVEE_engine_data_get(void)
 
 void DRW_game_render_loop(bContext *C, GPUViewport *viewport, Main *bmain, Scene *scene,
   float view[4][4], float viewinv[4][4], float proj[4][4], float pers[4][4], float persinv[4][4],
-  const rcti *window, bool called_from_constructor, bool use_aregion_size, bool reset_taa_samples)
+  const rcti *window, bool called_from_constructor, bool reset_taa_samples)
 {
   /* Reset before using it. */
   drw_state_prepare_clean_for_draw(&DST);
@@ -3060,12 +3060,7 @@ void DRW_game_render_loop(bContext *C, GPUViewport *viewport, Main *bmain, Scene
 
   RegionView3D *rv3d = CTX_wm_region_view3d(C);
 
-  if (use_aregion_size) {
-    GPU_viewport_bind(viewport, &ar->winrct);
-  }
-  else {
-    GPU_viewport_bind(viewport, window);
-  }
+  GPU_viewport_bind(viewport, window);
 
   bool gpencil_engine_needed = drw_gpencil_engine_needed(depsgraph, v3d);
 

--- a/source/blender/draw/intern/draw_manager.c
+++ b/source/blender/draw/intern/draw_manager.c
@@ -3128,7 +3128,9 @@ void DRW_game_render_loop(bContext *C, GPUViewport *viewport, Main *bmain, Scene
 
   drw_engines_draw_background();
 
-  drw_engines_draw_scene();
+  if (gpencil_engine_needed) {
+    drw_engines_draw_scene();
+  }
 
   DRW_state_reset();
 

--- a/source/blender/draw/intern/draw_manager.c
+++ b/source/blender/draw/intern/draw_manager.c
@@ -3027,7 +3027,7 @@ EEVEE_Data *EEVEE_engine_data_get(void)
 
 void DRW_game_render_loop(bContext *C, GPUViewport *viewport, Main *bmain, Scene *scene,
   float view[4][4], float viewinv[4][4], float proj[4][4], float pers[4][4], float persinv[4][4],
-  const rcti *window, bool called_from_constructor, bool image_render, bool reset_taa_samples)
+  const rcti *window, bool called_from_constructor, bool use_aregion_size, bool reset_taa_samples)
 {
   /* Reset before using it. */
   drw_state_prepare_clean_for_draw(&DST);
@@ -3060,7 +3060,7 @@ void DRW_game_render_loop(bContext *C, GPUViewport *viewport, Main *bmain, Scene
 
   RegionView3D *rv3d = CTX_wm_region_view3d(C);
 
-  if (!image_render) {
+  if (use_aregion_size) {
     GPU_viewport_bind(viewport, &ar->winrct);
   }
   else {

--- a/source/blender/draw/intern/draw_manager.c
+++ b/source/blender/draw/intern/draw_manager.c
@@ -3060,8 +3060,8 @@ void DRW_game_render_loop(bContext *C, GPUViewport *viewport, Main *bmain, Scene
 
   RegionView3D *rv3d = CTX_wm_region_view3d(C);
 
-  const rcti rect = {v[0], v[2], v[1], v[3]};
-  GPU_viewport_bind(viewport, &rect);
+  //const rcti rect = {v[0], v[2], v[1], v[3]};
+  GPU_viewport_bind(viewport, &ar->winrct);
 
   bool gpencil_engine_needed = drw_gpencil_engine_needed(depsgraph, v3d);
 

--- a/source/blender/draw/intern/draw_manager.c
+++ b/source/blender/draw/intern/draw_manager.c
@@ -3127,11 +3127,9 @@ void DRW_game_render_loop(bContext *C, GPUViewport *viewport, Main *bmain, Scene
   DRW_state_reset();
 
   GPU_viewport_unbind(DST.viewport);
-
-  //DRW_opengl_context_disable();
 }
 
-void DRW_game_render_loop_finish()
+void DRW_game_render_loop_finish() //unused: check if something is needed
 {
   GPU_viewport_texture_pool_clear_users_bge(DST.viewport);
   GPU_framebuffer_restore();

--- a/source/blender/draw/intern/draw_manager.c
+++ b/source/blender/draw/intern/draw_manager.c
@@ -3027,7 +3027,7 @@ EEVEE_Data *EEVEE_engine_data_get(void)
 
 void DRW_game_render_loop(bContext *C, GPUViewport *viewport, Main *bmain, Scene *scene,
   float view[4][4], float viewinv[4][4], float proj[4][4], float pers[4][4], float persinv[4][4],
-  int window_size[4], bool called_from_constructor, bool reset_taa_samples)
+  const rcti *window, bool called_from_constructor, bool image_render, bool reset_taa_samples)
 {
   /* Reset before using it. */
   drw_state_prepare_clean_for_draw(&DST);
@@ -3060,8 +3060,12 @@ void DRW_game_render_loop(bContext *C, GPUViewport *viewport, Main *bmain, Scene
 
   RegionView3D *rv3d = CTX_wm_region_view3d(C);
 
-  //const rcti rect = {v[0], v[2], v[1], v[3]};
-  GPU_viewport_bind(viewport, &ar->winrct);
+  if (!image_render) {
+    GPU_viewport_bind(viewport, &ar->winrct);
+  }
+  else {
+    GPU_viewport_bind(viewport, window);
+  }
 
   bool gpencil_engine_needed = drw_gpencil_engine_needed(depsgraph, v3d);
 

--- a/source/blender/draw/intern/draw_manager.c
+++ b/source/blender/draw/intern/draw_manager.c
@@ -3182,6 +3182,9 @@ void DRW_opengl_context_create_blenderplayer(void)
   wm_window_reset_drawable();
 }
 
+/* Called instead of DRW_transform_to_display in eevee_engine
+ * to avoid double tonemapping of rendered textures with ImageRender
+ */
 void DRW_transform_to_display_image_render(GPUTexture *tex)
 {
   drw_state_set(DRW_STATE_WRITE_COLOR);
@@ -3190,7 +3193,6 @@ void DRW_transform_to_display_image_render(GPUTexture *tex)
   uint pos = GPU_vertformat_attr_add(vert_format, "pos", GPU_COMP_F32, 2, GPU_FETCH_FLOAT);
   uint texco = GPU_vertformat_attr_add(vert_format, "texCoord", GPU_COMP_F32, 2, GPU_FETCH_FLOAT);
 
-  const float dither = 1.0f;
   immBindBuiltinProgram(GPU_SHADER_2D_IMAGE_COLOR);
   immUniform1i("image", 0);
 

--- a/source/blender/draw/intern/draw_manager.c
+++ b/source/blender/draw/intern/draw_manager.c
@@ -3156,6 +3156,7 @@ void DRW_game_render_loop_end()
 
   eevee_game_view_layer_data_free();
   draw_engine_eevee_type.engine_free();
+  draw_engine_gpencil_type.engine_free();
 
   memset(&DST, 0xFF, offsetof(DRWManager, gl_context));
 }

--- a/source/blender/draw/intern/draw_manager.c
+++ b/source/blender/draw/intern/draw_manager.c
@@ -3027,7 +3027,7 @@ EEVEE_Data *EEVEE_engine_data_get(void)
 
 void DRW_game_render_loop(bContext *C, GPUViewport *viewport, Main *bmain, Scene *scene,
   float view[4][4], float viewinv[4][4], float proj[4][4], float pers[4][4], float persinv[4][4],
-  bool called_from_constructor, bool reset_taa_samples, int v[4])
+  int window_size[4], bool called_from_constructor, bool reset_taa_samples)
 {
   /* Reset before using it. */
   drw_state_prepare_clean_for_draw(&DST);

--- a/source/blender/draw/intern/draw_manager.c
+++ b/source/blender/draw/intern/draw_manager.c
@@ -3140,8 +3140,6 @@ void DRW_game_render_loop(bContext *C, GPUViewport *viewport, Main *bmain, Scene
 
 void DRW_game_render_loop_finish() //unused: check if something is needed
 {
-  GPU_viewport_texture_pool_clear_users_bge(DST.viewport);
-  GPU_framebuffer_restore();
   drw_engines_disable();
   drw_viewport_cache_resize();
 }

--- a/source/blender/gpu/GPU_viewport.h
+++ b/source/blender/gpu/GPU_viewport.h
@@ -130,6 +130,4 @@ GPUTexture *GPU_viewport_texture_pool_query(
 bool GPU_viewport_engines_data_validate(GPUViewport *viewport, void **engine_handle_array);
 void GPU_viewport_cache_release(GPUViewport *viewport);
 
-void GPU_viewport_texture_pool_clear_users_bge(GPUViewport *viewport);
-
 #endif // __GPU_VIEWPORT_H__

--- a/source/blender/gpu/intern/gpu_viewport.c
+++ b/source/blender/gpu/intern/gpu_viewport.c
@@ -671,24 +671,3 @@ void GPU_viewport_free(GPUViewport *viewport)
 
   MEM_freeN(viewport);
 }
-
-void GPU_viewport_texture_pool_clear_users_bge(GPUViewport *viewport)
-{
-	ViewportTempTexture *tmp_tex_next;
-
-	for (ViewportTempTexture *tmp_tex = viewport->tex_pool.first; tmp_tex; tmp_tex = tmp_tex_next) {
-		tmp_tex_next = tmp_tex->next;
-		bool no_user = true;
-		for (int i = 0; i < MAX_ENGINE_BUFFER_SHARING; ++i) {
-			if (tmp_tex->user[i] != NULL) {
-				tmp_tex->user[i] = NULL;
-				no_user = false;
-			}
-		}
-
-		if (no_user) {
-			GPU_texture_free(tmp_tex->texture);
-			BLI_freelinkN(&viewport->tex_pool, tmp_tex);
-		}
-	}
-}

--- a/source/blender/makesdna/DNA_scene_types.h
+++ b/source/blender/makesdna/DNA_scene_types.h
@@ -2304,6 +2304,7 @@ typedef enum eVGroupSelect {
 #define SCE_FRAME_DROP			(1 << 3)
 #define SCE_KEYS_NO_SELONLY	    (1 << 4)
 #define SCE_INTERACTIVE         (1 << 5)
+#define SCE_INTERACTIVE_IMAGE_RENDER (1 << 6)
 
 	/* return flag BKE_scene_base_iter_next functions */
 /* #define F_ERROR			-1 */  /* UNUSED */

--- a/source/gameengine/Converter/BL_BlenderDataConversion.cpp
+++ b/source/gameengine/Converter/BL_BlenderDataConversion.cpp
@@ -160,11 +160,6 @@ extern "C" {
 #include "IMB_imbuf_types.h"
 #include "BKE_displist.h"
 
-#  include "eevee_private.h"
-#  include "eevee_engine.h"
-#  include "draw/intern/DRW_render.h"
-#  include "BLI_alloca.h"
-
 extern Material defmaterial;	/* material.c */
 }
 

--- a/source/gameengine/Converter/KX_BlenderConverter.h
+++ b/source/gameengine/Converter/KX_BlenderConverter.h
@@ -44,10 +44,6 @@
 
 #include "CM_Thread.h"
 
-extern "C" {
-#include "../draw/engines/eevee/eevee_private.h"
-}
-
 class CStringValue;
 class KX_BlenderSceneConverter;
 class KX_KetsjiEngine;

--- a/source/gameengine/Ketsji/KX_Camera.cpp
+++ b/source/gameengine/Ketsji/KX_Camera.cpp
@@ -44,11 +44,6 @@
 
 #include "GPU_glew.h"
 
-extern "C" {
-#  include "eevee_private.h"
-#  include "DRW_render.h"
-}
-
 KX_Camera::KX_Camera(void* sgReplicationInfo,
                      SG_Callbacks callbacks,
                      const RAS_CameraData& camdata,

--- a/source/gameengine/Ketsji/KX_Scene.cpp
+++ b/source/gameengine/Ketsji/KX_Scene.cpp
@@ -534,7 +534,7 @@ void KX_Scene::RenderAfterCameraSetup(bool calledFromConstructor)
               viewport->GetHeight() + 1};
 
   const RAS_Rect *window = &canvas->GetWindowArea();
-  int w[4] = {window->GetLeft(), window->GetBottom(), window->GetWidth(), window->GetHeight()};
+  int window_size[4] = {window->GetLeft(), window->GetBottom(), window->GetWidth(), window->GetHeight()};
 
   if (!calledFromConstructor) {
     rasty->SetMatrix(cam->GetModelviewMatrix(),
@@ -584,8 +584,7 @@ void KX_Scene::RenderAfterCameraSetup(bool calledFromConstructor)
 
   if (!m_gpuViewport) {
     /* Create eevee's cache space */
-    m_gpuOffScreen = GPU_offscreen_create(
-        w[1], w[3], 0, true, false, nullptr);
+    m_gpuOffScreen = GPU_offscreen_create(window_size[1], window_size[3], 0, true, false, nullptr);
     m_gpuViewport = GPU_viewport_create_from_offscreen(m_gpuOffScreen);
     GPU_viewport_engine_data_create(m_gpuViewport, &draw_engine_eevee_type);
   }
@@ -599,9 +598,9 @@ void KX_Scene::RenderAfterCameraSetup(bool calledFromConstructor)
       proj,
       pers,
       persinv,
+      window_size,
       calledFromConstructor,
-      reset_taa_samples,
-      w);
+      reset_taa_samples);
 
   RAS_FrameBuffer *input = rasty->GetFrameBuffer(rasty->NextFilterFrameBuffer(r));
   RAS_FrameBuffer *output = rasty->GetFrameBuffer(rasty->NextFilterFrameBuffer(s));
@@ -649,7 +648,7 @@ void KX_Scene::RenderAfterCameraSetup(bool calledFromConstructor)
   GPU_framebuffer_restore();
 }
 
-void KX_Scene::RenderAfterCameraSetupImageRender(RAS_Rasterizer *rasty, GPUViewport *viewport, int window[4])
+void KX_Scene::RenderAfterCameraSetupImageRender(RAS_Rasterizer *rasty, GPUViewport *viewport, int window_size[4])
 {
   for (KX_GameObject *gameobj : GetObjectList()) {
     gameobj->TagForUpdate();
@@ -681,9 +680,9 @@ void KX_Scene::RenderAfterCameraSetupImageRender(RAS_Rasterizer *rasty, GPUViewp
                                               proj,
                                               pers,
                                               persinv,
+                                              window_size,
                                               false,
-                                              true,
-                                              window);
+                                              true);
 }
 
 /******************End of EEVEE INTEGRATION****************************/

--- a/source/gameengine/Ketsji/KX_Scene.cpp
+++ b/source/gameengine/Ketsji/KX_Scene.cpp
@@ -534,7 +534,7 @@ void KX_Scene::RenderAfterCameraSetup(bool calledFromConstructor)
               viewport->GetHeight() + 1};
 
   const RAS_Rect *window = &canvas->GetWindowArea();
-  int w[4] = {window->GetLeft(), window->GetBottom(), window->GetWidth() + 1, window->GetHeight() + 1};
+  int w[4] = {window->GetLeft(), window->GetBottom(), window->GetWidth(), window->GetHeight()};
 
   if (!calledFromConstructor) {
     rasty->SetMatrix(cam->GetModelviewMatrix(),

--- a/source/gameengine/Ketsji/KX_Scene.cpp
+++ b/source/gameengine/Ketsji/KX_Scene.cpp
@@ -533,8 +533,8 @@ void KX_Scene::RenderAfterCameraSetup(bool calledFromConstructor)
               viewport->GetWidth() + 1,
               viewport->GetHeight() + 1};
 
-  const RAS_Rect *window = &canvas->GetWindowArea();
-  int window_size[4] = {window->GetLeft(), window->GetBottom(), window->GetWidth(), window->GetHeight()};
+  const RAS_Rect *w = &canvas->GetWindowArea();
+  const rcti window = {w->GetLeft(), w->GetWidth(), w->GetBottom(), w->GetHeight()};
 
   if (!calledFromConstructor) {
     rasty->SetMatrix(cam->GetModelviewMatrix(),
@@ -584,7 +584,7 @@ void KX_Scene::RenderAfterCameraSetup(bool calledFromConstructor)
 
   if (!m_gpuViewport) {
     /* Create eevee's cache space */
-    m_gpuOffScreen = GPU_offscreen_create(window_size[1], window_size[3], 0, true, false, nullptr);
+    m_gpuOffScreen = GPU_offscreen_create(window.xmax - window.xmin, window.ymax - window.ymin, 0, true, false, nullptr);
     m_gpuViewport = GPU_viewport_create_from_offscreen(m_gpuOffScreen);
     GPU_viewport_engine_data_create(m_gpuViewport, &draw_engine_eevee_type);
   }
@@ -598,8 +598,9 @@ void KX_Scene::RenderAfterCameraSetup(bool calledFromConstructor)
       proj,
       pers,
       persinv,
-      window_size,
+      &window,
       calledFromConstructor,
+      false,
       reset_taa_samples);
 
   RAS_FrameBuffer *input = rasty->GetFrameBuffer(rasty->NextFilterFrameBuffer(r));
@@ -648,7 +649,7 @@ void KX_Scene::RenderAfterCameraSetup(bool calledFromConstructor)
   GPU_framebuffer_restore();
 }
 
-void KX_Scene::RenderAfterCameraSetupImageRender(RAS_Rasterizer *rasty, GPUViewport *viewport, int window_size[4])
+void KX_Scene::RenderAfterCameraSetupImageRender(RAS_Rasterizer *rasty, GPUViewport *viewport, const rcti *window)
 {
   for (KX_GameObject *gameobj : GetObjectList()) {
     gameobj->TagForUpdate();
@@ -680,8 +681,9 @@ void KX_Scene::RenderAfterCameraSetupImageRender(RAS_Rasterizer *rasty, GPUViewp
                                               proj,
                                               pers,
                                               persinv,
-                                              window_size,
+                                              window,
                                               false,
+                                              true,
                                               true);
 }
 

--- a/source/gameengine/Ketsji/KX_Scene.cpp
+++ b/source/gameengine/Ketsji/KX_Scene.cpp
@@ -632,6 +632,8 @@ void KX_Scene::RenderAfterCameraSetup(bool calledFromConstructor)
 
   DRW_transform_none(GPU_framebuffer_color_texture(f->GetFrameBuffer()));
 
+  DRW_game_render_loop_finish();
+
   if (!calledFromConstructor) {
     engine->EndFrame();
   }

--- a/source/gameengine/Ketsji/KX_Scene.cpp
+++ b/source/gameengine/Ketsji/KX_Scene.cpp
@@ -597,7 +597,7 @@ void KX_Scene::RenderAfterCameraSetup(bool calledFromConstructor)
     GPU_viewport_engine_data_create(m_gpuViewport, &draw_engine_eevee_type);
   }
 
-  GPUTexture *finaltex = DRW_game_render_loop(engine->GetContext(),
+  DRW_game_render_loop(engine->GetContext(),
                                               m_gpuViewport,
                                               bmain,
                                               scene,
@@ -607,24 +607,27 @@ void KX_Scene::RenderAfterCameraSetup(bool calledFromConstructor)
                                               pers,
                                               persinv,
                                               calledFromConstructor,
-                                              reset_taa_samples);
+                                              reset_taa_samples,
+                                              v);
 
-  RAS_FrameBuffer *input = rasty->GetFrameBuffer(rasty->NextFilterFrameBuffer(r));
-  RAS_FrameBuffer *output = rasty->GetFrameBuffer(rasty->NextFilterFrameBuffer(s));
+  //RAS_FrameBuffer *input = rasty->GetFrameBuffer(rasty->NextFilterFrameBuffer(r));
+  //RAS_FrameBuffer *output = rasty->GetFrameBuffer(rasty->NextFilterFrameBuffer(s));
 
-  /* Detach Defaults attachments from input framebuffer... */
-  GPU_framebuffer_texture_detach(input->GetFrameBuffer(), input->GetColorAttachment());
-  GPU_framebuffer_texture_detach(input->GetFrameBuffer(), input->GetDepthAttachment());
-  /* And replace it with color and depth textures from viewport */
-  GPU_framebuffer_texture_attach(input->GetFrameBuffer(), finaltex, 0, 0);
-  GPU_framebuffer_texture_attach(
-      input->GetFrameBuffer(), DRW_viewport_texture_list_get()->depth, 0, 0);
+  ///* Detach Defaults attachments from input framebuffer... */
+  //GPU_framebuffer_texture_detach(input->GetFrameBuffer(), input->GetColorAttachment());
+  //GPU_framebuffer_texture_detach(input->GetFrameBuffer(), input->GetDepthAttachment());
+  ///* And replace it with color and depth textures from viewport */
+  //GPU_framebuffer_texture_attach(input->GetFrameBuffer(), finaltex, 0, 0);
+  //GPU_framebuffer_texture_attach(
+  //    input->GetFrameBuffer(), DRW_viewport_texture_list_get()->depth, 0, 0);
 
-  GPU_framebuffer_bind(input->GetFrameBuffer());
+  //GPU_framebuffer_bind(input->GetFrameBuffer());
 
-  RAS_FrameBuffer *f = Render2DFilters(rasty, canvas, input, output);
+  //RAS_FrameBuffer *f = Render2DFilters(rasty, canvas, input, output);
 
-  GPU_framebuffer_restore();
+  //GPU_framebuffer_restore();
+
+  //DRW_game_render_loop_finish();
 
   rasty->SetViewport(v[0], v[1], v[2], v[3]);
 
@@ -633,20 +636,19 @@ void KX_Scene::RenderAfterCameraSetup(bool calledFromConstructor)
     rasty->SetScissor(v[0], v[1], v[2], v[3]);
   }
 
-  DRW_transform_to_display(GPU_framebuffer_color_texture(f->GetFrameBuffer()), true, true);
+  DRW_transform_none(GPU_viewport_color_texture(m_gpuViewport));
 
   if (!calledFromConstructor) {
     engine->EndFrame();
   }
 
-  /* Detach viewport textures from input framebuffer... */
-  GPU_framebuffer_texture_detach(input->GetFrameBuffer(), finaltex);
-  GPU_framebuffer_texture_detach(input->GetFrameBuffer(), DRW_viewport_texture_list_get()->depth);
-  /* And restore defaults attachments */
-  GPU_framebuffer_texture_attach(input->GetFrameBuffer(), input->GetColorAttachment(), 0, 0);
-  GPU_framebuffer_texture_attach(input->GetFrameBuffer(), input->GetDepthAttachment(), 0, 0);
+  ///* Detach viewport textures from input framebuffer... */
+  //GPU_framebuffer_texture_detach(input->GetFrameBuffer(), finaltex);
+  //GPU_framebuffer_texture_detach(input->GetFrameBuffer(), DRW_viewport_texture_list_get()->depth);
+  ///* And restore defaults attachments */
+  //GPU_framebuffer_texture_attach(input->GetFrameBuffer(), input->GetColorAttachment(), 0, 0);
+  //GPU_framebuffer_texture_attach(input->GetFrameBuffer(), input->GetDepthAttachment(), 0, 0);
 
-  DRW_game_render_loop_finish();
   GPU_framebuffer_restore();
 }
 
@@ -674,7 +676,9 @@ GPUTexture *KX_Scene::RenderAfterCameraSetupImageRender(RAS_Rasterizer *rasty,
   m.pers.getValue(&pers[0][0]);
   m.persinv.getValue(&persinv[0][0]);
 
-  GPUTexture *finaltex = DRW_game_render_loop(KX_GetActiveEngine()->GetContext(),
+  int v[4] = {0, 0, 0, 0};
+
+  DRW_game_render_loop(KX_GetActiveEngine()->GetContext(),
                                               viewport,
                                               bmain,
                                               scene,
@@ -684,8 +688,9 @@ GPUTexture *KX_Scene::RenderAfterCameraSetupImageRender(RAS_Rasterizer *rasty,
                                               pers,
                                               persinv,
                                               false,
-                                              true);
-  return finaltex;
+                                              true,
+                                              v);
+  return nullptr;
 }
 
 /******************End of EEVEE INTEGRATION****************************/

--- a/source/gameengine/Ketsji/KX_Scene.cpp
+++ b/source/gameengine/Ketsji/KX_Scene.cpp
@@ -169,7 +169,6 @@ KX_Scene::KX_Scene(SCA_IInputDevice *inputDevice,
       m_lastReplicatedParentObject(nullptr),  // eevee
       m_gameDefaultCamera(nullptr),           // eevee
       m_gpuViewport(nullptr),                 // eevee
-      m_gpuOffScreen(nullptr),                // eevee
       m_keyboardmgr(nullptr),
       m_mousemgr(nullptr),
       m_physicsEnvironment(0),
@@ -534,8 +533,7 @@ void KX_Scene::RenderAfterCameraSetup(bool calledFromConstructor)
               viewport->GetWidth() + 1,
               viewport->GetHeight() + 1};
 
-  const RAS_Rect *w = &canvas->GetWindowArea();
-  const rcti window = {w->GetLeft(), w->GetWidth(), w->GetBottom(), w->GetHeight()};
+  const rcti window = {0, viewport->GetWidth(), 0, viewport->GetHeight()};
 
   if (!calledFromConstructor) {
     rasty->SetMatrix(cam->GetModelviewMatrix(),
@@ -585,9 +583,7 @@ void KX_Scene::RenderAfterCameraSetup(bool calledFromConstructor)
 
   if (!m_gpuViewport) {
     /* Create eevee's cache space */
-    m_gpuOffScreen = GPU_offscreen_create(window.xmax - window.xmin, window.ymax - window.ymin, 0, true, false, nullptr);
-    m_gpuViewport = GPU_viewport_create_from_offscreen(m_gpuOffScreen);
-    GPU_viewport_engine_data_create(m_gpuViewport, &draw_engine_eevee_type);
+    m_gpuViewport = GPU_viewport_create();
   }
 
   DRW_game_render_loop(engine->GetContext(),
@@ -601,7 +597,6 @@ void KX_Scene::RenderAfterCameraSetup(bool calledFromConstructor)
       persinv,
       &window,
       calledFromConstructor,
-      canvas->GetARegion() ? true : false,
       reset_taa_samples);
 
   RAS_FrameBuffer *input = rasty->GetFrameBuffer(rasty->NextFilterFrameBuffer(r));
@@ -680,7 +675,6 @@ void KX_Scene::RenderAfterCameraSetupImageRender(RAS_Rasterizer *rasty, GPUViewp
                                               pers,
                                               persinv,
                                               window,
-                                              false,
                                               false,
                                               true);
 }

--- a/source/gameengine/Ketsji/KX_Scene.cpp
+++ b/source/gameengine/Ketsji/KX_Scene.cpp
@@ -657,8 +657,7 @@ void KX_Scene::RenderAfterCameraSetup(bool calledFromConstructor)
   GPU_framebuffer_restore();
 }
 
-GPUTexture *KX_Scene::RenderAfterCameraSetupImageRender(RAS_Rasterizer *rasty,
-                                                        GPUViewport *viewport)
+void KX_Scene::RenderAfterCameraSetupImageRender(RAS_Rasterizer *rasty, GPUViewport *viewport, int window[4])
 {
   for (KX_GameObject *gameobj : GetObjectList()) {
     gameobj->TagForUpdate();
@@ -681,8 +680,6 @@ GPUTexture *KX_Scene::RenderAfterCameraSetupImageRender(RAS_Rasterizer *rasty,
   m.pers.getValue(&pers[0][0]);
   m.persinv.getValue(&persinv[0][0]);
 
-  int v[4] = {0, 0, 0, 0};
-
   DRW_game_render_loop(KX_GetActiveEngine()->GetContext(),
                                               viewport,
                                               bmain,
@@ -694,8 +691,7 @@ GPUTexture *KX_Scene::RenderAfterCameraSetupImageRender(RAS_Rasterizer *rasty,
                                               persinv,
                                               false,
                                               true,
-                                              v);
-  return nullptr;
+                                              window);
 }
 
 /******************End of EEVEE INTEGRATION****************************/

--- a/source/gameengine/Ketsji/KX_Scene.cpp
+++ b/source/gameengine/Ketsji/KX_Scene.cpp
@@ -585,7 +585,7 @@ void KX_Scene::RenderAfterCameraSetup(bool calledFromConstructor)
   if (!m_gpuViewport) {
     /* Create eevee's cache space */
     m_gpuOffScreen = GPU_offscreen_create(
-        canvas->GetWidth() + 1, canvas->GetHeight() + 1, 0, true, false, nullptr);
+        w[1], w[3], 0, true, false, nullptr);
     m_gpuViewport = GPU_viewport_create_from_offscreen(m_gpuOffScreen);
     GPU_viewport_engine_data_create(m_gpuViewport, &draw_engine_eevee_type);
   }

--- a/source/gameengine/Ketsji/KX_Scene.cpp
+++ b/source/gameengine/Ketsji/KX_Scene.cpp
@@ -585,7 +585,7 @@ void KX_Scene::RenderAfterCameraSetup(bool calledFromConstructor)
   if (!m_gpuViewport) {
     /* Create eevee's cache space */
     m_gpuOffScreen = GPU_offscreen_create(
-        canvas->GetWindowArea().GetWidth(), canvas->GetWindowArea().GetHeight(), 0, true, false, nullptr);
+        canvas->GetWidth() + 1, canvas->GetHeight() + 1, 0, true, false, nullptr);
     m_gpuViewport = GPU_viewport_create_from_offscreen(m_gpuOffScreen);
     GPU_viewport_engine_data_create(m_gpuViewport, &draw_engine_eevee_type);
   }

--- a/source/gameengine/Ketsji/KX_Scene.cpp
+++ b/source/gameengine/Ketsji/KX_Scene.cpp
@@ -601,7 +601,7 @@ void KX_Scene::RenderAfterCameraSetup(bool calledFromConstructor)
       persinv,
       &window,
       calledFromConstructor,
-      false,
+      canvas->GetARegion() ? true : false,
       reset_taa_samples);
 
   RAS_FrameBuffer *input = rasty->GetFrameBuffer(rasty->NextFilterFrameBuffer(r));
@@ -681,7 +681,7 @@ void KX_Scene::RenderAfterCameraSetupImageRender(RAS_Rasterizer *rasty, GPUViewp
                                               persinv,
                                               window,
                                               false,
-                                              true,
+                                              false,
                                               true);
 }
 

--- a/source/gameengine/Ketsji/KX_Scene.cpp
+++ b/source/gameengine/Ketsji/KX_Scene.cpp
@@ -169,8 +169,6 @@ KX_Scene::KX_Scene(SCA_IInputDevice *inputDevice,
       m_gameDefaultCamera(nullptr),           // eevee
       m_gpuViewport(nullptr),                 // eevee
       m_gpuOffScreen(nullptr),                // eevee
-      m_v3dShadingTypeBackup(0),              // eevee
-      m_v3dShadingFlagBackup(0),              // eevee
       m_keyboardmgr(nullptr),
       m_mousemgr(nullptr),
       m_physicsEnvironment(0),
@@ -278,10 +276,6 @@ KX_Scene::KX_Scene(SCA_IInputDevice *inputDevice,
      * depsgraph code too later */
     scene->flag |= SCE_INTERACTIVE;
 
-    View3D *v3d = CTX_wm_view3d(KX_GetActiveEngine()->GetContext());
-    m_v3dShadingTypeBackup = v3d->shading.type;
-    m_v3dShadingFlagBackup = v3d->shading.flag;
-
     RenderAfterCameraSetup(true);
   }
   else {
@@ -322,10 +316,6 @@ KX_Scene::~KX_Scene()
       !ar) {  // if no ar, we are in blenderplayer
     /* This will free m_gpuViewport and m_gpuOffScreen */
     DRW_game_render_loop_end();
-
-    View3D *v3d = CTX_wm_view3d(KX_GetActiveEngine()->GetContext());
-    v3d->shading.type = m_v3dShadingTypeBackup;
-    v3d->shading.flag = m_v3dShadingFlagBackup;
   }
 
   LayerCollection *layer_collection = BKE_layer_collection_get_active(view_layer);

--- a/source/gameengine/Ketsji/KX_Scene.cpp
+++ b/source/gameengine/Ketsji/KX_Scene.cpp
@@ -110,6 +110,7 @@ extern "C" {
 #include "BKE_main.h"
 #include "BKE_object.h"
 #include "depsgraph/DEG_depsgraph_query.h"
+#include "eevee_private.h"
 #include "DNA_windowmanager_types.h"
 #include "DRW_render.h"
 #include "MEM_guardedalloc.h"

--- a/source/gameengine/Ketsji/KX_Scene.cpp
+++ b/source/gameengine/Ketsji/KX_Scene.cpp
@@ -601,36 +601,37 @@ void KX_Scene::RenderAfterCameraSetup(bool calledFromConstructor)
   }
 
   DRW_game_render_loop(engine->GetContext(),
-                                              m_gpuViewport,
-                                              bmain,
-                                              scene,
-                                              view,
-                                              viewinv,
-                                              proj,
-                                              pers,
-                                              persinv,
-                                              calledFromConstructor,
-                                              reset_taa_samples,
-                                              w);
+      m_gpuViewport,
+      bmain,
+      scene,
+      view,
+      viewinv,
+      proj,
+      pers,
+      persinv,
+      calledFromConstructor,
+      reset_taa_samples,
+      w);
 
-  //RAS_FrameBuffer *input = rasty->GetFrameBuffer(rasty->NextFilterFrameBuffer(r));
-  //RAS_FrameBuffer *output = rasty->GetFrameBuffer(rasty->NextFilterFrameBuffer(s));
+  RAS_FrameBuffer *input = rasty->GetFrameBuffer(rasty->NextFilterFrameBuffer(r));
+  RAS_FrameBuffer *output = rasty->GetFrameBuffer(rasty->NextFilterFrameBuffer(s));
 
-  ///* Detach Defaults attachments from input framebuffer... */
-  //GPU_framebuffer_texture_detach(input->GetFrameBuffer(), input->GetColorAttachment());
-  //GPU_framebuffer_texture_detach(input->GetFrameBuffer(), input->GetDepthAttachment());
-  ///* And replace it with color and depth textures from viewport */
-  //GPU_framebuffer_texture_attach(input->GetFrameBuffer(), finaltex, 0, 0);
-  //GPU_framebuffer_texture_attach(
-  //    input->GetFrameBuffer(), DRW_viewport_texture_list_get()->depth, 0, 0);
+  /* Detach Defaults attachments from input framebuffer... */
+  GPU_framebuffer_texture_detach(input->GetFrameBuffer(), input->GetColorAttachment());
+  GPU_framebuffer_texture_detach(input->GetFrameBuffer(), input->GetDepthAttachment());
+  /* And replace it with color and depth textures from viewport */
+  GPU_framebuffer_texture_attach(
+      input->GetFrameBuffer(), GPU_viewport_color_texture(m_gpuViewport), 0, 0);
+  GPU_framebuffer_texture_attach(
+      input->GetFrameBuffer(), DRW_viewport_texture_list_get()->depth, 0, 0);
 
-  //GPU_framebuffer_bind(input->GetFrameBuffer());
+  GPU_framebuffer_bind(input->GetFrameBuffer());
 
-  //RAS_FrameBuffer *f = Render2DFilters(rasty, canvas, input, output);
+  RAS_FrameBuffer *f = Render2DFilters(rasty, canvas, input, output);
 
-  //GPU_framebuffer_restore();
+  GPU_framebuffer_restore();
 
-  //DRW_game_render_loop_finish();
+  DRW_game_render_loop_finish();
 
   rasty->SetViewport(v[0], v[1], v[2], v[3]);
 
@@ -639,18 +640,19 @@ void KX_Scene::RenderAfterCameraSetup(bool calledFromConstructor)
     rasty->SetScissor(v[0], v[1], v[2], v[3]);
   }
 
-  DRW_transform_none(GPU_viewport_color_texture(m_gpuViewport));
+  DRW_transform_none(GPU_framebuffer_color_texture(f->GetFrameBuffer()));
 
   if (!calledFromConstructor) {
     engine->EndFrame();
   }
 
-  ///* Detach viewport textures from input framebuffer... */
-  //GPU_framebuffer_texture_detach(input->GetFrameBuffer(), finaltex);
-  //GPU_framebuffer_texture_detach(input->GetFrameBuffer(), DRW_viewport_texture_list_get()->depth);
-  ///* And restore defaults attachments */
-  //GPU_framebuffer_texture_attach(input->GetFrameBuffer(), input->GetColorAttachment(), 0, 0);
-  //GPU_framebuffer_texture_attach(input->GetFrameBuffer(), input->GetDepthAttachment(), 0, 0);
+  /* Detach viewport textures from input framebuffer... */
+  GPU_framebuffer_texture_detach(input->GetFrameBuffer(),
+                                 GPU_viewport_color_texture(m_gpuViewport));
+  GPU_framebuffer_texture_detach(input->GetFrameBuffer(), DRW_viewport_texture_list_get()->depth);
+  /* And restore defaults attachments */
+  GPU_framebuffer_texture_attach(input->GetFrameBuffer(), input->GetColorAttachment(), 0, 0);
+  GPU_framebuffer_texture_attach(input->GetFrameBuffer(), input->GetDepthAttachment(), 0, 0);
 
   GPU_framebuffer_restore();
 }

--- a/source/gameengine/Ketsji/KX_Scene.cpp
+++ b/source/gameengine/Ketsji/KX_Scene.cpp
@@ -622,8 +622,6 @@ void KX_Scene::RenderAfterCameraSetup(bool calledFromConstructor)
 
   GPU_framebuffer_restore();
 
-  DRW_game_render_loop_finish();
-
   rasty->SetViewport(v[0], v[1], v[2], v[3]);
 
   if ((scene->gm.flag & GAME_USE_UI_ANTI_FLICKER) == 0) {
@@ -632,8 +630,6 @@ void KX_Scene::RenderAfterCameraSetup(bool calledFromConstructor)
   }
 
   DRW_transform_none(GPU_framebuffer_color_texture(f->GetFrameBuffer()));
-
-  DRW_game_render_loop_finish();
 
   if (!calledFromConstructor) {
     engine->EndFrame();
@@ -647,6 +643,7 @@ void KX_Scene::RenderAfterCameraSetup(bool calledFromConstructor)
   GPU_framebuffer_texture_attach(input->GetFrameBuffer(), input->GetColorAttachment(), 0, 0);
   GPU_framebuffer_texture_attach(input->GetFrameBuffer(), input->GetDepthAttachment(), 0, 0);
 
+  DRW_game_render_loop_finish();
   GPU_framebuffer_restore();
 }
 

--- a/source/gameengine/Ketsji/KX_Scene.cpp
+++ b/source/gameengine/Ketsji/KX_Scene.cpp
@@ -543,6 +543,9 @@ void KX_Scene::RenderAfterCameraSetup(bool calledFromConstructor)
               viewport->GetWidth() + 1,
               viewport->GetHeight() + 1};
 
+  const RAS_Rect *window = &canvas->GetWindowArea();
+  int w[4] = {window->GetLeft(), window->GetBottom(), window->GetWidth() + 1, window->GetHeight() + 1};
+
   if (!calledFromConstructor) {
     rasty->SetMatrix(cam->GetModelviewMatrix(),
                      cam->GetProjectionMatrix(),
@@ -592,7 +595,7 @@ void KX_Scene::RenderAfterCameraSetup(bool calledFromConstructor)
   if (!m_gpuViewport) {
     /* Create eevee's cache space */
     m_gpuOffScreen = GPU_offscreen_create(
-        canvas->GetWidth() + 1, canvas->GetHeight() + 1, 0, true, false, nullptr);
+        canvas->GetWindowArea().GetWidth(), canvas->GetWindowArea().GetHeight(), 0, true, false, nullptr);
     m_gpuViewport = GPU_viewport_create_from_offscreen(m_gpuOffScreen);
     GPU_viewport_engine_data_create(m_gpuViewport, &draw_engine_eevee_type);
   }
@@ -608,7 +611,7 @@ void KX_Scene::RenderAfterCameraSetup(bool calledFromConstructor)
                                               persinv,
                                               calledFromConstructor,
                                               reset_taa_samples,
-                                              v);
+                                              w);
 
   //RAS_FrameBuffer *input = rasty->GetFrameBuffer(rasty->NextFilterFrameBuffer(r));
   //RAS_FrameBuffer *output = rasty->GetFrameBuffer(rasty->NextFilterFrameBuffer(s));

--- a/source/gameengine/Ketsji/KX_Scene.h
+++ b/source/gameengine/Ketsji/KX_Scene.h
@@ -323,7 +323,7 @@ public:
 	std::vector<Object *>m_hiddenObjectsDuringRuntime;
 
 	void RenderAfterCameraSetup(bool calledFromConstructor);
-	GPUTexture *RenderAfterCameraSetupImageRender(RAS_Rasterizer *rasty, struct GPUViewport *viewport);
+	void RenderAfterCameraSetupImageRender(RAS_Rasterizer *rasty, struct GPUViewport *viewport, int window[4]);
 
   void SetLastReplicatedParentObject(Object *ob);
   Object *GetLastReplicatedParentObject();

--- a/source/gameengine/Ketsji/KX_Scene.h
+++ b/source/gameengine/Ketsji/KX_Scene.h
@@ -321,7 +321,7 @@ public:
 	std::vector<Object *>m_hiddenObjectsDuringRuntime;
 
 	void RenderAfterCameraSetup(bool calledFromConstructor);
-	void RenderAfterCameraSetupImageRender(RAS_Rasterizer *rasty, struct GPUViewport *viewport, int window[4]);
+	void RenderAfterCameraSetupImageRender(RAS_Rasterizer *rasty, struct GPUViewport *viewport, const struct rcti *window);
 
   void SetLastReplicatedParentObject(Object *ob);
   Object *GetLastReplicatedParentObject();

--- a/source/gameengine/Ketsji/KX_Scene.h
+++ b/source/gameengine/Ketsji/KX_Scene.h
@@ -139,8 +139,6 @@ protected:
   Object *m_gameDefaultCamera;
   struct GPUViewport *m_gpuViewport;
   struct GPUOffScreen *m_gpuOffScreen;
-  int m_v3dShadingTypeBackup;
-  int m_v3dShadingFlagBackup;
 	/*************************************************/
 
 	RAS_BucketManager*	m_bucketmanager;

--- a/source/gameengine/Ketsji/KX_Scene.h
+++ b/source/gameengine/Ketsji/KX_Scene.h
@@ -138,7 +138,6 @@ protected:
   Object *m_lastReplicatedParentObject;
   Object *m_gameDefaultCamera;
   struct GPUViewport *m_gpuViewport;
-  struct GPUOffScreen *m_gpuOffScreen;
 	/*************************************************/
 
 	RAS_BucketManager*	m_bucketmanager;

--- a/source/gameengine/Rasterizer/RAS_2DFilterFrameBuffer.cpp
+++ b/source/gameengine/Rasterizer/RAS_2DFilterFrameBuffer.cpp
@@ -31,11 +31,6 @@
 #include "GPU_texture.h"
 #include "GPU_framebuffer.h"
 
-extern "C" {
-#  include "DRW_render.h"
-#  include "eevee_private.h"
-}
-
 RAS_2DFilterFrameBuffer::RAS_2DFilterFrameBuffer(unsigned short colorSlots, Flag flag,
 	unsigned int width, unsigned int height)
 	:m_flag(flag),

--- a/source/gameengine/Rasterizer/RAS_FrameBuffer.cpp
+++ b/source/gameengine/Rasterizer/RAS_FrameBuffer.cpp
@@ -29,8 +29,6 @@
 extern "C" {
 #include "GPU_framebuffer.h"
 #include "GPU_texture.h"
-#include "DRW_render.h"
-#include "eevee_private.h"
 }
 
 RAS_FrameBuffer::RAS_FrameBuffer(unsigned int width,

--- a/source/gameengine/Rasterizer/RAS_OpenGLRasterizer/RAS_OpenGLLight.cpp
+++ b/source/gameengine/Rasterizer/RAS_OpenGLRasterizer/RAS_OpenGLLight.cpp
@@ -38,11 +38,6 @@
 
 #include "BLI_math.h"
 
-extern "C" {
-#  include "eevee_private.h"
-#  include "DRW_render.h"
-}
-
 RAS_OpenGLLight::RAS_OpenGLLight()
 {
 }

--- a/source/gameengine/Rasterizer/RAS_Rasterizer.cpp
+++ b/source/gameengine/Rasterizer/RAS_Rasterizer.cpp
@@ -57,10 +57,8 @@ extern "C" {
 #  include "BLF_api.h"
 #  include "GPU_viewport.h"
 #  include "GPU_uniformbuffer.h"
-#  include "DRW_engine.h"
-#  include "DRW_render.h"
-#  include "eevee_private.h"
 #  include "DNA_view3d_types.h"
+#  include "DRW_render.h"
 }
 
 #include "MEM_guardedalloc.h"

--- a/source/gameengine/VideoTexture/ImageRender.cpp
+++ b/source/gameengine/VideoTexture/ImageRender.cpp
@@ -332,7 +332,9 @@ bool ImageRender::Render()
 
 	m_engine->UpdateAnimations(m_scene);
 
-	m_scene->RenderAfterCameraSetupImageRender(m_rasterizer, m_gpuViewport, viewport); //viewport and window are the same here
+	/* viewport and window share the same values here */
+	const rcti window = {viewport[0], viewport[2], viewport[1], viewport[3]};
+	m_scene->RenderAfterCameraSetupImageRender(m_rasterizer, m_gpuViewport, &window);
 
 	m_canvas->EndFrame();
 

--- a/source/gameengine/VideoTexture/ImageRender.cpp
+++ b/source/gameengine/VideoTexture/ImageRender.cpp
@@ -57,7 +57,6 @@
 extern "C" {
 #  include "BKE_global.h"
 #  include "../depsgraph/DEG_depsgraph_query.h"
-#  include "DRW_render.h"
 #  include "eevee_private.h"
 #  include "GPU_viewport.h"
 }

--- a/source/gameengine/VideoTexture/ImageRender.cpp
+++ b/source/gameengine/VideoTexture/ImageRender.cpp
@@ -82,7 +82,6 @@ ImageRender::ImageRender (KX_Scene *scene, KX_Camera * camera, unsigned int widt
     m_camera(camera),
     m_owncamera(false),
     m_gpuViewport(nullptr),
-    m_gpuOffScreen(nullptr),
     m_observer(nullptr),
     m_mirror(nullptr),
     m_clip(100.f),
@@ -248,9 +247,7 @@ bool ImageRender::Render()
 	m_rasterizer->SetScissor(viewport[0], viewport[1], viewport[2], viewport[3]);
 
 	if (!m_gpuViewport) {
-		m_gpuOffScreen = GPU_offscreen_create(viewport[2], viewport[3], 0, true, false, nullptr);
-		m_gpuViewport = GPU_viewport_create_from_offscreen(m_gpuOffScreen);
-		GPU_viewport_engine_data_create(m_gpuViewport, &draw_engine_eevee_type);
+		m_gpuViewport = GPU_viewport_create();
 	}
 
 	m_rasterizer->Clear(RAS_Rasterizer::RAS_DEPTH_BUFFER_BIT);

--- a/source/gameengine/VideoTexture/ImageRender.h
+++ b/source/gameengine/VideoTexture/ImageRender.h
@@ -83,7 +83,6 @@ protected:
 	/// do we own the camera?
 	bool m_owncamera;
 
-	GPUTexture *m_gpuTexture;
   struct GPUViewport *m_gpuViewport;
   struct GPUOffScreen *m_gpuOffScreen;
 

--- a/source/gameengine/VideoTexture/ImageRender.h
+++ b/source/gameengine/VideoTexture/ImageRender.h
@@ -84,7 +84,6 @@ protected:
 	bool m_owncamera;
 
   struct GPUViewport *m_gpuViewport;
-  struct GPUOffScreen *m_gpuOffScreen;
 
   GPUFrameBuffer *m_targetfb;
 

--- a/source/gameengine/VideoTexture/Texture.cpp
+++ b/source/gameengine/VideoTexture/Texture.cpp
@@ -59,7 +59,6 @@
 #include "GPU_texture.h"
 
 extern "C" {
-#  include "eevee_private.h"
 #  include "IMB_imbuf.h"
 }
 


### PR DESCRIPTION
I added gpencil engine to test.

Before, only eevee engine was enabled in game engine render loop.
The render loop returned the final_tex rendered by eevee and was displayed in bge.

But I had another look at render code and they do differently.

A GPUViewport is bound before drawing.
All engines are rendered and at the end of each engine render loop, the returned color is written into the GPUViewport framebuffer (which can be accessed for example with DRW_viewport_framebuffer_list_get()->default_fb)
Then the GPUViewport is unbound.

Then finally we can access the viewport texture which has accumulated the results of all enabled engines with GPU_viewport_color_texture(viewport).

Then I refactored the game engine render loop in this way to have the possibility to use several engines.

Furthermore, I added the possibility to render in lookdev mode.

Side note: There's currently a bug in blender code in the check to enable gpencil engine ot not (gpencil engine is always enabled). I opened a bug report about it: https://developer.blender.org/T72973 then it will work in our branch when the bug will be fixed in blender.