### PR TITLE
UPBGE: Try to fix some transformation weirdness (with anims,addObject..)

### DIFF
--- a/source/gameengine/Ketsji/KX_FontObject.cpp
+++ b/source/gameengine/Ketsji/KX_FontObject.cpp
@@ -121,8 +121,6 @@ void KX_FontObject::UpdateCurveText(std::string newText) //eevee
 	DEG_id_tag_update(&ob->id, ID_RECALC_GEOMETRY);
 	DEG_id_tag_update(&ob->id, ID_RECALC_COPY_ON_WRITE);
 
-	UseCopy();
-
 	GetScene()->ResetTaaSamples();
 }
 

--- a/source/gameengine/Ketsji/KX_GameObject.cpp
+++ b/source/gameengine/Ketsji/KX_GameObject.cpp
@@ -127,7 +127,6 @@ KX_GameObject::KX_GameObject(void *sgReplicationInfo, SG_Callbacks callbacks)
       m_castShadows(true),          // eevee
       m_isReplica(false),           // eevee
       m_staticObject(true),         // eevee
-      m_useCopy(false),             // eevee
       m_visibleAtGameStart(false),  // eevee
       m_layer(0),
       m_lodManager(nullptr),
@@ -188,7 +187,11 @@ KX_GameObject::~KX_GameObject()
   if (ob) {
     copy_m4_m4(ob->obmat, m_savedObmat);
     invert_m4_m4(ob->imat, m_savedObmat);
-    DEG_id_tag_update(&ob->id, ID_RECALC_COPY_ON_WRITE);
+    /* Warning, can cause issue with armatured objects
+     * -> use Undo at exit
+     */
+    BKE_object_apply_mat4(ob, ob->obmat, false, false);
+    DEG_id_tag_update(&ob->id, ID_RECALC_TRANSFORM | ID_RECALC_COPY_ON_WRITE);
   }
 
   KX_Scene *scene = GetScene();
@@ -274,35 +277,18 @@ void KX_GameObject::TagForUpdate()
   NodeGetWorldTransform().getValue(&obmat[0][0]);
   m_staticObject = compare_m4m4(m_prevObmat, obmat, FLT_MIN);
 
-  Scene *sc = GetScene()->GetBlenderScene();
-  ViewLayer *view_layer = BKE_view_layer_default_view(sc);
-  Main *bmain = KX_GetActiveEngine()->GetConverter()->GetMain();
-  Depsgraph *depsgraph = BKE_scene_get_depsgraph(bmain, sc, view_layer, false);
-
   if (m_staticObject) {
     GetScene()->AppendToStaticObjects(this);
   }
-  Object *orig_ob = GetBlenderObject();
-  if (orig_ob) {
-    Object *ob = GetBlenderObject()->type != OB_MBALL && !m_useCopy ?
-                     DEG_get_evaluated_object(depsgraph, GetBlenderObject()) :
-                     GetBlenderObject();
+  Object *ob = GetBlenderObject();
+  if (ob) {
 
     copy_m4_m4(ob->obmat, obmat);
     invert_m4_m4(ob->imat, obmat);
-    /* The following line was creating issues in some of my test files
-     * and BPR had issues too. It was introduced when working on object color.
-     * Waiting we find something better, I comment it... */
-    //BKE_object_apply_mat4(ob, ob->obmat, false, true);
+    BKE_object_apply_mat4(ob, ob->obmat, false, true);
     /* NORMAL CASE */
     if (!m_staticObject && ob->type != OB_MBALL) {
-      if (!m_useCopy) {
-        DEG_id_tag_update(&ob->id, ID_RECALC_TRANSFORM);
-      }
-      else {
-        DEG_id_tag_update(&ob->id, NC_OBJECT | ND_TRANSFORM);
-        DEG_id_tag_update(&ob->id, ID_RECALC_COPY_ON_WRITE);
-      }
+      DEG_id_tag_update(&ob->id, ID_RECALC_TRANSFORM | ID_RECALC_COPY_ON_WRITE);
     }
     /* SPECIAL CASE: EXPERIMENTAL -> TEST METABALLS (incomplete) (TODO restore elems position at ge
      * exit) */
@@ -311,9 +297,7 @@ void KX_GameObject::TagForUpdate()
         DEG_id_tag_update(&ob->id, ID_RECALC_GEOMETRY);
       }
       else {
-        // DEG_id_tag_update(&ob->id, ID_RECALC_TRANSFORM);
-        DEG_id_tag_update(&ob->id, NC_OBJECT | ND_TRANSFORM);
-        DEG_id_tag_update(&ob->id, ID_RECALC_COPY_ON_WRITE);
+        DEG_id_tag_update(&ob->id, ID_RECALC_TRANSFORM | ID_RECALC_COPY_ON_WRITE);
       }
     }
 
@@ -324,13 +308,7 @@ void KX_GameObject::TagForUpdate()
       }
     }
   }
-  m_useCopy = false;
   copy_m4_m4(m_prevObmat, obmat);
-}
-
-void KX_GameObject::UseCopy()
-{
-  m_useCopy = true;
 }
 
 void KX_GameObject::ReplicateBlenderObject()
@@ -415,7 +393,6 @@ void KX_GameObject::RecalcGeometry()
   Object *ob = GetBlenderObject();
   if (ob) {
     DEG_id_tag_update(&ob->id, ID_RECALC_GEOMETRY);
-    UseCopy();
   }
 }
 
@@ -2216,11 +2193,6 @@ PyObject *KX_GameObject::PyUpdatePhysicsShape(PyObject *args)
   }
 
   if (GetPhysicsController()) {
-
-	if (recalcGeom) {
-      UseCopy();
-	}
-
     GetPhysicsController()->ReinstancePhysicsShape2(GetMesh(0), GetBlenderObject(), recalcGeom);
     Py_RETURN_NONE;
   }
@@ -3390,19 +3362,9 @@ int KX_GameObject::pyattr_set_obcolor(PyObjectPlus *self_v,
   Object *ob = self->GetBlenderObject();
   if (ob && ELEM(ob->type, OB_MESH, OB_CURVE, OB_SURF, OB_FONT, OB_MBALL)) {
     copy_v4_v4(ob->color, obcolor.getValue());
-    if (!self->IsStatic()) {
-      self->UseCopy();
-    }
-    else {
-      DEG_id_tag_update(&ob->id, ID_RECALC_TRANSFORM);
-      /* Warning about the following function which can cause mess
-       * for object transfrom / armatures transform BUT which
-       * was needed to avoid that when we set object color
-       * the position of the object was sometimes "reseted"...
-       */
-      BKE_object_apply_mat4(ob, ob->obmat, true, false);
-      self->GetScene()->ResetTaaSamples();
-    }
+    DEG_id_tag_update(&ob->id, ID_RECALC_TRANSFORM | ID_RECALC_COPY_ON_WRITE);
+    BKE_object_apply_mat4(ob, ob->obmat, true, true);
+    self->GetScene()->ResetTaaSamples();
     WM_main_add_notifier(NC_OBJECT | ND_DRAW, &ob->id);
     return PY_SET_ATTR_SUCCESS;
   }

--- a/source/gameengine/Ketsji/KX_GameObject.h
+++ b/source/gameengine/Ketsji/KX_GameObject.h
@@ -91,7 +91,6 @@ protected:
 	bool m_castShadows;
 	bool m_isReplica;
 	bool m_staticObject;
-  bool m_useCopy;
   bool m_visibleAtGameStart;
 	/* END OF EEVEE INTEGRATION */
 
@@ -145,7 +144,6 @@ public:
 	void RemoveReplicaObject();
 	bool IsStatic();
 	void RecalcGeometry();
-  void UseCopy();
   void SuspendPhysics(bool freeConstraints, bool childrenRecursive);
   void RestorePhysics(bool childrenRecursive);
   void AddDummyLodManager(RAS_MeshObject *meshObj);

--- a/source/gameengine/Ketsji/KX_Scene.cpp
+++ b/source/gameengine/Ketsji/KX_Scene.cpp
@@ -336,10 +336,6 @@ KX_Scene::~KX_Scene()
   // Put that before we flush depsgraph updates at scene exit
   scene->flag &= ~SCE_INTERACTIVE;
 
-  // Flush depsgraph updates a last time at ge exit
-  Depsgraph *depsgraph = BKE_scene_get_depsgraph(bmain, scene, view_layer, false);
-  BKE_scene_graph_update_tagged(depsgraph, bmain);
-
   /* End of EEVEE INTEGRATION */
 
   // The release of debug properties used to be in SCA_IScene::~SCA_IScene
@@ -367,6 +363,12 @@ KX_Scene::~KX_Scene()
   BKE_id_free(bmain, m_gameDefaultCamera);
   m_gameDefaultCamera = nullptr;
   DEG_relations_tag_update(bmain);
+
+  /* Flush depsgraph updates a last time at ge exit after all objects have been removed
+   * to reset their transformation as savedMat is restored in KX_GameObject destructor
+   */
+  Depsgraph *depsgraph = BKE_scene_get_depsgraph(bmain, scene, view_layer, false);
+  BKE_scene_graph_update_tagged(depsgraph, bmain);
 
   if (m_parentlist)
     m_parentlist->Release();


### PR DESCRIPTION
For now, because I understand almost nothing to the depsgraph,
KX_GameObject::TagForUpdate was using "evaluated object" mainly to
update the Object obmat.

I did that because I had issues with AddObject
in some cases.

But when we use the original object, and
BKE_object_apply_mat4 and ID_RECALC_TRANSFORM | ID_RECALC_COPY_ON_WRITE,
it seems to work better, fixes some issues with animations not played
and a glitch when we addObject.

In most of my test files, this seems to work better and this is more
like in the blender code.