### PR TITLE
UPBGE: Try to restore post_draw callbacks

### DIFF
--- a/source/blender/draw/intern/draw_manager.c
+++ b/source/blender/draw/intern/draw_manager.c
@@ -2976,25 +2976,6 @@ EEVEE_Data *EEVEE_engine_data_get(void)
   return data;
 }
 
-static void DRW_draw_callbacks_post_scene_simplified(void)
-{
-  RegionView3D *rv3d = DST.draw_ctx.rv3d;
-
-  DRW_state_reset();
-
-  GPU_matrix_projection_set(rv3d->winmat);
-  GPU_matrix_set(rv3d->viewmat);
-
-  GPU_depth_test(false);
-  ED_region_draw_cb_draw(DST.draw_ctx.evil_C, DST.draw_ctx.region, REGION_DRAW_POST_VIEW);
-
-  /* Callback can be nasty and do whatever they want with the state.
-   * Don't trust them! */
-  DRW_state_reset();
-
-  GPU_depth_test(true);
-}
-
 void DRW_game_render_loop(bContext *C,
                           GPUViewport *viewport,
                           Main *bmain,
@@ -3122,14 +3103,10 @@ void DRW_game_render_loop(bContext *C,
 
   DRW_hair_update();
 
-  DRW_draw_callbacks_pre_scene();
-
   drw_engines_draw_scene();
 
   /* Fix 3D view being "laggy" on macos and win+nvidia. (See T56996, T61474) */
   GPU_flush();
-
-  DRW_draw_callbacks_post_scene_simplified();
 
   DRW_state_reset();
 

--- a/source/gameengine/Ketsji/KX_KetsjiEngine.cpp
+++ b/source/gameengine/Ketsji/KX_KetsjiEngine.cpp
@@ -245,13 +245,6 @@ void KX_KetsjiEngine::BeginFrame()
 
 void KX_KetsjiEngine::EndFrame()
 {
-  // Show profiling info
-  m_logger.StartLog(tc_overhead, m_kxsystem->GetTimeInSeconds());
-  if (m_flags & (SHOW_PROFILE | SHOW_FRAMERATE | SHOW_DEBUG_PROPERTIES)) {
-    RenderDebugProperties();
-  }
-
-  m_rasterizer->FlushDebugDraw(m_canvas);
 
   DRW_state_reset();
   GPU_matrix_reset();
@@ -266,6 +259,14 @@ void KX_KetsjiEngine::EndFrame()
 
   DRW_state_reset();
   GPU_depth_test(GPU_DEPTH_ALWAYS);
+
+  // Show profiling info
+  m_logger.StartLog(tc_overhead, m_kxsystem->GetTimeInSeconds());
+  if (m_flags & (SHOW_PROFILE | SHOW_FRAMERATE | SHOW_DEBUG_PROPERTIES)) {
+    RenderDebugProperties();
+  }
+
+  m_rasterizer->FlushDebugDraw(m_canvas);
 
   double tottime = m_logger.GetAverage();
   if (tottime < 1e-6)

--- a/source/gameengine/Rasterizer/RAS_OpenGLRasterizer/RAS_OpenGLDebugDraw.cpp
+++ b/source/gameengine/Rasterizer/RAS_OpenGLRasterizer/RAS_OpenGLDebugDraw.cpp
@@ -141,8 +141,14 @@ void RAS_OpenGLDebugDraw::Flush(RAS_Rasterizer *rasty,
     uint col = GPU_vertformat_attr_add(format, "color", GPU_COMP_F32, 4, GPU_FETCH_FLOAT);
     immBindBuiltinProgram(GPU_SHADER_3D_FLAT_COLOR);
 
-    GPU_depth_test(GPU_DEPTH_NONE);
-    //GPU_blend(true);
+    bContext *C = KX_GetActiveEngine()->GetContext();
+    RegionView3D *rv3d = CTX_wm_region_view3d(C);
+    GPU_matrix_push();
+    GPU_matrix_push_projection();
+    GPU_matrix_projection_set(rv3d->winmat);
+    GPU_matrix_set(rv3d->viewmat);
+
+    GPU_depth_test(GPU_DEPTH_LESS_EQUAL);
     GPU_line_smooth(true);
     GPU_line_width(1.0f);
     immBegin(GPU_PRIM_LINES, 2 * debugDraw->m_lines.size());
@@ -157,15 +163,16 @@ void RAS_OpenGLDebugDraw::Flush(RAS_Rasterizer *rasty,
     immEnd();
 
     /* Reset defaults */
-    //GPU_blend(false);
     GPU_line_smooth(false);
+    GPU_matrix_pop();
+    GPU_matrix_pop_projection();
+    GPU_depth_test(GPU_DEPTH_ALWAYS);
+    GPU_face_culling(GPU_CULL_NONE);
 
     immUnbindProgram();
   }
 
   /* The Performances profiler */
-
-  GPU_matrix_reset();
 
   if (debugDraw->m_boxes2D.size()) {
     GPU_depth_test(GPU_DEPTH_NONE);


### PR DESCRIPTION
With recent eevee's refactor, there were issues with post draw.

I tried to have the render in this depth order:

1) scene 2) physics debug 3) post_draw 4) profile drawing

It needs to switch between matrix and depth tests but seems to work with this file:

https://pasteall.org/blend/4671296344af4604ad36af9845ead5a1

Note: I removed the pre/post draw callbacks from blender because they are now using an overlay-fb which is not in use in bge draw loop.

Picture:

![Capture](https://user-images.githubusercontent.com/10052509/91653357-4914fa80-eaa0-11ea-8162-fd065f32b177.PNG)
