### PR TITLE
UPBGE: Recover last version of python components

### DIFF
--- a/release/scripts/startup/bl_ui/space_logic.py
+++ b/release/scripts/startup/bl_ui/space_logic.py
@@ -40,20 +40,24 @@ class LOGIC_PT_components(bpy.types.Panel):
         st = context.space_data
 
         row = layout.row()
-        row.operator("logic.add_python_component", text="Add Component", icon="PLUS")
+        row.operator("logic.python_component_register", text="Register Component", icon="PLUS")
+        row.operator("logic.python_component_create", text="Create Component", icon="PLUS")
 
         for i, c in enumerate(game.components):
             box = layout.box()
             row = box.row()
-            row.prop(c, "name", text="")
-            row.operator("logic.component_reload", text="", icon='RECOVER_LAST').index = i
-            row.operator("logic.component_remove", text="", icon='X').index = i
+            row.prop(c, "show_expanded", text="", emboss=False)
+            row.label(text=c.name)
+            row.operator("logic.python_component_reload", text="", icon='RECOVER_LAST').index = i
+            row.operator("logic.python_component_remove", text="", icon='X').index = i
 
-            for prop in c.properties:
-                row = box.row()
-                row.label(text=prop.name)
-                col = row.column()
-                col.prop(prop, "value", text="")
+            if c.show_expanded and len(c.properties) > 0:
+                box = box.box()
+                for prop in c.properties:
+                    row = box.row()
+                    row.label(text=prop.name)
+                    col = row.column()
+                    col.prop(prop, "value", text="")
 
 
 class LOGIC_PT_properties(Panel):

--- a/source/blender/blenkernel/intern/python_component.c
+++ b/source/blender/blenkernel/intern/python_component.c
@@ -21,7 +21,9 @@
  */
 
 #include "BLI_fileops.h"
+
 #include "BLI_listbase.h"
+
 #include "BLI_path_util.h"
 #include "BLI_string.h"
 #include "DNA_property_types.h" /* For MAX_PROPSTRING */
@@ -34,6 +36,7 @@
 #include "BKE_main.h"
 #include "BKE_python_component.h"
 #include "BKE_report.h"
+
 #include "BKE_text.h"
 
 #include "RNA_types.h"
@@ -97,6 +100,7 @@ static PyTypeObject PythonComponentType = {
     NULL,                                                /* tp_subclasses */
     NULL,                                                /* tp_weaklist */
     NULL                                                 /* tp_del */
+
 };
 
 PyDoc_STRVAR(module_documentation,
@@ -365,6 +369,9 @@ static bool load_component(PythonComponent *pc, ReportList *reports, Main *maggi
 /* Macro used to release all python variable if the convertion fail or succeed.
  * The "value" argument is false on failure and true on succes.
  */
+/* Macro used to release all python variable if the convertion fail or succeed.
+ * The "value" argument is false on failure and true on succes.
+ */
 #  define FINISH(value) \
     PyErr_Print(); \
     if (mod) { \
@@ -562,7 +569,7 @@ PythonComponent *BKE_python_component_create_file(char *import,
   text = BKE_text_add(maggie, filename);
 
   BLI_strncpy(
-      respath, BKE_appdir_folder_id(BLENDER_SYSTEM_SCRIPTS, "templates_py"), sizeof(respath));
+      respath, BKE_appdir_folder_id(BLENDER_SYSTEM_SCRIPTS, "templates_py_components"), sizeof(respath));
   BLI_path_append(respath, sizeof(respath), "python_component.py");
 
   orgfilecontent = BLI_file_read_text_as_mem(respath, 0, &filesize);

--- a/source/blender/editors/space_logic/logic_ops.c
+++ b/source/blender/editors/space_logic/logic_ops.c
@@ -815,7 +815,7 @@ static void LOGIC_OT_region_flip(wmOperatorType *ot)
 }
 
 /* Component operators */
-static int component_add_exec(bContext *C, wmOperator *op)
+static int component_register_exec(bContext *C, wmOperator *op)
 {
   PythonComponent *pycomp;
   Object *ob = CTX_data_active_object(C);
@@ -838,20 +838,67 @@ static int component_add_exec(bContext *C, wmOperator *op)
   return OPERATOR_FINISHED;
 }
 
+static int component_create_exec(bContext *C, wmOperator *op)
+{
+  PythonComponent *pycomp;
+  Object *ob = CTX_data_active_object(C);
+  char import[MAX_NAME];
+
+  if (!ob) {
+    return OPERATOR_CANCELLED;
+  }
+
+  RNA_string_get(op->ptr, "component_name", import);
+  pycomp = BKE_python_component_create_file(import, op->reports, C);
+
+  if (!pycomp) {
+    return OPERATOR_CANCELLED;
+  }
+
+  BLI_addtail(&ob->components, pycomp);
+  WM_event_add_notifier(C, NC_LOGIC, NULL);
+
+  return OPERATOR_FINISHED;
+}
+
 static int component_new_invoke(bContext *C, wmOperator *op, const wmEvent *UNUSED(event))
 {
   /* Better for user feedback. */
-  return WM_operator_props_dialog_popup(C, op, 15 * UI_UNIT_X);
+  return WM_operator_props_dialog_popup(C, op, 15 * UI_UNIT_X, UI_UNIT_Y);
 }
 
-static void LOGIC_OT_component_add(wmOperatorType *ot)
+static void LOGIC_OT_python_component_register(wmOperatorType *ot)
 {
   ot->name = "Add Python Component";
-  ot->idname = "LOGIC_OT_add_python_component";
+  ot->idname = "LOGIC_OT_python_component_register";
   ot->description = "Add a python component to the selected object";
 
   /* api callbacks */
-  ot->exec = component_add_exec;
+  ot->exec = component_register_exec;
+  ot->invoke = component_new_invoke;
+  ot->poll = ED_operator_object_active_editable;
+
+  /* flags */
+  ot->flag = OPTYPE_REGISTER | OPTYPE_UNDO;
+
+  PropertyRNA *parm;
+  parm = RNA_def_string(ot->srna,
+                        "component_name",
+                        "module.Component",
+                        64,
+                        "Component",
+                        "The component class name with module (module.ComponentName)");
+  RNA_def_parameter_flags(parm, 0, PARM_REQUIRED);
+}
+
+static void LOGIC_OT_python_component_create(wmOperatorType *ot)
+{
+  ot->name = "Create Python Component";
+  ot->idname = "LOGIC_OT_python_component_create";
+  ot->description = "Create a python component to the selected object";
+
+  /* api callbacks */
+  ot->exec = component_create_exec;
   ot->invoke = component_new_invoke;
   ot->poll = ED_operator_object_active_editable;
 
@@ -892,12 +939,12 @@ static int component_remove_exec(bContext *C, wmOperator *op)
   return OPERATOR_FINISHED;
 }
 
-static void LOGIC_OT_component_remove(wmOperatorType *ot)
+static void LOGIC_OT_python_component_remove(wmOperatorType *ot)
 {
   /* identifiers */
   ot->name = "Remove Component";
   ot->description = "Remove Component";
-  ot->idname = "LOGIC_OT_component_remove";
+  ot->idname = "LOGIC_OT_python_component_remove";
 
   /* api callbacks */
   ot->exec = component_remove_exec;
@@ -939,12 +986,12 @@ static int component_reload_exec(bContext *C, wmOperator *op)
   return OPERATOR_FINISHED;
 }
 
-static void LOGIC_OT_component_reload(wmOperatorType *ot)
+static void LOGIC_OT_python_component_reload(wmOperatorType *ot)
 {
   /* identifiers */
   ot->name = "Reload Component";
   ot->description = "Reload Component";
-  ot->idname = "LOGIC_OT_component_reload";
+  ot->idname = "LOGIC_OT_python_component_reload";
 
   /* api callbacks */
   ot->exec = component_reload_exec;
@@ -959,6 +1006,8 @@ static void LOGIC_OT_component_reload(wmOperatorType *ot)
 
 /* ************************* */
 
+/* ************************* */
+
 void ED_operatortypes_logic(void)
 {
   WM_operatortype_append(LOGIC_OT_sensor_remove);
@@ -970,9 +1019,10 @@ void ED_operatortypes_logic(void)
   WM_operatortype_append(LOGIC_OT_actuator_remove);
   WM_operatortype_append(LOGIC_OT_actuator_add);
   WM_operatortype_append(LOGIC_OT_actuator_move);
-  WM_operatortype_append(LOGIC_OT_component_add);
-  WM_operatortype_append(LOGIC_OT_component_remove);
-  WM_operatortype_append(LOGIC_OT_component_reload);
+  WM_operatortype_append(LOGIC_OT_python_component_register);
+  WM_operatortype_append(LOGIC_OT_python_component_reload);
+  WM_operatortype_append(LOGIC_OT_python_component_create);
+  WM_operatortype_append(LOGIC_OT_python_component_remove);
   WM_operatortype_append(LOGIC_OT_view_all);
   WM_operatortype_append(LOGIC_OT_region_flip);
 }

--- a/source/blender/makesdna/DNA_python_component_types.h
+++ b/source/blender/makesdna/DNA_python_component_types.h
@@ -27,12 +27,12 @@
 
 typedef struct PythonComponentProperty {
   struct PythonComponentProperty *next, *prev;
-  char name[64];
+  char name[128]; /* 128 = MAX_PROPSTRING */
   short type;
   short boolval;
   int intval;
   float floatval;
-  char strval[64];
+  char strval[128]; /* 128 = MAX_PROPSTRING */
   int itemval;
   float vec[4];
   ListBase enumval;
@@ -41,8 +41,10 @@ typedef struct PythonComponentProperty {
 typedef struct PythonComponent {
   struct PythonComponent *next, *prev;
   ListBase properties;
-  char name[64];
-  char module[64];
+  char name[1024];   /* 1024 = FILE_MAX */
+  char module[1024]; /* 1024 = FILE_MAX */
+  int flag;
+  int _pad;
 } PythonComponent;
 
 /* PythonComponentProperty.type */
@@ -54,5 +56,9 @@ typedef struct PythonComponent {
 #define CPROP_TYPE_VEC2 5
 #define CPROP_TYPE_VEC3 6
 #define CPROP_TYPE_VEC4 7
+#define CPROP_TYPE_COL3 8
+#define CPROP_TYPE_COL4 9
+
+enum { COMPONENT_SHOW = (1 << 0) };
 
 #endif /* __DNA_COMPONENT_TYPES_H__ */

--- a/source/blender/makesrna/intern/rna_python_component.c
+++ b/source/blender/makesrna/intern/rna_python_component.c
@@ -53,6 +53,10 @@ static StructRNA *rna_PythonComponentProperty_refine(struct PointerRNA *ptr)
       return &RNA_ComponentVector3DProperty;
     case CPROP_TYPE_VEC4:
       return &RNA_ComponentVector4DProperty;
+    case CPROP_TYPE_COL3:
+      return &RNA_ComponentColor3Property;
+    case CPROP_TYPE_COL4:
+      return &RNA_ComponentColor4Property;
     default:
       return &RNA_PythonComponentProperty;
   }
@@ -112,6 +116,19 @@ static void rna_def_py_component(BlenderRNA *brna)
   RNA_def_property_ui_text(prop, "Name", "");
   RNA_def_struct_name_property(srna, prop);
   RNA_def_property_clear_flag(prop, PROP_EDITABLE);
+  RNA_def_property_update(prop, NC_LOGIC, NULL);
+
+  prop = RNA_def_property(srna, "module", PROP_STRING, PROP_NONE);
+  RNA_def_property_string_sdna(prop, NULL, "module");
+  RNA_def_property_ui_text(prop, "Module", "");
+  RNA_def_struct_name_property(srna, prop);
+  RNA_def_property_clear_flag(prop, PROP_EDITABLE);
+  RNA_def_property_update(prop, NC_LOGIC, NULL);
+
+  prop = RNA_def_property(srna, "show_expanded", PROP_BOOLEAN, PROP_NONE);
+  RNA_def_property_boolean_sdna(prop, NULL, "flag", COMPONENT_SHOW);
+  RNA_def_property_ui_text(prop, "Expanded", "Set sensor expanded in the user interface");
+  RNA_def_property_ui_icon(prop, ICON_TRIA_RIGHT, 1);
   RNA_def_property_update(prop, NC_LOGIC, NULL);
 
   prop = RNA_def_property(srna, "properties", PROP_COLLECTION, PROP_NONE);
@@ -232,6 +249,32 @@ static void rna_def_py_component_property(BlenderRNA *brna)
       srna, "Python Component Vector 4D Property", "A 4D vector property of a Python Component");
 
   prop = RNA_def_property(srna, "value", PROP_FLOAT, PROP_COORDS);
+  RNA_def_property_float_sdna(prop, NULL, "vec");
+  RNA_def_property_array(prop, 4);
+  RNA_def_property_ui_text(prop, "Value", "Property value");
+  RNA_def_property_update(prop, NC_LOGIC, NULL);
+
+  /* Color 3 */
+  srna = RNA_def_struct(brna, "ComponentColor3Property", "PythonComponentProperty");
+  RNA_def_struct_sdna(srna, "PythonComponentProperty");
+  RNA_def_struct_ui_text(srna,
+                         "Python Component Color 3 Property",
+                         "A 3 channels color property of a Python Component");
+
+  prop = RNA_def_property(srna, "value", PROP_FLOAT, PROP_COLOR);
+  RNA_def_property_float_sdna(prop, NULL, "vec");
+  RNA_def_property_array(prop, 3);
+  RNA_def_property_ui_text(prop, "Value", "Property value");
+  RNA_def_property_update(prop, NC_LOGIC, NULL);
+
+  /* Color 4 */
+  srna = RNA_def_struct(brna, "ComponentColor4Property", "PythonComponentProperty");
+  RNA_def_struct_sdna(srna, "PythonComponentProperty");
+  RNA_def_struct_ui_text(srna,
+                         "Python Component Color 4 Property",
+                         "A 4 channels color property of a Python Component");
+
+  prop = RNA_def_property(srna, "value", PROP_FLOAT, PROP_COLOR);
   RNA_def_property_float_sdna(prop, NULL, "vec");
   RNA_def_property_array(prop, 4);
   RNA_def_property_ui_text(prop, "Value", "Property value");


### PR DESCRIPTION
This is fixing https://github.com/UPBGE/upbge/issues/1230

I copied, the old DNA_python_component.h, rna_python_component, python_component.c, the space_logic.py ui, the part of logic_ops related to python components.

I didn't touched to the code in gameengine folder.

I need to test. Idk if you prefer recover commits by commits or do the stuff like that.

I create a pull request to have a better view 