### PR TITLE
UPBGE: Restore logic editor keymap (shortcuts)

### DIFF
--- a/release/scripts/presets/keyconfig/keymap_data/blender_default.py
+++ b/release/scripts/presets/keyconfig/keymap_data/blender_default.py
@@ -1791,6 +1791,24 @@ def km_node_editor(params):
 
     return keymap
 
+def km_logic(params):
+    items = []
+    keymap = (
+        "Logic Editor",
+        {"space_type": 'LOGIC_EDITOR', "region_type": 'WINDOW'},
+        {"items": items},
+    )
+
+    items.extend([
+        ("logic.properties", {"type": 'N', "value": 'PRESS'}, None),
+        ("logic.links_cut", {"type": 'EVT_TWEAK_R', "value": 'ANY', "ctrl": True}, None),
+        ("logic.view_all", {"type": 'HOME', "value": 'PRESS'}, None),
+        ("logic.view_all", {"type": 'NDOF_BUTTON_FIT', "value": 'PRESS'}, None),
+        op_menu("LOGIC_MT_logicbricks_add", {"type": 'A', "value": 'PRESS', "shift": True}),
+    ])
+
+    return keymap
+
 
 def km_info(params):
     items = []
@@ -6152,6 +6170,7 @@ def generate_keymaps(params=None):
         km_property_editor(params),
 
         # Editors.
+        km_logic(params),
         km_outliner(params),
         km_uv_editor(params),
         km_view3d_generic(params),

--- a/source/blender/editors/space_logic/space_logic.c
+++ b/source/blender/editors/space_logic/space_logic.c
@@ -178,7 +178,7 @@ static void logic_operatortypes(void)
 
 static void logic_keymap(struct wmKeyConfig *keyconf)
 {
-	/*wmKeyMap *keymap = WM_keymap_ensure(keyconf, "Logic Editor", SPACE_LOGIC, 0);
+	wmKeyMap *keymap = WM_keymap_ensure(keyconf, "Logic Editor", SPACE_LOGIC, 0);
 	
 	WM_keymap_add_item(keymap, "LOGIC_OT_properties", NKEY, KM_PRESS, 0, 0);
 	WM_keymap_add_item(keymap, "LOGIC_OT_links_cut", LEFTMOUSE, KM_PRESS, KM_CTRL, 0);
@@ -187,7 +187,7 @@ static void logic_keymap(struct wmKeyConfig *keyconf)
 	WM_keymap_add_item(keymap, "LOGIC_OT_view_all", HOMEKEY, KM_PRESS, 0, 0);
 #ifdef WITH_INPUT_NDOF
 	WM_keymap_add_item(keymap, "LOGIC_OT_view_all", NDOF_BUTTON_FIT, KM_PRESS, 0, 0);
-#endif*/
+#endif
 }
 
 static void logic_refresh(const bContext *UNUSED(C), ScrArea *UNUSED(sa))
@@ -236,13 +236,13 @@ static int logic_context(const bContext *UNUSED(C), const char *UNUSED(member), 
 /* add handlers, stuff you only do once or on area/region changes */
 static void logic_main_region_init(wmWindowManager *wm, ARegion *ar)
 {
-	//wmKeyMap *keymap;
+	wmKeyMap *keymap;
 	
 	UI_view2d_region_reinit(&ar->v2d, V2D_COMMONVIEW_CUSTOM, ar->winx, ar->winy);
 	
 	///* own keymaps */
-	//keymap = WM_keymap_ensure(wm->defaultconf, "Logic Editor", SPACE_LOGIC, 0);
-	//WM_event_add_keymap_handler(&ar->handlers, keymap);
+	keymap = WM_keymap_ensure(wm->defaultconf, "Logic Editor", SPACE_LOGIC, 0);
+	WM_event_add_keymap_handler(&ar->handlers, keymap);
 }
 
 static void logic_main_region_draw(const bContext *C, ARegion *ar)

--- a/source/blender/editors/space_logic/space_logic.c
+++ b/source/blender/editors/space_logic/space_logic.c
@@ -178,16 +178,6 @@ static void logic_operatortypes(void)
 
 static void logic_keymap(struct wmKeyConfig *keyconf)
 {
-	wmKeyMap *keymap = WM_keymap_ensure(keyconf, "Logic Editor", SPACE_LOGIC, 0);
-	
-	WM_keymap_add_item(keymap, "LOGIC_OT_properties", NKEY, KM_PRESS, 0, 0);
-	WM_keymap_add_item(keymap, "LOGIC_OT_links_cut", LEFTMOUSE, KM_PRESS, KM_CTRL, 0);
-	WM_keymap_add_menu(keymap, "LOGIC_MT_logicbricks_add", AKEY, KM_PRESS, KM_SHIFT, 0);
-	
-	WM_keymap_add_item(keymap, "LOGIC_OT_view_all", HOMEKEY, KM_PRESS, 0, 0);
-#ifdef WITH_INPUT_NDOF
-	WM_keymap_add_item(keymap, "LOGIC_OT_view_all", NDOF_BUTTON_FIT, KM_PRESS, 0, 0);
-#endif
 }
 
 static void logic_refresh(const bContext *UNUSED(C), ScrArea *UNUSED(sa))
@@ -276,12 +266,12 @@ static void logic_main_region_draw(const bContext *C, ARegion *ar)
 /* add handlers, stuff you only do once or on area/region changes */
 static void logic_buttons_region_init(wmWindowManager *wm, ARegion *ar)
 {
-	//wmKeyMap *keymap;
+	wmKeyMap *keymap;
 
 	ED_region_panels_init(wm, ar);
 	
-	/*keymap = WM_keymap_ensure(wm->defaultconf, "Logic Editor", SPACE_LOGIC, 0);
-	WM_event_add_keymap_handler(&ar->handlers, keymap);*/
+	keymap = WM_keymap_ensure(wm->defaultconf, "Logic Editor", SPACE_LOGIC, 0);
+	WM_event_add_keymap_handler(&ar->handlers, keymap);
 }
 
 static void logic_buttons_region_draw(const bContext *C, ARegion *ar)


### PR DESCRIPTION
During 2.8 development, as keymap system changed a bit and as I don't use it, I commented the code.
Here I tried to adapt the code for 2.8 as I saw someone asked this on BA