### PR TITLE
UPBGE: Try to fix crash when removing bge.constraint in some cases

### DIFF
--- a/source/gameengine/Ketsji/KX_ConstraintWrapper.cpp
+++ b/source/gameengine/Ketsji/KX_ConstraintWrapper.cpp
@@ -33,8 +33,11 @@
 #include "KX_ConstraintWrapper.h"
 #include "PHY_IConstraint.h"
 
-KX_ConstraintWrapper::KX_ConstraintWrapper(PHY_IConstraint *constraint)
-	:m_constraint(constraint)
+KX_ConstraintWrapper::KX_ConstraintWrapper(PHY_IConstraint *constraint,
+                                           PHY_ConstraintType ctype, int user_id)
+	:m_constraint(constraint),
+	m_ctype(ctype),
+	m_userId(user_id)
 {
 }
 KX_ConstraintWrapper::~KX_ConstraintWrapper()
@@ -50,7 +53,7 @@ std::string KX_ConstraintWrapper::GetName()
 
 PyObject *KX_ConstraintWrapper::PyGetConstraintId()
 {
-	return PyLong_FromLong(m_constraint->GetIdentifier());
+	return PyLong_FromLong(m_userId);
 }
 
 
@@ -121,13 +124,13 @@ PyAttributeDef KX_ConstraintWrapper::Attributes[] = {
 PyObject *KX_ConstraintWrapper::pyattr_get_constraintId(PyObjectPlus *self_v, const KX_PYATTRIBUTE_DEF *attrdef)
 {
 	KX_ConstraintWrapper* self = static_cast<KX_ConstraintWrapper*>(self_v);
-	return PyLong_FromLong(self->m_constraint->GetIdentifier());
+	return PyLong_FromLong(self->m_userId);
 }
 
 PyObject *KX_ConstraintWrapper::pyattr_get_constraintType(PyObjectPlus *self_v, const KX_PYATTRIBUTE_DEF *attrdef)
 {
 	KX_ConstraintWrapper* self = static_cast<KX_ConstraintWrapper*>(self_v);
-	return PyLong_FromLong(self->m_constraint->GetType());
+	return PyLong_FromLong(self->m_ctype);
 }
 
 PyObject *KX_ConstraintWrapper::pyattr_get_breakingThreshold(PyObjectPlus *self_v, const KX_PYATTRIBUTE_DEF *attrdef)

--- a/source/gameengine/Ketsji/KX_ConstraintWrapper.h
+++ b/source/gameengine/Ketsji/KX_ConstraintWrapper.h
@@ -40,7 +40,8 @@ class PHY_IConstraint;
 class	KX_ConstraintWrapper : public CValue
 {
 	Py_Header
-public: KX_ConstraintWrapper(PHY_IConstraint *constraint, PHY_ConstraintType ctype, int user_id);
+public:
+  KX_ConstraintWrapper(PHY_IConstraint *constraint, PHY_ConstraintType ctype, int user_id);
 	virtual ~KX_ConstraintWrapper ();
 
 	virtual std::string GetName();

--- a/source/gameengine/Ketsji/KX_ConstraintWrapper.h
+++ b/source/gameengine/Ketsji/KX_ConstraintWrapper.h
@@ -33,14 +33,14 @@
 #define __KX_CONSTRAINTWRAPPER_H__
 
 #include "EXP_Value.h"
+#include "PHY_DynamicTypes.h"
 
 class PHY_IConstraint;
 
 class	KX_ConstraintWrapper : public CValue
 {
 	Py_Header
-public:
-	KX_ConstraintWrapper(PHY_IConstraint *constraint);
+public: KX_ConstraintWrapper(PHY_IConstraint *constraint, PHY_ConstraintType ctype, int user_id);
 	virtual ~KX_ConstraintWrapper ();
 
 	virtual std::string GetName();
@@ -60,6 +60,8 @@ public:
 
 private:
 	PHY_IConstraint *m_constraint;
+  PHY_ConstraintType m_ctype;
+  int m_userId;
 };
 
 #endif  /* __KX_CONSTRAINTWRAPPER_H__ */

--- a/source/gameengine/Ketsji/KX_PyConstraintBinding.cpp
+++ b/source/gameengine/Ketsji/KX_PyConstraintBinding.cpp
@@ -34,6 +34,7 @@
 #include "KX_ConstraintWrapper.h"
 #include "KX_VehicleWrapper.h"
 #include "KX_CharacterWrapper.h"
+#include "PHY_IConstraint.h"
 #include "PHY_IPhysicsController.h"
 #include "PHY_IVehicle.h"
 #include "PHY_DynamicTypes.h"
@@ -547,7 +548,7 @@ static PyObject *gPyCreateConstraint(PyObject *self,
 				return nullptr;
 			}
 
-			KX_ConstraintWrapper *wrap = new KX_ConstraintWrapper(constraint);
+			KX_ConstraintWrapper *wrap = new KX_ConstraintWrapper(constraint, (enum PHY_ConstraintType)constrainttype, constraint->GetIdentifier());
 
 			return wrap->NewProxy(true);
 		}


### PR DESCRIPTION
This is inspired by old bge code which had not this issue. I think this comes from the way constraints are created with NewProxy(true)