### PR TITLE
 UPBGE: Try to fix freeze when we run files with fluids

### DIFF
--- a/source/gameengine/Ketsji/BL_Action.cpp
+++ b/source/gameengine/Ketsji/BL_Action.cpp
@@ -437,7 +437,7 @@ void BL_Action::Update(float curtime, bool applyToObject)
       if (con) {
         if (ob->adt && ob->adt->action->id.name == m_action->id.name) {
           if (!m_obj->OrigObCanBeTransformedInRealtime(ob)) {
-            return;
+            break;
           }
           DEG_id_tag_update(&ob->id, ID_RECALC_TRANSFORM);
           PointerRNA ptrrna;

--- a/source/gameengine/Ketsji/BL_Action.cpp
+++ b/source/gameengine/Ketsji/BL_Action.cpp
@@ -436,6 +436,9 @@ void BL_Action::Update(float curtime, bool applyToObject)
          con = (bConstraint *)con->next) {
       if (con) {
         if (ob->adt && ob->adt->action->id.name == m_action->id.name) {
+          if (!m_obj->OrigObCanBeTransformedInRealtime(ob)) {
+            return;
+          }
           DEG_id_tag_update(&ob->id, ID_RECALC_TRANSFORM);
           PointerRNA ptrrna;
           RNA_id_pointer_create(&ob->id, &ptrrna);

--- a/source/gameengine/Ketsji/CMakeLists.txt
+++ b/source/gameengine/Ketsji/CMakeLists.txt
@@ -243,4 +243,15 @@ if(WITH_GAMEENGINE)
   add_definitions(-DWITH_GAMEENGINE)
 endif()
 
+if(WITH_CYCLES)
+  add_definitions(-DWITH_CYCLES)
+endif()
+
+if(WITH_MOD_FLUID)
+  list(APPEND LIB
+    bf_intern_mantaflow
+  )
+  add_definitions(-DWITH_FLUID)
+endif()
+
 blender_add_lib(ge_ketsji "${SRC}" "${INC}" "${INC_SYS}" "${LIB}")

--- a/source/gameengine/Ketsji/KX_GameObject.cpp
+++ b/source/gameengine/Ketsji/KX_GameObject.cpp
@@ -268,7 +268,7 @@ void KX_GameObject::IgnoreParentTxBGE(Main *bmain,
        * This is because parent matrix did change, so in theory the child object might now be
        * evaluated to a different location in another editing context. */
       if (!OrigObCanBeTransformedInRealtime(ob_child)) {
-        return;
+        break;
       }
       DEG_id_tag_update(&ob_child->id, ID_RECALC_TRANSFORM);
     }

--- a/source/gameengine/Ketsji/KX_GameObject.h
+++ b/source/gameengine/Ketsji/KX_GameObject.h
@@ -156,6 +156,7 @@ class KX_GameObject : public SCA_IObject {
   void RestoreObmat(Object *ob);
   void IgnoreParentTxBGE(struct Main *bmain, struct Depsgraph *depsgraph, KX_Scene *kxscene, Object *ob);
   void ForceIgnoreParentTx();
+  bool OrigObCanBeTransformedInRealtime(Object *ob);
   /* END OF EEVEE INTEGRATION */
 
   /**


### PR DESCRIPTION
Fluid: https://pasteall.org/blend/bca2c52db77b49068ac069c694dd38ba
Smoke: https://pasteall.org/blend/b5579b5a9649426b9427f9d297503b24

When we call ID_RECAL_TRANSFORM on orig_objects with a fluid modifier or a
smoke modifier, it enables heavy computations in
BKE_fluid_modifier_do...

When we only change ob_eval obmat, it's ok. Except that smoke doesn't seem to
move, but at least there's no freeze.

There are still some issues with blenderplayer but part of issues can be solved if we indicate the absolute path of the fluid cache.

Else, there's a warning displayed in blenderplayer which says that bpy_import_main_set has not been called. It can be a threading issue but I'm not sure for now. There are maybe some things that we can pick from bpy_interface to try to understand.

But in a first time, I propose to commit this which fixes freezes in embedded.

We could see later if we do something about pathes and this warning in blenderplayer.