### PR TITLE
UPBGE: Fix wrong projection matrix used by texture renderers when main

### DIFF
--- a/source/gameengine/Ketsji/KX_Camera.cpp
+++ b/source/gameengine/Ketsji/KX_Camera.cpp
@@ -148,6 +148,7 @@ void KX_Camera::InvalidateProjectionMatrix()
 	for (unsigned short i = 0; i < RAS_Rasterizer::RAS_STEREO_MAXEYE; ++i) {
 		m_views[i].projectionDirty = true;
 	}
+	GetScene()->GetTextureRendererManager()->InvalidateRenderersProjectionMatrix();
 }
 
 void KX_Camera::UpdateView(RAS_Rasterizer* rasty, KX_Scene* scene, RAS_Rasterizer::StereoMode stereoMode,

--- a/source/gameengine/Ketsji/KX_TextureRendererManager.cpp
+++ b/source/gameengine/Ketsji/KX_TextureRendererManager.cpp
@@ -219,3 +219,12 @@ void KX_TextureRendererManager::Merge(KX_TextureRendererManager *other)
 		other->m_renderers[i].clear();
 	}
 }
+
+void KX_TextureRendererManager::InvalidateRenderersProjectionMatrix()
+{
+	for (unsigned short i = 0; i < CATEGORY_MAX; ++i) {
+		for (KX_TextureRenderer* renderer : m_renderers[i]) {
+			renderer->InvalidateProjectionMatrix();
+		}
+	}
+}

--- a/source/gameengine/Ketsji/KX_TextureRendererManager.h
+++ b/source/gameengine/Ketsji/KX_TextureRendererManager.h
@@ -71,6 +71,7 @@ public:
 
 	/// Invalidate renderers using the given game object as viewpoint object.
 	void InvalidateViewpoint(KX_GameObject *gameobj);
+	void InvalidateRenderersProjectionMatrix();
 
 	/** Add and create a renderer if none existing renderer was using the same
 	* texture containing in the material texture passed.


### PR DESCRIPTION
cam projmat settings change

KX_TextureRenderers projection matrix must be invalidated if sceneCamera
used change of projection matrix (if camera lens changes for example)

It is a fix proposal for this bug report:
https://github.com/UPBGE/upbge/issues/1255