### PR TITLE
UPBGE: Try to fix a crash with m_blendpose free

### DIFF
--- a/source/gameengine/Converter/BL_ArmatureObject.cpp
+++ b/source/gameengine/Converter/BL_ArmatureObject.cpp
@@ -527,7 +527,7 @@ void BL_ArmatureObject::GetPose(bPose **pose)
 		 * a crash and memory leakage when
 		 * &BL_ActionActuator::m_pose is freed
 		 */
-		game_copy_pose(pose, m_pose, 0);
+		BKE_pose_copy_data(pose, m_pose, 1);
 	}
 	else {
 		if (*pose == m_pose) {


### PR DESCRIPTION
Following compiler error messages.

I use blender code instead of game_copy_pose

and I use BKE_pose_copy_data with constraints = true because
BKE_pose_free tries to free constraints