### PR TITLE
UPBGE: Recover use of DRW_engines_free

### DIFF
--- a/source/blender/draw/engines/basic/basic_engine.c
+++ b/source/blender/draw/engines/basic/basic_engine.c
@@ -91,7 +91,9 @@ static void basic_engine_init(void *UNUSED(vedata))
   /* Depth prepass */
   if (!sh_data->depth) {
     sh_data->depth = DRW_shader_create_3d_depth_only(draw_ctx->sh_cfg);
+  }
 
+  if (!sh_data->depth_conservative) { /* Game Engine transition */
     const GPUShaderConfigData *sh_cfg = &GPU_shader_cfg_data[draw_ctx->sh_cfg];
     sh_data->depth_conservative = GPU_shader_create_from_arrays({
         .vert = (const char *[]){sh_cfg->lib,

--- a/source/blender/draw/intern/draw_manager.c
+++ b/source/blender/draw/intern/draw_manager.c
@@ -2733,6 +2733,7 @@ void DRW_engines_free(void)
 
   if (DST.draw_list) {
     GPU_draw_list_discard(DST.draw_list);
+    DST.draw_list = NULL; /* Game Engine transition */
   }
 
   DRW_opengl_context_disable();
@@ -3036,8 +3037,7 @@ void DRW_game_render_loop_end()
   GPU_viewport_free(DST.viewport);
 
   EEVEE_view_layer_data_free(EEVEE_view_layer_data_ensure());
-  draw_engine_eevee_type.engine_free();
-  draw_engine_gpencil_type.engine_free();
+  DRW_engines_free();
 
   memset(&DST, 0xFF, offsetof(DRWManager, gl_context));
 }


### PR DESCRIPTION
previously we had crashes related to basic engine depth conservative shader.

The reason is that when we finalized the game engine the basic engine was freed (freeing the depth_conservative shader) but the depth shader wasn't freed as it is a built-in shader and it uses another procedure.

Then when we are initializing again the basic engine for Blender we only were checking for depth shader inexistence to create both shaders but we could have the case that depth shader exists but depth_conservative shader not.

To avoid that we separate the creation of both shaders checking for its existence indepently.