### PR TITLE
UPBGE: Prevent draw request when DRW_state_image_render

### DIFF
--- a/source/blender/draw/engines/eevee/eevee_volumes.c
+++ b/source/blender/draw/engines/eevee/eevee_volumes.c
@@ -243,15 +243,14 @@ void EEVEE_volumes_init(EEVEE_ViewLayerData *sldata, EEVEE_Data *vedata)
   }
   else if (DRW_state_is_image_render()) {
 #endif
+  if (DRW_state_is_image_render()) {
     const uint max_sample = (ht_primes[0] * ht_primes[1] * ht_primes[2]);
     current_sample = effects->volume_current_sample = (effects->volume_current_sample + 1) %
                                                       max_sample;
     if (current_sample != max_sample - 1) {
       DRW_viewport_request_redraw();
     }
-#if 0 /* Game engine transition */
   }
-#endif
 
   EEVEE_volumes_set_jitter(sldata, current_sample);
 


### PR DESCRIPTION
Actually, i noticed that in wanderer scene there was a little flickering
which didn't happen in blender official.

This seems to fix the issue. (in bge render loop, we never set the
DRW_state to DRW_state_image_render (we could to avoid to have infinite
taa maybe, but this would need to check))