### PR TITLE
UPBGE: Few tweaks

### DIFF
--- a/source/blender/draw/intern/draw_manager.c
+++ b/source/blender/draw/intern/draw_manager.c
@@ -1299,6 +1299,10 @@ void DRW_notify_view_update(const DRWUpdateContext *update_ctx)
   Scene *scene = update_ctx->scene;
   ViewLayer *view_layer = update_ctx->view_layer;
 
+  if (scene->flag & SCE_INTERACTIVE) {
+    return;
+  }
+
   const bool gpencil_engine_needed = drw_gpencil_engine_needed(depsgraph, v3d);
 
   /* Separate update for each stereo view. */

--- a/source/blender/draw/intern/draw_manager.c
+++ b/source/blender/draw/intern/draw_manager.c
@@ -687,6 +687,9 @@ DefaultTextureList *DRW_viewport_texture_list_get(void)
 
 void DRW_viewport_request_redraw(void)
 {
+  if (DRW_context_state_get()->scene->flag & SCE_INTERACTIVE) {
+    return;
+  }
   GPU_viewport_tag_update(DST.viewport);
 }
 

--- a/source/blender/editors/space_view3d/view3d_view.c
+++ b/source/blender/editors/space_view3d/view3d_view.c
@@ -1957,6 +1957,8 @@ static int game_engine_exec(bContext *C, wmOperator *op)
 
   game_engine_save_state(C, prevwin);
 
+  WM_jobs_kill_all(CTX_wm_manager(C));
+
   StartKetsjiShell(C, ar, &cam_frame, 1);
 
   /* window wasnt closed while the BGE was running */

--- a/source/blender/editors/space_view3d/view3d_view.c
+++ b/source/blender/editors/space_view3d/view3d_view.c
@@ -1924,6 +1924,7 @@ static int game_engine_exec(bContext *C, wmOperator *op)
 
   /* redraw to hide any menus/popups, we don't go back to
    * the window manager until after this operator exits */
+  ED_area_tag_redraw(CTX_wm_area(C));
   WM_redraw_windows(C);
 
   BKE_callback_exec_null(bmain, BKE_CB_EVT_GAME_PRE);

--- a/source/blender/editors/space_view3d/view3d_view.c
+++ b/source/blender/editors/space_view3d/view3d_view.c
@@ -1922,9 +1922,12 @@ static int game_engine_exec(bContext *C, wmOperator *op)
   if (!ED_view3d_context_activate(C))
     return OPERATOR_CANCELLED;
 
-  /* redraw to hide any menus/popups, we don't go back to
-   * the window manager until after this operator exits */
+  /* Calling this seems to avoid some UI flickering on windows
+   * later during runtime. */
   ED_area_tag_redraw(CTX_wm_area(C));
+
+  /* Redraw to hide any menus/popups, we don't go back to
+   * the window manager until after this operator exits */
   WM_redraw_windows(C);
 
   BKE_callback_exec_null(bmain, BKE_CB_EVT_GAME_PRE);
@@ -1958,6 +1961,7 @@ static int game_engine_exec(bContext *C, wmOperator *op)
 
   game_engine_save_state(C, prevwin);
 
+  /* We can kill existing threads by precaution before ge start */
   WM_jobs_kill_all(CTX_wm_manager(C));
 
   StartKetsjiShell(C, ar, &cam_frame, 1);

--- a/source/gameengine/Ketsji/KX_Scene.cpp
+++ b/source/gameengine/Ketsji/KX_Scene.cpp
@@ -419,6 +419,7 @@ void KX_Scene::ReinitBlenderContextVariables()
     }
 
     for (ScrArea *sa = (ScrArea *)screen->areabase.first; sa; sa = sa->next) {
+      /* We choose the biggest ScrArea to match the behaviour in WM_init_game */
       if (sa->spacetype == SPACE_VIEW3D && sa == BKE_screen_find_big_area(CTX_wm_screen(C), SPACE_VIEW3D, 0)) {
         ListBase *regionbase = &sa->regionbase;
         for (ar = (ARegion *)regionbase->first; ar; ar = ar->next) {

--- a/source/gameengine/Ketsji/KX_Scene.cpp
+++ b/source/gameengine/Ketsji/KX_Scene.cpp
@@ -419,7 +419,7 @@ void KX_Scene::ReinitBlenderContextVariables()
     }
 
     for (ScrArea *sa = (ScrArea *)screen->areabase.first; sa; sa = sa->next) {
-      if (sa->spacetype == SPACE_VIEW3D) {
+      if (sa->spacetype == SPACE_VIEW3D && sa == BKE_screen_find_big_area(CTX_wm_screen(C), SPACE_VIEW3D, 0)) {
         ListBase *regionbase = &sa->regionbase;
         for (ar = (ARegion *)regionbase->first; ar; ar = ar->next) {
           if (ar->regiontype == RGN_TYPE_WINDOW) {

--- a/source/gameengine/Ketsji/KX_Scene.cpp
+++ b/source/gameengine/Ketsji/KX_Scene.cpp
@@ -226,10 +226,6 @@ KX_Scene::KX_Scene(SCA_IInputDevice *inputDevice,
   defaultCamBase->flag |= BASE_HIDDEN;
   DEG_relations_tag_update(bmain);
 
-  m_taaSamplesBackup = scene->eevee.taa_samples;
-  scene->eevee.taa_samples = 0;
-  DEG_id_tag_update(&scene->id, ID_RECALC_COPY_ON_WRITE);
-
   m_overlay_collections = {};
   m_imageRenderCameraList = {};
 
@@ -304,9 +300,6 @@ KX_Scene::~KX_Scene()
     BKE_layer_collection_sync(scene, view_layer);
     DEG_id_tag_update(&scene->id, ID_RECALC_BASE_FLAGS);
   }
-
-  scene->eevee.taa_samples = m_taaSamplesBackup;
-  DEG_id_tag_update(&scene->id, ID_RECALC_COPY_ON_WRITE);
 
   // Put that before we flush depsgraph updates at scene exit
   scene->flag &= ~SCE_INTERACTIVE;


### PR DESCRIPTION
I was reviewing a bit the code and I changed few things.

1. Previously, in some scenes, when taa_tot_samples was not set to 0, there were some small artifacts/pixels moving, then I choosed to force this setting at ge start. It seems that now we can keep viewport taa_tot_samples setting.
It has several advantages:
- The image looks more like in the viewport.
- When taa_tot_samples was set to 0, there were some weird behaviours sometimes (on a pine tree for example, the spikes were more and more thick when the image was not moving)
- The more we were waiting on a static image, the more the framerate was slowing whereas now, the GPU seems to reduce its activity when we reach tot_samples.

2. I noticed that some parts of the drawing code were called whereas it seems not needed with bge render loop then I did an early return for this code when scene->flag & SCE_INTERACTIVE.

3. I noticed that in embedded, calling ED_area_tag_redraw at ge start was avoiding some UI flickering, then I added that in the embedded ge start operator.

4. I noticed that in WM_init_game, the screen area chosen to start ge was choosed with BKE_screen_find_big_area(CTX_wm_screen(C), SPACE_VIEW3D, 0). Then I modified the ReinitContextVariables code to always choose the "big" area too to init context variables.

I tested in few files and it sounds to work well for me