### PR TITLE
UPBGE: ReplaceMesh Actuator: Restore replace physics shape option

### DIFF
--- a/source/blender/editors/space_logic/logic_window.c
+++ b/source/blender/editors/space_logic/logic_window.c
@@ -1934,9 +1934,9 @@ static void draw_actuator_edit_object(uiLayout *layout, PointerRNA *ptr)
       }
       split = uiLayoutSplit(layout, 0.6, false);
       uiItemR(split, ptr, "mesh", 0, NULL, ICON_NONE);
-      /*row = uiLayoutRow(split, false);
+      row = uiLayoutRow(split, false);
       uiItemR(row, ptr, "use_replace_display_mesh", UI_ITEM_R_TOGGLE, NULL, ICON_NONE);
-      uiItemR(row, ptr, "use_replace_physics_mesh", UI_ITEM_R_TOGGLE, NULL, ICON_NONE);*/
+      uiItemR(row, ptr, "use_replace_physics_mesh", UI_ITEM_R_TOGGLE, NULL, ICON_NONE);
       break;
     case ACT_EDOB_TRACK_TO:
       split = uiLayoutSplit(layout, 0.5, false);

--- a/source/blender/makesdna/DNA_actuator_types.h
+++ b/source/blender/makesdna/DNA_actuator_types.h
@@ -466,8 +466,8 @@ typedef struct bActuator {
 #define ACT_TRACK_TRAXIS_NEGZ 5
 
 /* editObjectActuator->flag for replace mesh actuator */
-//#define ACT_EDOB_REPLACE_MESH_NOGFX		2 /* use for replace mesh actuator */
-//#define ACT_EDOB_REPLACE_MESH_PHYS		4
+#define ACT_EDOB_REPLACE_MESH_NOGFX		2 /* use for replace mesh actuator */
+#define ACT_EDOB_REPLACE_MESH_PHYS		4
 
 /* editObjectActuator->dyn_operation */
 #define ACT_EDOB_RESTORE_DYN 0

--- a/source/blender/makesrna/intern/rna_actuator.c
+++ b/source/blender/makesrna/intern/rna_actuator.c
@@ -1585,7 +1585,7 @@ static void rna_def_edit_object_actuator(BlenderRNA *brna)
   RNA_def_property_ui_text(prop, "L", "Apply the rotation locally");
   RNA_def_property_update(prop, NC_LOGIC, NULL);
 
-  /*prop = RNA_def_property(srna, "use_replace_display_mesh", PROP_BOOLEAN, PROP_NONE);
+  prop = RNA_def_property(srna, "use_replace_display_mesh", PROP_BOOLEAN, PROP_NONE);
   RNA_def_property_boolean_negative_sdna(prop, NULL, "flag", ACT_EDOB_REPLACE_MESH_NOGFX);
   RNA_def_property_ui_text(prop, "Gfx", "Replace the display mesh");
   RNA_def_property_update(prop, NC_LOGIC, NULL);
@@ -1593,8 +1593,8 @@ static void rna_def_edit_object_actuator(BlenderRNA *brna)
   prop = RNA_def_property(srna, "use_replace_physics_mesh", PROP_BOOLEAN, PROP_NONE);
   RNA_def_property_boolean_sdna(prop, NULL, "flag", ACT_EDOB_REPLACE_MESH_PHYS);
   RNA_def_property_ui_text(prop, "Phys",
-                           "Replace the physics mesh (triangle bounds only - compound shapes not
-  supported)"); RNA_def_property_update(prop, NC_LOGIC, NULL);*/
+                           "Replace the physics mesh (triangle bounds only - compound shapes not supported)");
+  RNA_def_property_update(prop, NC_LOGIC, NULL);
 
   prop = RNA_def_property(srna, "use_3d_tracking", PROP_BOOLEAN, PROP_NONE);
   RNA_def_property_boolean_sdna(prop, NULL, "flag", ACT_TRACK_3D);

--- a/source/gameengine/Converter/BL_ConvertActuators.cpp
+++ b/source/gameengine/Converter/BL_ConvertActuators.cpp
@@ -424,8 +424,8 @@ void BL_ConvertActuators(const char *maggiename,
                 gameobj,
                 tmpmesh,
                 scene,
-                /*(editobact->flag & ACT_EDOB_REPLACE_MESH_NOGFX) == 0*/ true,
-                /*(editobact->flag & ACT_EDOB_REPLACE_MESH_PHYS) != 0)*/ false);
+                (editobact->flag & ACT_EDOB_REPLACE_MESH_NOGFX) == 0,
+                (editobact->flag & ACT_EDOB_REPLACE_MESH_PHYS) != 0);
 
             baseact = tmpreplaceact;
           } break;

--- a/source/gameengine/Ketsji/KX_Scene.cpp
+++ b/source/gameengine/Ketsji/KX_Scene.cpp
@@ -1673,6 +1673,42 @@ void KX_Scene::ReplaceMesh(KX_GameObject *gameobj,
     return;
   }
 
+  /* Update physics mesh. Do it before use_gfx, else it won't work.
+   * (It has to be done before we call gameobj->removeMeshes() + gameobj->AddMesh(mesh)).
+   */
+  if (use_phys) {
+    if (gameobj->GetPhysicsController()) {
+      KX_GameObject *reference = nullptr;
+      for (KX_GameObject *gob : GetObjectList()) {
+        if (gob->GetMeshCount() > 0) { // only for object with meshes
+          if (gob->GetMesh(0) == mesh) {
+            reference = gob;
+            break;
+          }
+        }
+      }
+      for (KX_GameObject *gob : GetInactiveList()) {
+        if (gob->GetMeshCount() > 0) { // only for object with meshes
+          if (gob->GetMesh(0) == mesh) {
+            reference = gob;
+            break;
+          }
+        }
+      }
+      if (reference) {
+        PHY_IPhysicsController *ref_ctrl = reference->GetPhysicsController();
+        if (ref_ctrl) {
+          gameobj->GetPhysicsController()->ReplacePhysicsShape(ref_ctrl);
+        }
+        else {
+          std::cout << "ReplaceMesh: To replacePhysicsShape, the actuator mesh must have a "
+                       "physics shape."
+                    << std::endl;
+        }
+      }
+    }
+  }
+
   if (use_gfx) {
     gameobj->RemoveMeshes();
     gameobj->AddMesh(mesh);
@@ -1690,13 +1726,6 @@ void KX_Scene::ReplaceMesh(KX_GameObject *gameobj,
 
     DEG_id_tag_update(&gameobj->GetBlenderObject()->id, ID_RECALC_GEOMETRY);
   }
-
-  // if (use_phys) { /* update the new assigned mesh with the physics mesh */
-  //  if (gameobj->GetPhysicsController()) {
-  //    gameobj->GetPhysicsController()->ReinstancePhysicsShape2(mesh, mesh->GetOriginalObject(),
-  //    true);
-  //  }
-  //}
 
   ResetTaaSamples();
 }

--- a/source/gameengine/Ketsji/KX_Scene.cpp
+++ b/source/gameengine/Ketsji/KX_Scene.cpp
@@ -1725,7 +1725,9 @@ void KX_Scene::ReplaceMesh(KX_GameObject *gameobj,
       }
       gameobj->AddDummyLodManager(mesh);
     }
+  }
 
+  if (use_gfx || use_phys) {
     DEG_id_tag_update(&gameobj->GetBlenderObject()->id, ID_RECALC_GEOMETRY);
   }
 

--- a/source/gameengine/Ketsji/KX_Scene.cpp
+++ b/source/gameengine/Ketsji/KX_Scene.cpp
@@ -1687,11 +1687,13 @@ void KX_Scene::ReplaceMesh(KX_GameObject *gameobj,
           }
         }
       }
-      for (KX_GameObject *gob : GetInactiveList()) {
-        if (gob->GetMeshCount() > 0) { // only for object with meshes
-          if (gob->GetMesh(0) == mesh) {
-            reference = gob;
-            break;
+      if (!reference) { // Avoid to loop in InactiveList if we already have a reference
+        for (KX_GameObject *gob : GetInactiveList()) {
+          if (gob->GetMeshCount() > 0) {  // only for object with meshes
+            if (gob->GetMesh(0) == mesh) {
+              reference = gob;
+              break;
+            }
           }
         }
       }


### PR DESCRIPTION
test file: https://pasteall.org/blend/cd5635c360c64f7f86a9502e3be82a5a

It is using ReplacePhysicsShape whereas before I think it was using ReinstancePhysicsShape.

I think it is better because it just replace the shape with an already existing shape without having to do computation.