### PR TITLE
UPBGE: Try to fix camera matrix when restart game

### DIFF
--- a/source/gameengine/Ketsji/KX_GameObject.cpp
+++ b/source/gameengine/Ketsji/KX_GameObject.cpp
@@ -561,7 +561,7 @@ void KX_GameObject::RestoreObmat(Object *ob)
 {
   if (ob) {
     Scene *sce = GetScene()->GetBlenderScene();
-    if (sce->gm.flag & GAME_USE_UNDO) {
+    if (sce->gm.flag & GAME_USE_UNDO && ob->type != OB_CAMERA) {
       copy_m4_m4(ob->obmat, m_origObmat);
       BKE_object_apply_mat4(ob, ob->obmat, false, true);
       DEG_id_tag_update(&ob->id, ID_RECALC_TRANSFORM);


### PR DESCRIPTION
Random fix

Idk why cam matrix doesn't like RestoreObmat code.

Calling RestoreObmat cause issues when we restart a scene with a camera
parented to an object like in this file:

https://pasteall.org/blend/6bab5870d9ef4c9d91ea9a6f80321c0e