### PR TITLE
UPBGE: Implement viewport render in blenderplayer + profile in viewport render (experimental)

### DIFF
--- a/source/blender/draw/intern/DRW_render.h
+++ b/source/blender/draw/intern/DRW_render.h
@@ -789,6 +789,7 @@ void DRW_game_render_loop(struct bContext *C,
 
 void DRW_game_render_loop_end(void);
 void DRW_game_python_loop_end(struct ViewLayer *view_layer);
+void DRW_game_viewport_render_loop_end(void);
 void DRW_transform_to_display(struct GPUTexture *tex, struct View3D *v3d, bool do_dithering);
 void DRW_transform_to_display_image_render(struct GPUTexture *tex);
 /**************************END OF GAME ENGINE*******************************/

--- a/source/blender/draw/intern/draw_debug.c
+++ b/source/blender/draw/intern/draw_debug.c
@@ -257,7 +257,7 @@ void DRW_debug_text_2D_bge(const float xco, const float yco, const char *str)
   DRWDebugText2D *text = MEM_mallocN(sizeof(DRWDebugText2D), "DRWDebugText2D");
   text->xco = xco;
   text->yco = yco;
-  text->text = str;
+  strncpy(text->text, str, 64);
   BLI_LINKS_PREPEND(DST.debug_bge.texts, text);
 }
 
@@ -314,12 +314,10 @@ static void drw_debug_draw_boxes_bge(void)
   const float *size = DRW_viewport_size_get();
   const unsigned int width = size[0];
   const unsigned int height = size[1];
+  GPU_matrix_reset();
   GPU_matrix_ortho_set(0, width, 0, height, -100, 100);
 
   immBindBuiltinProgram(GPU_SHADER_2D_UNIFORM_COLOR);
-
-  DRW_state_reset();
-  GPU_depth_test(GPU_DEPTH_ALWAYS);
 
   while (DST.debug_bge.boxes) {
     void *next = DST.debug_bge.boxes->next;
@@ -345,6 +343,7 @@ static void drw_debug_draw_text_bge(void)
   const float *size = DRW_viewport_size_get();
   const unsigned int width = size[0];
   const unsigned int height = size[1];
+  GPU_matrix_reset();
   GPU_matrix_ortho_set(0, width, 0, height, -100, 100);
 
   BLF_size(blf_mono_font, 11, 72);
@@ -360,7 +359,7 @@ static void drw_debug_draw_text_bge(void)
     DRWDebugText2D *t = DST.debug_bge.texts;
     BLF_color4fv(blf_mono_font, white);
     BLF_position(blf_mono_font, t->xco, t->yco, 0.0f);
-    BLF_draw(blf_mono_font, t->text, sizeof(t));
+    BLF_draw(blf_mono_font, t->text, BLF_DRAW_STR_DUMMY_MAX);
     MEM_freeN(DST.debug_bge.texts);
     DST.debug_bge.texts = next;
   }
@@ -369,13 +368,7 @@ static void drw_debug_draw_text_bge(void)
 
 void drw_debug_draw_bge(void)
 {
-  GPU_matrix_push();
-  GPU_matrix_push_projection();
-
   drw_debug_draw_lines_bge();
   drw_debug_draw_boxes_bge();
   drw_debug_draw_text_bge();
-
-  GPU_matrix_pop();
-  GPU_matrix_pop_projection();
 }

--- a/source/blender/draw/intern/draw_debug.c
+++ b/source/blender/draw/intern/draw_debug.c
@@ -228,3 +228,154 @@ void drw_debug_init(void)
 {
   DRW_debug_modelmat_reset();
 }
+
+
+#include "BLF_api.h"
+#include "GPU_matrix.h"
+
+void DRW_debug_line_bge(const float v1[3], const float v2[3], const float color[4])
+{
+  DRWDebugLine *line = MEM_mallocN(sizeof(DRWDebugLine), "DRWDebugLine");
+  mul_v3_m4v3(line->pos[0], g_modelmat, v1);
+  mul_v3_m4v3(line->pos[1], g_modelmat, v2);
+  copy_v4_v4(line->color, color);
+  BLI_LINKS_PREPEND(DST.debug_bge.lines, line);
+}
+
+void DRW_debug_box_2D_bge(const float xco, const float yco, const float xsize, const float ysize)
+{
+  DRWDebugBox2D *box = MEM_mallocN(sizeof(DRWDebugBox2D), "DRWDebugBox");
+  box->xco = xco;
+  box->yco = yco;
+  box->xsize = xsize;
+  box->ysize = ysize;
+  BLI_LINKS_PREPEND(DST.debug_bge.boxes, box);
+}
+
+void DRW_debug_text_2D_bge(const float xco, const float yco, const char *str)
+{
+  DRWDebugText2D *text = MEM_mallocN(sizeof(DRWDebugText2D), "DRWDebugText2D");
+  text->xco = xco;
+  text->yco = yco;
+  text->text = str;
+  BLI_LINKS_PREPEND(DST.debug_bge.texts, text);
+}
+
+static void drw_debug_draw_lines_bge(void)
+{
+  int count = BLI_linklist_count((LinkNode *)DST.debug_bge.lines);
+
+  if (count == 0) {
+    return;
+  }
+
+  GPUVertFormat *vert_format = immVertexFormat();
+  uint pos = GPU_vertformat_attr_add(vert_format, "pos", GPU_COMP_F32, 3, GPU_FETCH_FLOAT);
+  uint col = GPU_vertformat_attr_add(vert_format, "color", GPU_COMP_F32, 4, GPU_FETCH_FLOAT);
+
+  immBindBuiltinProgram(GPU_SHADER_3D_FLAT_COLOR);
+
+  GPU_line_smooth(true);
+  GPU_line_width(1.0f);
+
+  immBegin(GPU_PRIM_LINES, count * 2);
+
+  while (DST.debug_bge.lines) {
+    void *next = DST.debug_bge.lines->next;
+
+    immAttr4fv(col, DST.debug_bge.lines->color);
+    immVertex3fv(pos, DST.debug_bge.lines->pos[0]);
+
+    immAttr4fv(col, DST.debug_bge.lines->color);
+    immVertex3fv(pos, DST.debug_bge.lines->pos[1]);
+
+    MEM_freeN(DST.debug_bge.lines);
+    DST.debug_bge.lines = next;
+  }
+  immEnd();
+
+  GPU_line_smooth(false);
+
+  immUnbindProgram();
+}
+
+static void drw_debug_draw_boxes_bge(void)
+{
+  int count = BLI_linklist_count((LinkNode *)DST.debug_bge.boxes);
+
+  if (count == 0) {
+    return;
+  }
+
+  GPUVertFormat *format = immVertexFormat();
+  uint pos = GPU_vertformat_attr_add(format, "pos", GPU_COMP_F32, 2, GPU_FETCH_FLOAT);
+  static float white[4] = {1.0f, 1.0f, 1.0f, 1.0f};
+
+  const float *size = DRW_viewport_size_get();
+  const unsigned int width = size[0];
+  const unsigned int height = size[1];
+  GPU_matrix_ortho_set(0, width, 0, height, -100, 100);
+
+  immBindBuiltinProgram(GPU_SHADER_2D_UNIFORM_COLOR);
+
+  DRW_state_reset();
+  GPU_depth_test(GPU_DEPTH_ALWAYS);
+
+  while (DST.debug_bge.boxes) {
+    void *next = DST.debug_bge.boxes->next;
+    DRWDebugBox2D *b = DST.debug_bge.boxes;
+    immUniformColor4fv(white);
+    immRectf(pos, b->xco + 1 + b->xsize, b->yco + b->ysize, b->xco, b->yco);
+    MEM_freeN(DST.debug_bge.boxes);
+    DST.debug_bge.boxes = next;
+  }
+  immUnbindProgram();
+}
+
+static void drw_debug_draw_text_bge(void)
+{
+  int count = BLI_linklist_count((LinkNode *)DST.debug_bge.texts);
+
+  if (count == 0) {
+    return;
+  }
+
+  static float white[4] = {1.0f, 1.0f, 1.0f, 1.0f};
+
+  const float *size = DRW_viewport_size_get();
+  const unsigned int width = size[0];
+  const unsigned int height = size[1];
+  GPU_matrix_ortho_set(0, width, 0, height, -100, 100);
+
+  BLF_size(blf_mono_font, 11, 72);
+
+  BLF_enable(blf_mono_font, BLF_SHADOW);
+
+  static float black[4] = {0.0f, 0.0f, 0.0f, 1.0f};
+  BLF_shadow(blf_mono_font, 1, black);
+  BLF_shadow_offset(blf_mono_font, 1, 1);
+
+  while (DST.debug_bge.texts) {
+    void *next = DST.debug_bge.texts->next;
+    DRWDebugText2D *t = DST.debug_bge.texts;
+    BLF_color4fv(blf_mono_font, white);
+    BLF_position(blf_mono_font, t->xco, t->yco, 0.0f);
+    BLF_draw(blf_mono_font, t->text, sizeof(t));
+    MEM_freeN(DST.debug_bge.texts);
+    DST.debug_bge.texts = next;
+  }
+  BLF_disable(blf_mono_font, BLF_SHADOW);
+}
+
+void drw_debug_draw_bge(void)
+{
+  GPU_matrix_push();
+  GPU_matrix_push_projection();
+
+  drw_debug_draw_lines_bge();
+  drw_debug_draw_boxes_bge();
+  drw_debug_draw_text_bge();
+
+  GPU_matrix_pop();
+  GPU_matrix_pop_projection();
+}

--- a/source/blender/draw/intern/draw_debug.h
+++ b/source/blender/draw/intern/draw_debug.h
@@ -24,6 +24,10 @@
 
 struct BoundBox;
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void DRW_debug_modelmat_reset(void);
 void DRW_debug_modelmat(const float modelmat[4][4]);
 
@@ -33,3 +37,12 @@ void DRW_debug_m4(const float m[4][4]);
 void DRW_debug_m4_as_bbox(const float m[4][4], const float color[4], const bool invert);
 void DRW_debug_bbox(const BoundBox *bbox, const float color[4]);
 void DRW_debug_sphere(const float center[3], const float radius, const float color[4]);
+
+/* Game engine transition */
+void DRW_debug_line_bge(const float v1[3], const float v2[3], const float color[4]);
+void DRW_debug_box_2D_bge(const float xco, const float yco, const float xsize, const float ysize);
+void DRW_debug_text_2D_bge(const float xco, const float yco, const char *str);
+
+#ifdef __cplusplus
+}
+#endif

--- a/source/blender/draw/intern/draw_manager.c
+++ b/source/blender/draw/intern/draw_manager.c
@@ -3388,6 +3388,11 @@ void DRW_game_render_loop_end()
   memset(&DST, 0xFF, offsetof(DRWManager, gl_context));
 }
 
+void DRW_game_viewport_render_loop_end()
+{
+  drw_debug_draw_bge();
+}
+
 void DRW_game_python_loop_end(ViewLayer *view_layer)
 {
   /* When we run blenderplayer -p script.py

--- a/source/blender/draw/intern/draw_manager.c
+++ b/source/blender/draw/intern/draw_manager.c
@@ -1427,7 +1427,10 @@ void DRW_draw_callbacks_post_scene(void)
     GPU_depth_test(GPU_DEPTH_NONE);
     drw_engines_draw_text();
 
-    DRW_draw_region_info();
+    Scene *orig_scene = (Scene *)DEG_get_original_id(&DST.draw_ctx.scene->id);
+    if (!(orig_scene->flag & SCE_IS_BLENDERPLAYER)) {
+      DRW_draw_region_info();
+    }
 
     /* annotations - temporary drawing buffer (screenspace) */
     /* XXX: Or should we use a proper draw/overlay engine for this case? */

--- a/source/blender/draw/intern/draw_manager.c
+++ b/source/blender/draw/intern/draw_manager.c
@@ -1410,6 +1410,8 @@ void DRW_draw_callbacks_post_scene(void)
 
     /* Game engine transition */
     drw_debug_draw_bge();
+    GPU_matrix_projection_set(rv3d->winmat);
+    GPU_matrix_set(rv3d->viewmat);
     /**************************/
 
     GPU_depth_test(GPU_DEPTH_NONE);

--- a/source/blender/draw/intern/draw_manager.c
+++ b/source/blender/draw/intern/draw_manager.c
@@ -1408,6 +1408,10 @@ void DRW_draw_callbacks_post_scene(void)
 
     drw_debug_draw();
 
+    /* Game engine transition */
+    drw_debug_draw_bge();
+    /**************************/
+
     GPU_depth_test(GPU_DEPTH_NONE);
     /* Apply state for callbacks. */
     GPU_apply_state();

--- a/source/blender/draw/intern/draw_manager.h
+++ b/source/blender/draw/intern/draw_manager.h
@@ -472,7 +472,7 @@ typedef struct DRWDebugSphere {
 /* Game engine transition */
 typedef struct DRWDebugText2D {
   struct DRWDebugText2D *next; /* linked list */
-  char *text;
+  char text[64];
   float xco;
   float yco;
 } DRWDebugText2D;

--- a/source/blender/draw/intern/draw_manager.h
+++ b/source/blender/draw/intern/draw_manager.h
@@ -469,6 +469,23 @@ typedef struct DRWDebugSphere {
   float color[4];
 } DRWDebugSphere;
 
+/* Game engine transition */
+typedef struct DRWDebugText2D {
+  struct DRWDebugText2D *next; /* linked list */
+  char *text;
+  float xco;
+  float yco;
+} DRWDebugText2D;
+
+typedef struct DRWDebugBox2D {
+  struct DRWDebugBox2D *next; /* linked list */
+  float xco;
+  float yco;
+  float xsize;
+  float ysize;
+} DRWDebugBox2D;
+/* End of Game engine transition */
+
 /* ------------- DRAW MANAGER ------------ */
 
 #define DST_MAX_SLOTS 64  /* Cannot be changed without modifying RST.bound_tex_slots */
@@ -571,6 +588,16 @@ typedef struct DRWManager {
     DRWDebugLine *lines;
     DRWDebugSphere *spheres;
   } debug;
+
+  /* Game engine transition */
+  struct {
+    /* TODO(fclem) optimize: use chunks. */
+    DRWDebugLine *lines;
+    DRWDebugBox2D *boxes;
+    DRWDebugText2D *texts;
+  } debug_bge;
+  /* Game engine transition */
+
 } DRWManager;
 
 extern DRWManager DST; /* TODO: get rid of this and allow multi-threaded rendering. */
@@ -598,3 +625,7 @@ void drw_resource_buffer_finish(ViewportMemoryPool *vmempool);
 GPUBatch *drw_cache_procedural_points_get(void);
 GPUBatch *drw_cache_procedural_lines_get(void);
 GPUBatch *drw_cache_procedural_triangles_get(void);
+
+/* Game engine transition */
+void drw_debug_draw_bge(void);
+/**************************/

--- a/source/blender/draw/intern/draw_manager_shader.c
+++ b/source/blender/draw/intern/draw_manager_shader.c
@@ -213,7 +213,7 @@ static void drw_deferred_shader_add(GPUMaterial *mat, bool deferred)
   /* Do not defer the compilation if we are rendering for image.
    * deferred rendering is only possible when `evil_C` is available */
   if (DST.draw_ctx.evil_C == NULL || DRW_state_is_image_render() || !USE_DEFERRED_COMPILATION ||
-      !deferred || (scene->flag & SCE_INTERACTIVE)) {
+      !deferred || (scene->flag & SCE_INTERACTIVE || (scene->flag & SCE_IS_BLENDERPLAYER))) {
     /* Double checking that this GPUMaterial is not going to be
      * compiled by another thread. */
     DRW_deferred_shader_remove(mat);

--- a/source/blender/editors/space_view3d/view3d_draw.c
+++ b/source/blender/editors/space_view3d/view3d_draw.c
@@ -1579,15 +1579,17 @@ void view3d_draw_region_info(const bContext *C, ARegion *region)
 
 static void view3d_draw_view(const bContext *C, ARegion *region)
 {
-  ED_view3d_draw_setup_view(CTX_wm_manager(C),
-                            CTX_wm_window(C),
-                            CTX_data_expect_evaluated_depsgraph(C),
-                            CTX_data_scene(C),
-                            region,
-                            CTX_wm_view3d(C),
-                            NULL,
-                            NULL,
-                            NULL);
+  if (!(CTX_data_scene(C)->flag & SCE_IS_BLENDERPLAYER)) {
+    ED_view3d_draw_setup_view(CTX_wm_manager(C),
+                              CTX_wm_window(C),
+                              CTX_data_expect_evaluated_depsgraph(C),
+                              CTX_data_scene(C),
+                              region,
+                              CTX_wm_view3d(C),
+                              NULL,
+                              NULL,
+                              NULL);
+  }
 
   /* Only 100% compliant on new spec goes below */
   DRW_draw_view(C);

--- a/source/blender/editors/space_view3d/view3d_draw.c
+++ b/source/blender/editors/space_view3d/view3d_draw.c
@@ -1579,17 +1579,15 @@ void view3d_draw_region_info(const bContext *C, ARegion *region)
 
 static void view3d_draw_view(const bContext *C, ARegion *region)
 {
-  if (!(CTX_data_scene(C)->flag & SCE_IS_BLENDERPLAYER)) {
-    ED_view3d_draw_setup_view(CTX_wm_manager(C),
-                              CTX_wm_window(C),
-                              CTX_data_expect_evaluated_depsgraph(C),
-                              CTX_data_scene(C),
-                              region,
-                              CTX_wm_view3d(C),
-                              NULL,
-                              NULL,
-                              NULL);
-  }
+  ED_view3d_draw_setup_view(CTX_wm_manager(C),
+                            CTX_wm_window(C),
+                            CTX_data_expect_evaluated_depsgraph(C),
+                            CTX_data_scene(C),
+                            region,
+                            CTX_wm_view3d(C),
+                            NULL,
+                            NULL,
+                            NULL);
 
   /* Only 100% compliant on new spec goes below */
   DRW_draw_view(C);

--- a/source/blender/makesdna/DNA_scene_types.h
+++ b/source/blender/makesdna/DNA_scene_types.h
@@ -2292,6 +2292,7 @@ typedef enum eVGroupSelect {
 #define SCE_READFILE_LIBLINK_NEED_SETSCENE_CHECK (1 << 5)
 #define SCE_INTERACTIVE (1 << 6)
 #define SCE_INTERACTIVE_IMAGE_RENDER (1 << 7)
+#define SCE_IS_BLENDERPLAYER (1 << 8)
 
 /* return flag BKE_scene_base_iter_next functions */
 /* #define F_ERROR          -1 */ /* UNUSED */

--- a/source/gameengine/Converter/BL_BlenderDataConversion.cpp
+++ b/source/gameengine/Converter/BL_BlenderDataConversion.cpp
@@ -732,7 +732,6 @@ static KX_GameObject *gameobject_from_blenderobject(Object *ob,
                                                     bool converting_during_runtime)
 {
   KX_GameObject *gameobj = nullptr;
-  Scene *blenderscene = kxscene->GetBlenderScene();
 
   switch (ob->type) {
     case OB_LAMP: {

--- a/source/gameengine/Converter/BL_BlenderDataConversion.cpp
+++ b/source/gameengine/Converter/BL_BlenderDataConversion.cpp
@@ -846,12 +846,12 @@ static KX_GameObject *gameobject_from_blenderobject(Object *ob,
 
 #ifdef THREADED_DAG_WORKAROUND
     case OB_CURVE: {
-      bContext *C = KX_GetActiveEngine()->GetContext();
+      /*bContext *C = KX_GetActiveEngine()->GetContext();
       if (ob->runtime.curve_cache == nullptr) {
         Depsgraph *depsgraph = CTX_data_depsgraph_on_load(C);
         BKE_displist_make_curveTypes(
             depsgraph, blenderscene, DEG_get_evaluated_object(depsgraph, ob), false, false);
-      }
+      }*/
       // eevee add curves to scene.objects list
       gameobj = new KX_EmptyObject(kxscene, KX_Scene::m_callbacks);
       // set transformation

--- a/source/gameengine/GameLogic/SCA_GameActuator.cpp
+++ b/source/gameengine/GameLogic/SCA_GameActuator.cpp
@@ -77,13 +77,6 @@ CValue *SCA_GameActuator::GetReplica()
 
 bool SCA_GameActuator::Update()
 {
-  bool useViewportRender =
-      (KX_GetActiveEngine()->CurrentScenes()->GetFront()->GetBlenderScene()->gm.flag &
-       GAME_USE_VIEWPORT_RENDER) != 0;
-  if (useViewportRender) {
-    std::cout << "Game actuator is not available in viewport render mode." << std::endl;
-    return false;
-  }
   // bool result = false;	 /*unused*/
   bool bNegativeEvent = IsNegativeEvent();
   RemoveAllEvents();

--- a/source/gameengine/GameLogic/SCA_GameActuator.cpp
+++ b/source/gameengine/GameLogic/SCA_GameActuator.cpp
@@ -34,7 +34,11 @@
 
 #include "SCA_GameActuator.h"
 
+#include "DNA_scene_types.h"
+
 #include "CM_Message.h"
+#include "EXP_ListValue.h"
+#include "KX_Globals.h"
 #include "KX_KetsjiEngine.h"
 #include "KX_PythonInit.h" /* for config load/saving */
 #include "RAS_ICanvas.h"
@@ -73,6 +77,13 @@ CValue *SCA_GameActuator::GetReplica()
 
 bool SCA_GameActuator::Update()
 {
+  bool useViewportRender =
+      (KX_GetActiveEngine()->CurrentScenes()->GetFront()->GetBlenderScene()->gm.flag &
+       GAME_USE_VIEWPORT_RENDER) != 0;
+  if (useViewportRender) {
+    std::cout << "Game actuator is not available in viewport render mode." << std::endl;
+    return false;
+  }
   // bool result = false;	 /*unused*/
   bool bNegativeEvent = IsNegativeEvent();
   RemoveAllEvents();

--- a/source/gameengine/GamePlayer/GPG_Canvas.cpp
+++ b/source/gameengine/GamePlayer/GPG_Canvas.cpp
@@ -41,8 +41,8 @@
 
 #include "KX_Globals.h"
 
-GPG_Canvas::GPG_Canvas(RAS_Rasterizer *rasty, GHOST_IWindow *window, Scene *startscene)
-    : RAS_ICanvas(rasty), m_window(window), m_startScene(startscene), m_width(0), m_height(0)
+GPG_Canvas::GPG_Canvas(RAS_Rasterizer *rasty, GHOST_IWindow *window)
+    : RAS_ICanvas(rasty), m_window(window), m_width(0), m_height(0)
 {
   if (m_window) {
     GHOST_Rect bnds;
@@ -219,7 +219,3 @@ bool GPG_Canvas::IsBlenderPlayer()
   return true;
 }
 
-Scene *GPG_Canvas::GetStartScene()
-{
-  return m_startScene;
-}

--- a/source/gameengine/GamePlayer/GPG_Canvas.h
+++ b/source/gameengine/GamePlayer/GPG_Canvas.h
@@ -49,7 +49,6 @@ class GPG_Canvas : public RAS_ICanvas {
  protected:
   /// GHOST window.
   GHOST_IWindow *m_window;
-  Scene *m_startScene;
   /// Width of the context.
   int m_width;
   /// Height of the context.
@@ -62,7 +61,7 @@ class GPG_Canvas : public RAS_ICanvas {
   int m_viewport[4];
 
  public:
-  GPG_Canvas(RAS_Rasterizer *rasty, GHOST_IWindow *window, Scene *startscene);
+  GPG_Canvas(RAS_Rasterizer *rasty, GHOST_IWindow *window);
   virtual ~GPG_Canvas();
 
   /**
@@ -96,8 +95,6 @@ class GPG_Canvas : public RAS_ICanvas {
   virtual void EndDraw();
 
   virtual bool IsBlenderPlayer();
-
-  virtual Scene *GetStartScene();
 };
 
 #endif  // __GPG_CANVAS_H__

--- a/source/gameengine/GamePlayer/GPG_ghost.cpp
+++ b/source/gameengine/GamePlayer/GPG_ghost.cpp
@@ -807,6 +807,9 @@ int main(int argc,
   MEM_CacheLimiter_set_disabled(true);
   BKE_cachefiles_init();
   BKE_idtype_init();
+
+  BKE_appdir_init();
+  BLI_task_scheduler_init();
   IMB_init();
 
   BKE_images_init();
@@ -820,9 +823,6 @@ int main(int argc,
   RE_texture_rng_init();
 
   BKE_callback_global_init();
-
-  /* After parsing number of threads argument. */
-  BLI_task_scheduler_init();
 
   RNA_init();
 

--- a/source/gameengine/Ketsji/KX_BlenderCanvas.cpp
+++ b/source/gameengine/Ketsji/KX_BlenderCanvas.cpp
@@ -46,10 +46,9 @@
 KX_BlenderCanvas::KX_BlenderCanvas(RAS_Rasterizer *rasty,
                                    wmWindowManager *wm,
                                    wmWindow *win,
-                                   Scene *startscene,
                                    rcti *viewport,
                                    struct ARegion *ar)
-    : RAS_ICanvas(rasty), m_wm(wm), m_win(win), m_startScene(startscene), m_ar(ar)
+    : RAS_ICanvas(rasty), m_wm(wm), m_win(win), m_ar(ar)
 {
   m_frame = 1;
 
@@ -203,9 +202,4 @@ void KX_BlenderCanvas::MakeScreenShot(const std::string &filename)
 bool KX_BlenderCanvas::IsBlenderPlayer()
 {
   return false;
-}
-
-Scene *KX_BlenderCanvas::GetStartScene()
-{
-  return m_startScene;
 }

--- a/source/gameengine/Ketsji/KX_BlenderCanvas.h
+++ b/source/gameengine/Ketsji/KX_BlenderCanvas.h
@@ -56,7 +56,6 @@ class KX_BlenderCanvas : public RAS_ICanvas {
 
   wmWindowManager *m_wm;
   wmWindow *m_win;
-  Scene *m_startScene;
   RAS_Rect m_area_rect;
   ARegion *m_ar;
 
@@ -68,7 +67,6 @@ class KX_BlenderCanvas : public RAS_ICanvas {
   KX_BlenderCanvas(RAS_Rasterizer *rasty,
                    wmWindowManager *wm,
                    wmWindow *win,
-                   Scene *startscene,
                    rcti *viewport,
                    ARegion *ar);
   virtual ~KX_BlenderCanvas();
@@ -100,8 +98,6 @@ class KX_BlenderCanvas : public RAS_ICanvas {
   virtual void EndDraw();
 
   virtual bool IsBlenderPlayer();
-
-  virtual Scene *GetStartScene();
 };
 
 #endif  // __KX_BLENDERCANVAS_H__

--- a/source/gameengine/Ketsji/KX_BlenderMaterial.cpp
+++ b/source/gameengine/Ketsji/KX_BlenderMaterial.cpp
@@ -59,9 +59,7 @@ KX_BlenderMaterial::KX_BlenderMaterial(RAS_Rasterizer *rasty,
    * (m_textures list won't be available for these object)
    */
   if (m_material->use_nodes && m_material->nodetree && !converting_during_runtime) {
-    RAS_ICanvas *canvas = KX_GetActiveEngine()->GetCanvas();
-    if ((m_scene->GetBlenderScene()->gm.flag & GAME_USE_VIEWPORT_RENDER) == 0 ||
-        canvas->IsBlenderPlayer()) {
+    if ((m_scene->GetBlenderScene()->gm.flag & GAME_USE_VIEWPORT_RENDER) == 0) {
       EEVEE_Data *vedata = EEVEE_engine_data_get();
       EEVEE_EffectsInfo *effects = vedata->stl->effects;
       const bool use_ssrefract = ((m_material->blend_flag & MA_BL_SS_REFRACTION) != 0) &&

--- a/source/gameengine/Ketsji/KX_KetsjiEngine.cpp
+++ b/source/gameengine/Ketsji/KX_KetsjiEngine.cpp
@@ -1292,8 +1292,8 @@ KX_Scene *KX_KetsjiEngine::CreateScene(const std::string &scenename)
 bool KX_KetsjiEngine::ReplaceScene(const std::string &oldscene, const std::string &newscene)
 {
   bool useViewportRender = (m_scenes->GetFront()->GetBlenderScene()->gm.flag & GAME_USE_VIEWPORT_RENDER) != 0;
-  if (useViewportRender) {
-    std::cout << "Replace Scene is not available in viewport render mode." << std::endl;
+  if (useViewportRender && !m_canvas->IsBlenderPlayer()) {
+    std::cout << "Replace Scene is not available in viewport render mode in embedded." << std::endl;
     return false;
   }
   // Don't allow replacement if the new scene doesn't exist.

--- a/source/gameengine/Ketsji/KX_KetsjiEngine.cpp
+++ b/source/gameengine/Ketsji/KX_KetsjiEngine.cpp
@@ -296,6 +296,51 @@ void KX_KetsjiEngine::EndFrame()
   m_canvas->EndDraw();
 }
 
+void KX_KetsjiEngine::EndFrameViewportRender()
+{
+  // Show profiling info
+  m_logger.StartLog(tc_overhead, m_kxsystem->GetTimeInSeconds());
+  if (m_flags & (SHOW_PROFILE | SHOW_FRAMERATE | SHOW_DEBUG_PROPERTIES)) {
+    RenderDebugProperties();
+  }
+
+  m_rasterizer->FlushDebugDraw(m_canvas);
+
+  double tottime = m_logger.GetAverage();
+  if (tottime < 1e-6)
+    tottime = 1e-6;
+
+#ifdef WITH_PYTHON
+  for (int i = tc_first; i < tc_numCategories; ++i) {
+    double time = m_logger.GetAverage((KX_TimeCategory)i);
+    PyObject *val = PyTuple_New(2);
+    PyTuple_SetItem(val, 0, PyFloat_FromDouble(time * 1000.0));
+    PyTuple_SetItem(val, 1, PyFloat_FromDouble(time / tottime * 100.0));
+
+    PyDict_SetItemString(m_pyprofiledict, m_profileLabels[i].c_str(), val);
+    Py_DECREF(val);
+  }
+#endif
+
+  m_average_framerate = 1.0 / tottime;
+
+  // Go to next profiling measurement, time spent after this call is shown in the next frame.
+  m_logger.NextMeasurement(m_kxsystem->GetTimeInSeconds());
+
+  m_logger.StartLog(tc_rasterizer, m_kxsystem->GetTimeInSeconds());
+  m_rasterizer->EndFrame();
+
+  m_logger.StartLog(tc_logic, m_kxsystem->GetTimeInSeconds());
+  m_canvas->FlushScreenshots();
+
+  // swap backbuffer (drawing into this buffer) <-> front/visible buffer
+  m_logger.StartLog(tc_latency, m_kxsystem->GetTimeInSeconds());
+  //m_canvas->SwapBuffers();
+  m_logger.StartLog(tc_rasterizer, m_kxsystem->GetTimeInSeconds());
+
+  m_canvas->EndDraw();
+}
+
 bool KX_KetsjiEngine::NextFrame()
 {
   m_logger.StartLog(tc_services, m_kxsystem->GetTimeInSeconds());
@@ -693,6 +738,9 @@ void KX_KetsjiEngine::Render()
     GPU_apply_state();
     EndFrame();
   }
+  else {
+    EndFrameViewportRender();
+  }
 }
 
 void KX_KetsjiEngine::RequestExit(KX_ExitRequest exitrequestmode)
@@ -941,15 +989,6 @@ void KX_KetsjiEngine::RenderCamera(KX_Scene *scene,
     m_rasterizer->Enable(RAS_Rasterizer::RAS_BLEND);
     m_rasterizer->SetBlendFunc(RAS_Rasterizer::RAS_ONE, RAS_Rasterizer::RAS_ONE_MINUS_SRC_ALPHA);
   }
-
-  // Show profiling info
-  m_logger.StartLog(tc_overhead, m_kxsystem->GetTimeInSeconds());
-  if (m_flags & (SHOW_PROFILE | SHOW_FRAMERATE | SHOW_DEBUG_PROPERTIES)) {
-    RenderDebugProperties();
-  }
-
-  // TODO: Rework that
-  m_rasterizer->FlushDebugDraw(m_canvas);
 
   scene->RenderAfterCameraSetup(rendercam, viewport, is_overlay_pass);
 

--- a/source/gameengine/Ketsji/KX_KetsjiEngine.cpp
+++ b/source/gameengine/Ketsji/KX_KetsjiEngine.cpp
@@ -680,7 +680,7 @@ void KX_KetsjiEngine::Render()
     }
   }
   Scene *first_scene = m_scenes->GetFront()->GetBlenderScene();
-  if (!(first_scene->gm.flag & GAME_USE_VIEWPORT_RENDER && !m_canvas->IsBlenderPlayer())) {
+  if (!(first_scene->gm.flag & GAME_USE_VIEWPORT_RENDER)) {
     int v[4];
     v[0] = m_canvas->GetViewportArea().GetLeft();
     v[1] = m_canvas->GetViewportArea().GetBottom();
@@ -1242,6 +1242,11 @@ KX_Scene *KX_KetsjiEngine::CreateScene(const std::string &scenename)
 
 bool KX_KetsjiEngine::ReplaceScene(const std::string &oldscene, const std::string &newscene)
 {
+  bool useViewportRender = (m_scenes->GetFront()->GetBlenderScene()->gm.flag & GAME_USE_VIEWPORT_RENDER) != 0;
+  if (useViewportRender) {
+    std::cout << "Replace Scene is not available in viewport render mode." << std::endl;
+    return false;
+  }
   // Don't allow replacement if the new scene doesn't exist.
   // Allows smarter game design (used to have no check here).
   // Note that it creates a small backward compatbility issue

--- a/source/gameengine/Ketsji/KX_KetsjiEngine.cpp
+++ b/source/gameengine/Ketsji/KX_KetsjiEngine.cpp
@@ -941,6 +941,16 @@ void KX_KetsjiEngine::RenderCamera(KX_Scene *scene,
     m_rasterizer->Enable(RAS_Rasterizer::RAS_BLEND);
     m_rasterizer->SetBlendFunc(RAS_Rasterizer::RAS_ONE, RAS_Rasterizer::RAS_ONE_MINUS_SRC_ALPHA);
   }
+
+  // Show profiling info
+  m_logger.StartLog(tc_overhead, m_kxsystem->GetTimeInSeconds());
+  if (m_flags & (SHOW_PROFILE | SHOW_FRAMERATE | SHOW_DEBUG_PROPERTIES)) {
+    RenderDebugProperties();
+  }
+
+  // TODO: Rework that
+  m_rasterizer->FlushDebugDraw(m_canvas);
+
   scene->RenderAfterCameraSetup(rendercam, viewport, is_overlay_pass);
 
   if (scene->GetPhysicsEnvironment()) {

--- a/source/gameengine/Ketsji/KX_KetsjiEngine.h
+++ b/source/gameengine/Ketsji/KX_KetsjiEngine.h
@@ -279,6 +279,7 @@ class KX_KetsjiEngine {
   // include depsgraph time in tc_depsgraph category
   void CountDepsgraphTime();
   void EndCountDepsgraphTime();
+  void EndFrameViewportRender();
   /* End of EEVEE integration */
 
   void EndFrame();

--- a/source/gameengine/Ketsji/KX_Scene.cpp
+++ b/source/gameengine/Ketsji/KX_Scene.cpp
@@ -459,7 +459,9 @@ void KX_Scene::BackupShadingType()
   Scene *scene = GetBlenderScene();
 
   /* Only if we are not in viewport render, modify + backup shading types */
-  if ((scene->gm.flag & GAME_USE_VIEWPORT_RENDER) == 0) {
+  RAS_ICanvas *canvas = KX_GetActiveEngine()->GetCanvas();
+  bool useViewportInBlenderplayer = (scene->gm.flag & GAME_USE_VIEWPORT_RENDER) != 0 && canvas->IsBlenderPlayer();
+  if ((scene->gm.flag & GAME_USE_VIEWPORT_RENDER) == 0 || useViewportInBlenderplayer) {
 
     View3D *v3d = CTX_wm_view3d(C);
 
@@ -469,7 +471,8 @@ void KX_Scene::BackupShadingType()
       m_shadingTypeBackup = v3d->shading.type;
       m_shadingFlagBackup = v3d->shading.flag;
       v3d->shading.type = OB_RENDER;
-      v3d->shading.flag |= (V3D_SHADING_SCENE_LIGHTS_RENDER | V3D_SHADING_SCENE_WORLD_RENDER);
+      v3d->shading.flag |= (V3D_SHADING_SCENE_WORLD_RENDER | V3D_SHADING_SCENE_LIGHTS_RENDER);
+      v3d->flag2 |= V3D_HIDE_OVERLAYS;
     }
   }
 }

--- a/source/gameengine/Ketsji/KX_Scene.cpp
+++ b/source/gameengine/Ketsji/KX_Scene.cpp
@@ -471,6 +471,7 @@ void KX_Scene::BackupShadingType()
       m_shadingTypeBackup = v3d->shading.type;
       m_shadingFlagBackup = v3d->shading.flag;
       v3d->shading.type = OB_RENDER;
+      //v3d->drawtype = OB_RENDER;
       v3d->shading.flag = (V3D_SHADING_SCENE_WORLD_RENDER | V3D_SHADING_SCENE_LIGHTS_RENDER);
       v3d->flag2 |= V3D_HIDE_OVERLAYS;
     }

--- a/source/gameengine/Ketsji/KX_Scene.cpp
+++ b/source/gameengine/Ketsji/KX_Scene.cpp
@@ -470,7 +470,7 @@ void KX_Scene::BackupShadingType()
     if (not_eevee) {
       m_shadingTypeBackup = v3d->shading.type;
       m_shadingFlagBackup = v3d->shading.flag;
-      v3d->shading.type = OB_RENDER;
+      v3d->drawtype = OB_RENDER;
       v3d->shading.flag |= (V3D_SHADING_SCENE_WORLD_RENDER | V3D_SHADING_SCENE_LIGHTS_RENDER);
       v3d->flag2 |= V3D_HIDE_OVERLAYS;
     }

--- a/source/gameengine/Ketsji/KX_Scene.cpp
+++ b/source/gameengine/Ketsji/KX_Scene.cpp
@@ -272,7 +272,6 @@ KX_Scene::~KX_Scene()
   m_isRuntime = false;  // eevee
 
   Scene *scene = GetBlenderScene();
-  RAS_ICanvas *canvas = KX_GetActiveEngine()->GetCanvas();
   ViewLayer *view_layer = BKE_view_layer_default_view(scene);
   bContext *C = KX_GetActiveEngine()->GetContext();
   Main *bmain = CTX_data_main(C);
@@ -288,9 +287,6 @@ KX_Scene::~KX_Scene()
       /* This will free m_gpuViewport and m_gpuOffScreen */
       DRW_game_render_loop_end();
     }
-    else if (canvas->IsBlenderPlayer() && (scene->gm.flag & GAME_USE_VIEWPORT_RENDER) != 0) {
-      DRW_game_render_loop_end();
-    }
     else {
       /* It has not been freed before because the main Render loop
        * is not executed then we free it now.
@@ -298,6 +294,10 @@ KX_Scene::~KX_Scene()
       GPU_viewport_free(m_initMaterialsGPUViewport);
       DRW_game_python_loop_end(DEG_get_evaluated_view_layer(depsgraph));
     }
+  }
+  else {
+    // Free the allocated profile a last time
+    DRW_game_viewport_render_loop_end();
   }
 
   for (Object *hiddenOb : m_hiddenObjectsDuringRuntime) {

--- a/source/gameengine/Ketsji/KX_Scene.cpp
+++ b/source/gameengine/Ketsji/KX_Scene.cpp
@@ -470,8 +470,8 @@ void KX_Scene::BackupShadingType()
     if (not_eevee) {
       m_shadingTypeBackup = v3d->shading.type;
       m_shadingFlagBackup = v3d->shading.flag;
-      v3d->drawtype = OB_RENDER;
-      v3d->shading.flag |= (V3D_SHADING_SCENE_WORLD_RENDER | V3D_SHADING_SCENE_LIGHTS_RENDER);
+      v3d->shading.type = OB_RENDER;
+      v3d->shading.flag = (V3D_SHADING_SCENE_WORLD_RENDER | V3D_SHADING_SCENE_LIGHTS_RENDER);
       v3d->flag2 |= V3D_HIDE_OVERLAYS;
     }
   }

--- a/source/gameengine/Ketsji/KX_Scene.cpp
+++ b/source/gameengine/Ketsji/KX_Scene.cpp
@@ -279,10 +279,6 @@ KX_Scene::~KX_Scene()
   View3D *v3d = CTX_wm_view3d(C);
 
   if ((scene->gm.flag & GAME_USE_VIEWPORT_RENDER) == 0) {
-    if (m_shadingTypeBackup != 0) {
-      v3d->shading.type = m_shadingTypeBackup;
-      v3d->shading.flag = m_shadingFlagBackup;
-    }
     if (!m_isPythonMainLoop) {
       /* This will free m_gpuViewport and m_gpuOffScreen */
       DRW_game_render_loop_end();
@@ -298,6 +294,11 @@ KX_Scene::~KX_Scene()
   else {
     // Free the allocated profile a last time
     DRW_game_viewport_render_loop_end();
+  }
+
+  if (m_shadingTypeBackup != 0) {
+    v3d->shading.type = m_shadingTypeBackup;
+    v3d->shading.flag = m_shadingFlagBackup;
   }
 
   for (Object *hiddenOb : m_hiddenObjectsDuringRuntime) {

--- a/source/gameengine/Ketsji/KX_Scene.cpp
+++ b/source/gameengine/Ketsji/KX_Scene.cpp
@@ -271,6 +271,8 @@ KX_Scene::~KX_Scene()
 
   m_isRuntime = false;  // eevee
 
+  ReinitBlenderContextVariables();
+
   Scene *scene = GetBlenderScene();
   ViewLayer *view_layer = BKE_view_layer_default_view(scene);
   bContext *C = KX_GetActiveEngine()->GetContext();

--- a/source/gameengine/Ketsji/KX_Scene.cpp
+++ b/source/gameengine/Ketsji/KX_Scene.cpp
@@ -677,9 +677,10 @@ void KX_Scene::RenderAfterCameraSetup(KX_Camera *cam, const RAS_Rect &viewport, 
 
   bool useViewportInBlenderplayer = canvas->IsBlenderPlayer() &&
                                      scene->gm.flag & GAME_USE_VIEWPORT_RENDER;
+  bool useViewportRender = scene->gm.flag & GAME_USE_VIEWPORT_RENDER;
 
   if (cam && (useViewportInBlenderplayer || scene->flag & SCE_INTERACTIVE)) {
-    if (useViewportInBlenderplayer) {
+    if (useViewportRender) {
       /* When we call wm_draw_update, bContext variables are unset,
        * then we need to set it again correctly to render the next frame.
        */

--- a/source/gameengine/Launcher/LA_BlenderLauncher.cpp
+++ b/source/gameengine/Launcher/LA_BlenderLauncher.cpp
@@ -71,10 +71,9 @@ LA_BlenderLauncher::~LA_BlenderLauncher()
 {
 }
 
-RAS_ICanvas *LA_BlenderLauncher::CreateCanvas(Scene *startscene)
+RAS_ICanvas *LA_BlenderLauncher::CreateCanvas()
 {
-  return (
-      new KX_BlenderCanvas(m_rasterizer, m_windowManager, m_window, startscene, m_camFrame, m_ar));
+  return (new KX_BlenderCanvas(m_rasterizer, m_windowManager, m_window, m_camFrame, m_ar));
 }
 
 bool LA_BlenderLauncher::GetUseAlwaysExpandFraming()

--- a/source/gameengine/Launcher/LA_BlenderLauncher.h
+++ b/source/gameengine/Launcher/LA_BlenderLauncher.h
@@ -54,7 +54,7 @@ class LA_BlenderLauncher : public LA_Launcher {
 
   virtual void RenderEngine();
 
-  virtual RAS_ICanvas *CreateCanvas(Scene *startscene);
+  virtual RAS_ICanvas *CreateCanvas();
   virtual bool GetUseAlwaysExpandFraming();
   virtual void InitCamera();
   virtual void InitPython();

--- a/source/gameengine/Launcher/LA_Launcher.cpp
+++ b/source/gameengine/Launcher/LA_Launcher.cpp
@@ -164,7 +164,7 @@ void LA_Launcher::InitEngine()
   m_savedData.mipmap = m_rasterizer->GetMipmapping();
 
   // Create the canvas, rasterizer and rendertools.
-  m_canvas = CreateCanvas(m_startScene);
+  m_canvas = CreateCanvas();
 
   // Copy current vsync mode to restore at the game end.
   m_canvas->GetSwapInterval(m_savedData.vsync);

--- a/source/gameengine/Launcher/LA_Launcher.h
+++ b/source/gameengine/Launcher/LA_Launcher.h
@@ -125,7 +125,7 @@ class LA_Launcher {
   virtual void RunPythonMainLoop(const std::string &pythonCode);
 #endif  // WITH_PYTHON
 
-  virtual RAS_ICanvas *CreateCanvas(Scene *startscene) = 0;
+  virtual RAS_ICanvas *CreateCanvas() = 0;
   virtual bool GetUseAlwaysExpandFraming() = 0;
   virtual void InitCamera() = 0;
   virtual void InitPython() = 0;

--- a/source/gameengine/Launcher/LA_PlayerLauncher.cpp
+++ b/source/gameengine/Launcher/LA_PlayerLauncher.cpp
@@ -149,7 +149,7 @@ bool LA_PlayerLauncher::EngineNextFrame()
   return LA_Launcher::EngineNextFrame();
 }
 
-RAS_ICanvas *LA_PlayerLauncher::CreateCanvas(Scene *startscene)
+RAS_ICanvas *LA_PlayerLauncher::CreateCanvas()
 {
-  return (new GPG_Canvas(m_rasterizer, m_mainWindow, startscene));
+  return (new GPG_Canvas(m_rasterizer, m_mainWindow));
 }

--- a/source/gameengine/Launcher/LA_PlayerLauncher.h
+++ b/source/gameengine/Launcher/LA_PlayerLauncher.h
@@ -51,7 +51,7 @@ class LA_PlayerLauncher : public LA_Launcher {
   virtual void RunPythonMainLoop(const std::string &pythonCode);
 #endif  // WITH_PYTHON
 
-  virtual RAS_ICanvas *CreateCanvas(Scene *startscene);
+  virtual RAS_ICanvas *CreateCanvas();
   virtual bool GetUseAlwaysExpandFraming();
   virtual void InitCamera();
   virtual void InitPython();

--- a/source/gameengine/Rasterizer/RAS_ICanvas.h
+++ b/source/gameengine/Rasterizer/RAS_ICanvas.h
@@ -73,8 +73,6 @@ class RAS_ICanvas {
 
   virtual bool IsBlenderPlayer() = 0;
 
-  virtual Scene *GetStartScene() = 0;
-
   /// probably needs some arguments for PS2 in future
   virtual void SwapBuffers() = 0;
   virtual void SetSwapInterval(int interval) = 0;

--- a/source/gameengine/Rasterizer/RAS_OpenGLRasterizer/RAS_OpenGLDebugDraw.cpp
+++ b/source/gameengine/Rasterizer/RAS_OpenGLRasterizer/RAS_OpenGLDebugDraw.cpp
@@ -25,6 +25,17 @@
  */
 
 #include "RAS_DebugDraw.h"
+
+#include "BLF_api.h"
+#include "DNA_scene_types.h"
+#include "DRW_render.h"
+#include "GPU_immediate.h"
+#include "GPU_matrix.h"
+
+#include "EXP_ListValue.h"
+#include "KX_Globals.h"
+#include "KX_KetsjiEngine.h"
+#include "RAS_ICanvas.h"
 #include "RAS_OpenGLDebugDraw.h"
 
 #include "draw_debug.h"
@@ -50,7 +61,7 @@ void RAS_OpenGLDebugDraw::Flush(RAS_Rasterizer *rasty,
                                 RAS_DebugDraw *debugDraw)
 {
   //// Draw aabbs USE imm API
-  //for (const RAS_DebugDraw::Aabb &aabb : debugDraw->m_aabbs) {
+  // for (const RAS_DebugDraw::Aabb &aabb : debugDraw->m_aabbs) {
 
   //  const MT_Matrix3x3 &rot = aabb.m_rot;
   //  const MT_Vector3 &pos = aabb.m_pos;
@@ -78,7 +89,8 @@ void RAS_OpenGLDebugDraw::Flush(RAS_Rasterizer *rasty,
   //      (float)min[0], (float)min[1], (float)min[2], (float)max[0], (float)min[1], (float)min[2],
   //      (float)max[0], (float)max[1], (float)min[2], (float)min[0], (float)max[1], (float)min[2],
   //      (float)min[0], (float)min[1], (float)max[2], (float)max[0], (float)min[1], (float)max[2],
-  //      (float)max[0], (float)max[1], (float)max[2], (float)min[0], (float)max[1], (float)max[2]};
+  //      (float)max[0], (float)max[1], (float)max[2], (float)min[0], (float)max[1],
+  //      (float)max[2]};
 
   //  // rasty->PushMatrix();
   //  // rasty->MultMatrix(mat);
@@ -97,7 +109,7 @@ void RAS_OpenGLDebugDraw::Flush(RAS_Rasterizer *rasty,
   //}
 
   //// Draw boxes. USE imm API
-  //for (const RAS_DebugDraw::SolidBox &box : debugDraw->m_solidBoxes) {
+  // for (const RAS_DebugDraw::SolidBox &box : debugDraw->m_solidBoxes) {
   //  GLfloat vertexes[24];
   //  int k = 0;
   //  for (int i = 0; i < 8; i++) {
@@ -127,20 +139,123 @@ void RAS_OpenGLDebugDraw::Flush(RAS_Rasterizer *rasty,
   //  UnbindVBO();*/
   //}
 
-  /* Draw Debug lines */
-  if (debugDraw->m_lines.size()) {
-    for (int i = 0; i < debugDraw->m_lines.size(); i++) {
-      RAS_DebugDraw::Line l = debugDraw->m_lines[i];
-      DRW_debug_line_bge(l.m_from.getValue(), l.m_to.getValue(), l.m_color.getValue());
+  Scene *mainScene = KX_GetActiveEngine()->CurrentScenes()->GetFront()->GetBlenderScene();
+  if (mainScene->gm.flag & GAME_USE_VIEWPORT_RENDER) {
+    /* Draw Debug lines */
+    if (debugDraw->m_lines.size()) {
+      for (int i = 0; i < debugDraw->m_lines.size(); i++) {
+        RAS_DebugDraw::Line l = debugDraw->m_lines[i];
+        DRW_debug_line_bge(l.m_from.getValue(), l.m_to.getValue(), l.m_color.getValue());
+      }
+    }
+    /* The Performances profiler */
+    const unsigned int left = canvas->GetViewportArea().GetLeft();
+    const unsigned int top = canvas->GetViewportArea().GetTop();
+    if (debugDraw->m_boxes2D.size()) {
+      for (const RAS_DebugDraw::Box2D &b : debugDraw->m_boxes2D) {
+        DRW_debug_box_2D_bge(left + b.m_pos[0], top - b.m_pos[1], b.m_size[0], b.m_size[1]);
+      }
+      for (const RAS_DebugDraw::Text2D &t : debugDraw->m_texts2D) {
+        DRW_debug_text_2D_bge(left + t.m_pos[0], top - t.m_pos[1], t.m_text.c_str());
+      }
     }
   }
-  /* The Performances profiler */
-  if (debugDraw->m_boxes2D.size()) {
-    for (const RAS_DebugDraw::Box2D &b : debugDraw->m_boxes2D) {
-      DRW_debug_box_2D_bge(b.m_pos[0], b.m_pos[1], b.m_size[0], b.m_size[1]);
+  else { // Non viewport render pipeline
+    if (!debugDraw->m_lines.empty()) {
+      GPUVertFormat *format = immVertexFormat();
+      uint pos = GPU_vertformat_attr_add(format, "pos", GPU_COMP_F32, 3, GPU_FETCH_FLOAT);
+      uint col = GPU_vertformat_attr_add(format, "color", GPU_COMP_F32, 4, GPU_FETCH_FLOAT);
+      immBindBuiltinProgram(GPU_SHADER_3D_FLAT_COLOR);
+
+      bContext *C = KX_GetActiveEngine()->GetContext();
+      RegionView3D *rv3d = CTX_wm_region_view3d(C);
+      GPU_matrix_push();
+      GPU_matrix_push_projection();
+      GPU_matrix_projection_set(rv3d->winmat);
+      GPU_matrix_set(rv3d->viewmat);
+
+      GPU_depth_test(GPU_DEPTH_ALWAYS);
+      GPU_line_smooth(true);
+      GPU_line_width(1.0f);
+      immBegin(GPU_PRIM_LINES, 2 * debugDraw->m_lines.size());
+      for (int i = 0; i < debugDraw->m_lines.size(); i++) {
+        RAS_DebugDraw::Line line = debugDraw->m_lines[i];
+        const MT_Vector3 &min = line.m_from;
+        const MT_Vector3 &max = line.m_to;
+        immAttr4fv(col, line.m_color.getValue());
+        immVertex3fv(pos, min.getValue());
+        immVertex3fv(pos, max.getValue());
+      }
+      immEnd();
+
+      /* Reset defaults */
+      GPU_line_smooth(false);
+      GPU_matrix_pop();
+      GPU_matrix_pop_projection();
+      GPU_depth_test(GPU_DEPTH_ALWAYS);
+      GPU_face_culling(GPU_CULL_NONE);
+
+      immUnbindProgram();
     }
-    for (const RAS_DebugDraw::Text2D &t : debugDraw->m_texts2D) {
-      DRW_debug_text_2D_bge(t.m_pos[0], t.m_pos[1], t.m_text.c_str());
+
+#ifdef WITH_PYTHON
+    KX_GetActiveScene()->RunDrawingCallbacks(KX_Scene::POST_DRAW, nullptr);
+#endif
+
+    DRW_state_reset();
+    GPU_depth_test(GPU_DEPTH_ALWAYS);
+
+    /* The Performances profiler */
+
+    const unsigned int width = canvas->GetWidth();
+    const unsigned int height = canvas->GetHeight();
+
+    if (!debugDraw->m_boxes2D.empty()) {
+      GPU_face_culling(GPU_CULL_BACK);
+
+      GPUVertFormat *format = immVertexFormat();
+      uint pos = GPU_vertformat_attr_add(format, "pos", GPU_COMP_F32, 2, GPU_FETCH_FLOAT);
+
+      immBindBuiltinProgram(GPU_SHADER_2D_UNIFORM_COLOR);
+      for (const RAS_DebugDraw::Box2D &box2d : debugDraw->m_boxes2D) {
+        const float xco = box2d.m_pos.x();
+        const float yco = height - box2d.m_pos.y();
+        const float xsize = box2d.m_size.x();
+        const float ysize = box2d.m_size.y();
+
+        immUniformColor4fv(box2d.m_color.getValue());
+        immRectf(pos, xco + 1 + xsize, yco + ysize, xco, yco);
+      }
+      immUnbindProgram();
+
+      DRW_state_reset();
+      GPU_depth_test(GPU_DEPTH_ALWAYS);
+    }
+
+    if (!debugDraw->m_texts2D.empty()) {
+
+      BLF_size(blf_mono_font, 11, 72);
+
+      BLF_enable(blf_mono_font, BLF_SHADOW);
+
+      static float black[4] = {0.0f, 0.0f, 0.0f, 1.0f};
+      BLF_shadow(blf_mono_font, 1, black);
+      BLF_shadow_offset(blf_mono_font, 1, 1);
+
+      for (const RAS_DebugDraw::Text2D &text2d : debugDraw->m_texts2D) {
+        std::string text = text2d.m_text;
+        const float xco = text2d.m_pos.x();
+        const float yco = height - text2d.m_pos.y();
+        float col[4];
+        text2d.m_color.getValue(col);
+
+        BLF_color4fv(blf_mono_font, col);
+        BLF_position(blf_mono_font, xco, yco, 0.0f);
+        BLF_draw(blf_mono_font, text.c_str(), text.size());
+      }
+      BLF_disable(blf_mono_font, BLF_SHADOW);
+      GPU_depth_test(GPU_DEPTH_ALWAYS);
+      GPU_face_culling(GPU_CULL_NONE);
     }
   }
 }

--- a/source/gameengine/Rasterizer/RAS_OpenGLRasterizer/RAS_OpenGLDebugDraw.cpp
+++ b/source/gameengine/Rasterizer/RAS_OpenGLRasterizer/RAS_OpenGLDebugDraw.cpp
@@ -142,7 +142,7 @@ void RAS_OpenGLDebugDraw::Flush(RAS_Rasterizer *rasty,
   Scene *mainScene = KX_GetActiveEngine()->CurrentScenes()->GetFront()->GetBlenderScene();
   if (mainScene->gm.flag & GAME_USE_VIEWPORT_RENDER) {
     /* Draw Debug lines */
-    if (debugDraw->m_lines.size()) {
+    if (!debugDraw->m_lines.empty()) {
       for (int i = 0; i < debugDraw->m_lines.size(); i++) {
         RAS_DebugDraw::Line l = debugDraw->m_lines[i];
         DRW_debug_line_bge(l.m_from.getValue(), l.m_to.getValue(), l.m_color.getValue());
@@ -151,10 +151,12 @@ void RAS_OpenGLDebugDraw::Flush(RAS_Rasterizer *rasty,
     /* The Performances profiler */
     const unsigned int left = canvas->GetViewportArea().GetLeft();
     const unsigned int top = canvas->GetViewportArea().GetTop();
-    if (debugDraw->m_boxes2D.size()) {
+    if (!debugDraw->m_boxes2D.empty()) {
       for (const RAS_DebugDraw::Box2D &b : debugDraw->m_boxes2D) {
         DRW_debug_box_2D_bge(left + b.m_pos[0], top - b.m_pos[1], b.m_size[0], b.m_size[1]);
       }
+    }
+    if (!debugDraw->m_texts2D.empty()) {
       for (const RAS_DebugDraw::Text2D &t : debugDraw->m_texts2D) {
         DRW_debug_text_2D_bge(left + t.m_pos[0], top - t.m_pos[1], t.m_text.c_str());
       }

--- a/source/gameengine/Rasterizer/RAS_OpenGLRasterizer/RAS_OpenGLDebugDraw.cpp
+++ b/source/gameengine/Rasterizer/RAS_OpenGLRasterizer/RAS_OpenGLDebugDraw.cpp
@@ -24,16 +24,10 @@
  *  \ingroup bgerastogl
  */
 
+#include "RAS_DebugDraw.h"
 #include "RAS_OpenGLDebugDraw.h"
 
-#include "BLF_api.h"
-#include "DRW_render.h"
-#include "GPU_immediate.h"
-#include "GPU_matrix.h"
-
-#include "KX_Camera.h"
-#include "KX_Globals.h"
-#include "RAS_ICanvas.h"
+#include "draw_debug.h"
 
 RAS_OpenGLDebugDraw::RAS_OpenGLDebugDraw()
 {
@@ -134,101 +128,19 @@ void RAS_OpenGLDebugDraw::Flush(RAS_Rasterizer *rasty,
   //}
 
   /* Draw Debug lines */
-
-  if (!debugDraw->m_lines.empty()) {
-    GPUVertFormat *format = immVertexFormat();
-    uint pos = GPU_vertformat_attr_add(format, "pos", GPU_COMP_F32, 3, GPU_FETCH_FLOAT);
-    uint col = GPU_vertformat_attr_add(format, "color", GPU_COMP_F32, 4, GPU_FETCH_FLOAT);
-    immBindBuiltinProgram(GPU_SHADER_3D_FLAT_COLOR);
-
-    bContext *C = KX_GetActiveEngine()->GetContext();
-    RegionView3D *rv3d = CTX_wm_region_view3d(C);
-    GPU_matrix_push();
-    GPU_matrix_push_projection();
-    GPU_matrix_projection_set(rv3d->winmat);
-    GPU_matrix_set(rv3d->viewmat);
-
-    GPU_depth_test(GPU_DEPTH_ALWAYS);
-    GPU_line_smooth(true);
-    GPU_line_width(1.0f);
-    immBegin(GPU_PRIM_LINES, 2 * debugDraw->m_lines.size());
+  if (debugDraw->m_lines.size()) {
     for (int i = 0; i < debugDraw->m_lines.size(); i++) {
-      RAS_DebugDraw::Line line = debugDraw->m_lines[i];
-      const MT_Vector3 &min = line.m_from;
-      const MT_Vector3 &max = line.m_to;
-      immAttr4fv(col, line.m_color.getValue());
-      immVertex3fv(pos, min.getValue());
-      immVertex3fv(pos, max.getValue());
+      RAS_DebugDraw::Line l = debugDraw->m_lines[i];
+      DRW_debug_line_bge(l.m_from.getValue(), l.m_to.getValue(), l.m_color.getValue());
     }
-    immEnd();
-
-    /* Reset defaults */
-    GPU_line_smooth(false);
-    GPU_matrix_pop();
-    GPU_matrix_pop_projection();
-    GPU_depth_test(GPU_DEPTH_ALWAYS);
-    GPU_face_culling(GPU_CULL_NONE);
-
-    immUnbindProgram();
   }
-
-#ifdef WITH_PYTHON
-  KX_GetActiveScene()->RunDrawingCallbacks(KX_Scene::POST_DRAW, nullptr);
-#endif
-
-  DRW_state_reset();
-  GPU_depth_test(GPU_DEPTH_ALWAYS);
-
   /* The Performances profiler */
-
-  const unsigned int width = canvas->GetWidth();
-  const unsigned int height = canvas->GetHeight();
-
-  if (!debugDraw->m_boxes2D.empty()) {
-    GPU_face_culling(GPU_CULL_BACK);
-
-    GPUVertFormat *format = immVertexFormat();
-    uint pos = GPU_vertformat_attr_add(format, "pos", GPU_COMP_F32, 2, GPU_FETCH_FLOAT);
-
-    immBindBuiltinProgram(GPU_SHADER_2D_UNIFORM_COLOR);
-    for (const RAS_DebugDraw::Box2D &box2d : debugDraw->m_boxes2D) {
-      const float xco = box2d.m_pos.x();
-      const float yco = height - box2d.m_pos.y();
-      const float xsize = box2d.m_size.x();
-      const float ysize = box2d.m_size.y();
-
-      immUniformColor4fv(box2d.m_color.getValue());
-      immRectf(pos, xco + 1 + xsize, yco + ysize, xco, yco);
+  if (debugDraw->m_boxes2D.size()) {
+    for (const RAS_DebugDraw::Box2D &b : debugDraw->m_boxes2D) {
+      DRW_debug_box_2D_bge(b.m_pos[0], b.m_pos[1], b.m_size[0], b.m_size[1]);
     }
-    immUnbindProgram();
-
-    DRW_state_reset();
-    GPU_depth_test(GPU_DEPTH_ALWAYS);
-  }
-
-  if (!debugDraw->m_texts2D.empty()) {
-
-    BLF_size(blf_mono_font, 11, 72);
-
-    BLF_enable(blf_mono_font, BLF_SHADOW);
-
-    static float black[4] = {0.0f, 0.0f, 0.0f, 1.0f};
-    BLF_shadow(blf_mono_font, 1, black);
-    BLF_shadow_offset(blf_mono_font, 1, 1);
-
-    for (const RAS_DebugDraw::Text2D &text2d : debugDraw->m_texts2D) {
-      std::string text = text2d.m_text;
-      const float xco = text2d.m_pos.x();
-      const float yco = height - text2d.m_pos.y();
-      float col[4];
-      text2d.m_color.getValue(col);
-
-      BLF_color4fv(blf_mono_font, col);
-      BLF_position(blf_mono_font, xco, yco, 0.0f);
-      BLF_draw(blf_mono_font, text.c_str(), text.size());
+    for (const RAS_DebugDraw::Text2D &t : debugDraw->m_texts2D) {
+      DRW_debug_text_2D_bge(t.m_pos[0], t.m_pos[1], t.m_text.c_str());
     }
-    BLF_disable(blf_mono_font, BLF_SHADOW);
-    GPU_depth_test(GPU_DEPTH_ALWAYS);
-    GPU_face_culling(GPU_CULL_NONE);
   }
 }


### PR DESCRIPTION
For now, I allowed only one scene because:
- Replace scene in blenderplayer viewport render generates mem leaks
- There are other few issues related to shading...

I didn't change the behaviour of viewport render in embedded.

In blenderplayer, we can use lookdev and eevee but not workbench (Because if we do nothing to change the shading type at ge start, workbench and lookdev work but not eevee...)

In blenderplayer, I hide overlays (grid, outlines...) drawing.

2D filters, ImageRender, overlay scenes, custom viewports... are not available in viewport render mode.

But stereo works and I guess virtual reality too and this is the main advantages.

Note: Why do we "need" 2 render implementations:

- Because old bge renders are done with cameras (for ImageRender, custom bge viewports, overlay collections...)
Then we choosed to use our own GPUViewports based on cameras settings.
- Because we need our own render loop to have things like overlay collections... working.

Blender render loop has its own GPUViewports but they are not based on Cameras, they are attached to ARegion (ARegion->draw_buffer->viewport[view] iirc). So this is not the same system than bge.
When we use "viewport render" option, we reuse these GPUViewports and we haven't our own GPUViewports.
It is easier to do like that but we can't have the old bge specificities (at least without work).