### PR TITLE
UPBGE: Fix Vertex vs face soft vs soft handling collision

### DIFF
--- a/release/scripts/startup/bl_ui/properties_game.py
+++ b/release/scripts/startup/bl_ui/properties_game.py
@@ -159,7 +159,7 @@ class PHYSICS_PT_game_physics(PhysicsButtonsPanel, Panel):
 
             sub = col.column()
             sub.active = soft.use_bending_constraints
-            #sub.prop(soft, "bending_distance")
+            sub.prop(soft, "bending_distance")
 
             col.prop(soft, "use_shape_match")
 

--- a/source/blender/makesrna/intern/rna_object_force.c
+++ b/source/blender/makesrna/intern/rna_object_force.c
@@ -1936,6 +1936,11 @@ static void rna_def_game_softbody(BlenderRNA *brna)
   RNA_def_property_range(prop, 1, 1000);
   RNA_def_property_ui_text(prop, "Cluster Iterations", "Number of cluster iterations");
 
+  prop = RNA_def_property(srna, "bending_distance", PROP_INT, PROP_NONE);
+  RNA_def_property_int_sdna(prop, NULL, "bending_dist");
+  RNA_def_property_range(prop, 1, 1000);
+  RNA_def_property_ui_text(prop, "Bending Distance", "Bending Constraint Distance");
+
   /* Booleans */
 
   prop = RNA_def_property(srna, "use_shape_match", PROP_BOOLEAN, PROP_NONE);

--- a/source/gameengine/Physics/Bullet/CcdPhysicsController.cpp
+++ b/source/gameengine/Physics/Bullet/CcdPhysicsController.cpp
@@ -423,8 +423,8 @@ bool CcdPhysicsController::CreateSoftbody()
     psb->m_cfg.collisions += btSoftBody::fCollision::CL_SS;
   }
   else {
-    /* This flag is causing freezes for objects like Suzanne with several "separate parts (head, eyes...) */
-    //psb->m_cfg.collisions += btSoftBody::fCollision::VF_SS;
+    // Flag VF_SS is causing freezes for objects like Suzanne with several "separate parts (head, eyes...)". We use VF_DD to avoid it
+    psb->m_cfg.collisions += btSoftBody::fCollision::VF_DD;
   }
 
   psb->m_cfg.kSRHR_CL = m_cci.m_soft_kSRHR_CL;  // Soft vs rigid hardness [0,1] (cluster only)


### PR DESCRIPTION
We use type VF_DD now to avoid crashes with objects like Suzanne with several separate parts.

Additionally, we recover bending distance slide option (default to 2).

2 samples:
[Softbody_simple.zip](https://github.com/UPBGE/upbge/files/5319088/Softbody_simple.zip)
[SoftBody_flag.zip](https://github.com/UPBGE/upbge/files/5319089/SoftBody_flag.zip)
