### PR TITLE
UPBGE: Fix for #1104, engine crash on exit due to NavMesh free data

### DIFF
--- a/source/blender/blenkernel/BKE_mesh_runtime.h
+++ b/source/blender/blenkernel/BKE_mesh_runtime.h
@@ -46,7 +46,7 @@ const struct MLoopTri *BKE_mesh_runtime_looptri_ensure(struct Mesh *mesh);
 bool BKE_mesh_runtime_ensure_edit_data(struct Mesh *mesh);
 bool BKE_mesh_runtime_clear_edit_data(struct Mesh *mesh);
 void BKE_mesh_runtime_clear_geometry(struct Mesh *mesh);
-void BKE_mesh_runtime_clear_cache(struct Mesh *mesh);
+void BKE_mesh_runtime_clear_cache(struct Mesh *mesh, bool navmesh); /* Game Engine transition */
 
 void BKE_mesh_runtime_verttri_from_looptri(struct MVertTri *r_verttri,
                                            const struct MLoop *mloop,

--- a/source/blender/blenkernel/intern/mesh.c
+++ b/source/blender/blenkernel/intern/mesh.c
@@ -488,7 +488,7 @@ void BKE_mesh_free(Mesh *me)
 void BKE_mesh_clear_geometry(Mesh *mesh)
 {
   BKE_animdata_free(&mesh->id, false);
-  BKE_mesh_runtime_clear_cache(mesh);
+  BKE_mesh_runtime_clear_cache(mesh, CustomData_has_layer(&mesh->pdata, CD_RECAST)); /* Game Engine transition */
 
   CustomData_free(&mesh->vdata, mesh->totvert);
   CustomData_free(&mesh->edata, mesh->totedge);

--- a/source/blender/blenkernel/intern/mesh_runtime.c
+++ b/source/blender/blenkernel/intern/mesh_runtime.c
@@ -74,7 +74,7 @@ void BKE_mesh_runtime_reset_on_copy(Mesh *mesh, const int UNUSED(flag))
   BLI_mutex_init(mesh->runtime.eval_mutex);
 }
 
-void BKE_mesh_runtime_clear_cache(Mesh *mesh)
+void BKE_mesh_runtime_clear_cache(Mesh *mesh, bool navmesh)
 {
   if (mesh->runtime.eval_mutex != NULL) {
     BLI_mutex_end(mesh->runtime.eval_mutex);
@@ -83,7 +83,10 @@ void BKE_mesh_runtime_clear_cache(Mesh *mesh)
   }
   if (mesh->runtime.mesh_eval != NULL) {
     mesh->runtime.mesh_eval->edit_mesh = NULL;
-    BKE_id_free(NULL, mesh->runtime.mesh_eval);
+    /* Navmesh is not built around 'id' unlike other meshes */
+    if (!navmesh) { /* Game Engine transition */
+      BKE_id_free(NULL, mesh->runtime.mesh_eval);
+    }
     mesh->runtime.mesh_eval = NULL;
   }
   BKE_mesh_runtime_clear_geometry(mesh);

--- a/source/gameengine/Launcher/LA_BlenderLauncher.cpp
+++ b/source/gameengine/Launcher/LA_BlenderLauncher.cpp
@@ -158,8 +158,16 @@ void LA_BlenderLauncher::ExitEngine()
 		m_startScene->camera= m_savedBlenderData.camera;
 	}
 
-	if (m_startScene->gm.flag & GAME_USE_UNDO) {
-	  BKE_undosys_step_undo(m_windowManager->undo_stack, m_context);
+    /* Undo System */
+    if (m_startScene->gm.flag & GAME_USE_UNDO) {
+        UndoStep *step_data_from_name = NULL;
+        step_data_from_name = BKE_undosys_step_find_by_name(m_windowManager->undo_stack, "bge_start");
+        if (step_data_from_name) {
+            BKE_undosys_step_undo_with_data(m_windowManager->undo_stack, m_context, step_data_from_name);
+        }
+        else {
+            BKE_undosys_step_undo(m_windowManager->undo_stack, m_context);
+        }
     }
 
 	// Free all window manager events unused.


### PR DESCRIPTION
Now, we don't free navmesh id as it is not based in id.
Additionally, we improve undo system including undo based in step name.