### PR TITLE
UPBGE: Restore old collision behaviour

### DIFF
--- a/doc/python_api/rst/bge.constraints.rst
+++ b/doc/python_api/rst/bge.constraints.rst
@@ -162,6 +162,40 @@ Functions
    :arg time: The deactivation time.
    :type time: float
 
+.. function:: setERPNonContact(erp)
+
+   Sets the Error Reduction Parameter (ERP) for non-contact constraints.
+   The Error Reduction Parameter (ERP) specifies what proportion of the joint error will be fixed during the next simulation step.
+   If ERP = 0.0 then no correcting force is applied and the bodies will eventually drift apart as the simulation proceeds.
+   If ERP = 1.0 then the simulation will attempt to fix all joint error during the next time step.
+   However, setting ERP = 1.0 is not recommended, as the joint error will not be completely fixed due to various internal approximations.
+   A value of ERP = 0.1 to 0.8 is recommended.
+
+   :arg erp: The ERP parameter for non-contact constraints.
+   :type erp: float [0.0, 1.0]
+
+.. function:: setERPContact(erp2)
+
+   Sets the Error Reduction Parameter (ERP) for contact constraints.
+   The Error Reduction Parameter (ERP) specifies what proportion of the joint error will be fixed during the next simulation step.
+   If ERP = 0.0 then no correcting force is applied and the bodies will eventually drift apart as the simulation proceeds.
+   If ERP = 1.0 then the simulation will attempt to fix all joint error during the next time step.
+   However, setting ERP = 1.0 is not recommended, as the joint error will not be completely fixed due to various internal approximations.
+   A value of ERP = 0.1 to 0.8 is recommended.
+
+   :arg erp2: The ERP parameter for contact constraints.
+   :type erp2: float [0.0, 1.0]
+
+.. function:: setCFM(cfm)
+
+   Sets the Constraint Force Mixing (CFM) for soft constraints.
+   If the Constraint Force Mixing (CFM) is set to zero, the constraint will be hard.
+   If CFM is set to a positive value, it will be possible to violate the constraint by pushing on it (for example, for contact constraints by forcing the two contacting objects together).
+   In other words the constraint will be soft, and the softness will increase as CFM increases.
+
+   :arg cfm: The CFM parameter for soft constraints.
+   :type cfm: float [0.0, 10000.0]
+
 .. function:: setDebugMode(mode)
 
    Sets the debug mode.

--- a/doc/python_api/rst/bge.constraints.rst
+++ b/doc/python_api/rst/bge.constraints.rst
@@ -217,12 +217,6 @@ Functions
    :arg z: Gravity Z force.
    :type z: float
 
-.. function:: setLinearAirDamping(damping)
-
-   .. note::
-
-      Not implemented
-
    Sets the linear air damping for rigidbodies.
 
 .. function:: setNumIterations(numiter)
@@ -278,12 +272,6 @@ Functions
 
    :arg sor: New sor value.
    :type sor: float
-
-.. function:: setUseEpa(epa)
-
-   .. note::
-
-      Not implemented
 
 
 Constants

--- a/extern/bullet2/CMakeLists.txt
+++ b/extern/bullet2/CMakeLists.txt
@@ -26,7 +26,11 @@ if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_C_COMPILER_ID MATCHES "Clang")
 endif()
 
 # Use double precision to make simulations of small objects stable.
-add_definitions(-DBT_USE_DOUBLE_PRECISION)
+# UPBGE - to recover double precision uncomment this definition, intern/rigidbody/CMakeLists.txt one
+# and source/gameengine/Physics/Bullet/CMakeLists.txt one.
+# Double precision is slower than float one but it will increase the precision in
+# open worlds games bigger than 10Km.
+#add_definitions(-DBT_USE_DOUBLE_PRECISION)
 
 set(INC
   .

--- a/extern/bullet2/patches/collision_behaviour.patch
+++ b/extern/bullet2/patches/collision_behaviour.patch
@@ -1,0 +1,11 @@
+--- extern/bullet2/src/BulletDynamics/ConstraintSolver/btContactSolverInfo.h
++++ extern/bullet2/src/BulletDynamics/ConstraintSolver/btContactSolverInfo.h
+@@ -84,7 +84,7 @@ struct btContactSolverInfo : public btContactSolverInfoData
+ 		m_maxErrorReduction = btScalar(20.);
+ 		m_numIterations = 10;
+ 		m_erp = btScalar(0.2);
+-		m_erp2 = btScalar(0.2);
++		m_erp2 = btScalar(0.8);
+ 		m_deformable_erp = btScalar(0.06);
+ 		m_deformable_cfm = btScalar(0.01);
+ 		m_deformable_maxErrorReduction = btScalar(0.1);

--- a/extern/bullet2/src/BulletDynamics/ConstraintSolver/btContactSolverInfo.h
+++ b/extern/bullet2/src/BulletDynamics/ConstraintSolver/btContactSolverInfo.h
@@ -84,7 +84,7 @@ struct btContactSolverInfo : public btContactSolverInfoData
 		m_maxErrorReduction = btScalar(20.);
 		m_numIterations = 10;
 		m_erp = btScalar(0.2);
-		m_erp2 = btScalar(0.2);
+    m_erp2 = btScalar(0.8);
 		m_deformable_erp = btScalar(0.06);
 		m_deformable_cfm = btScalar(0.01);
 		m_deformable_maxErrorReduction = btScalar(0.1);

--- a/intern/rigidbody/CMakeLists.txt
+++ b/intern/rigidbody/CMakeLists.txt
@@ -18,7 +18,11 @@
 # All rights reserved.
 # ***** END GPL LICENSE BLOCK *****
 
-add_definitions(-DBT_USE_DOUBLE_PRECISION)
+# UPBGE - to recover double precision uncomment this definition, intern/rigidbody/CMakeLists.txt one
+# and source/gameengine/Physics/Bullet/CMakeLists.txt one.
+# Double precision is slower than float one but it will increase the precision in
+# open worlds games bigger than 10Km.
+#add_definitions(-DBT_USE_DOUBLE_PRECISION)
 
 set(INC
   .

--- a/release/scripts/startup/bl_ui/properties_game.py
+++ b/release/scripts/startup/bl_ui/properties_game.py
@@ -390,6 +390,13 @@ class SCENE_PT_game_physics(SceneButtonsPanel, Panel):
             sub = col.row()
             sub.prop(gs, "deactivation_time", text="Time")
 
+            col = layout.column()
+            col.label(text="Physics Joint Error Reduction:")
+            sub = col.column(align=True)
+            sub.prop(gs, "erp_parameter", text="ERP for Non Contact Constraints")
+            sub.prop(gs, "erp2_parameter", text="ERP for Contact Constraints")
+            sub.prop(gs, "cfm_parameter", text="CFM for Soft Constraints")
+
         else:
             split = layout.split()
 

--- a/source/blender/blenkernel/BKE_blender_version.h
+++ b/source/blender/blenkernel/BKE_blender_version.h
@@ -49,7 +49,7 @@ extern "C" {
 
 /* UPBGE file format version. */
 #define UPBGE_FILE_VERSION UPBGE_VERSION
-#define UPBGE_FILE_SUBVERSION 2
+#define UPBGE_FILE_SUBVERSION 3
 
 /* Minimum Blender version that supports reading file written with the current
  * version. Older Blender versions will test this and show a warning if the file

--- a/source/blender/blenkernel/intern/scene.c
+++ b/source/blender/blenkernel/intern/scene.c
@@ -236,6 +236,9 @@ static void scene_init_data(ID *id)
   scene->gm.lineardeactthreshold = 0.8f;
   scene->gm.angulardeactthreshold = 1.0f;
   scene->gm.deactivationtime = 2.0f;
+  scene->gm.erp = 0.2f;
+  scene->gm.erp2 = 0.8f;
+  scene->gm.cfm = 0.0f;
 
   scene->gm.obstacleSimulation = OBSTSIMULATION_NONE;
   scene->gm.levelHeight = 2.f;

--- a/source/blender/blenloader/intern/versioning_280.c
+++ b/source/blender/blenloader/intern/versioning_280.c
@@ -1826,10 +1826,13 @@ void blo_do_versions_280(FileData *fd, Library *lib, Main *bmain)
       sce->gm.maxlogicstep = 5;
       sce->gm.physubstep = 1;
       sce->gm.maxphystep = 5;
-	  sce->gm.timeScale = 1.0f;
+      sce->gm.timeScale = 1.0f;
       sce->gm.lineardeactthreshold = 0.8f;
       sce->gm.angulardeactthreshold = 1.0f;
       sce->gm.deactivationtime = 2.0f;
+      sce->gm.erp = 0.2f;
+      sce->gm.erp2 = 0.8f;
+      sce->gm.cfm = 0.0f;
 
       sce->gm.obstacleSimulation = OBSTSIMULATION_NONE;
       sce->gm.levelHeight = 2.f;

--- a/source/blender/blenloader/intern/versioning_defaults.c
+++ b/source/blender/blenloader/intern/versioning_defaults.c
@@ -406,10 +406,13 @@ void BLO_update_defaults_startup_blend(Main *bmain, const char *app_template)
     sce->gm.maxlogicstep = 5;
     sce->gm.physubstep = 1;
     sce->gm.maxphystep = 5;
-	sce->gm.timeScale = 1.0f;
+    sce->gm.timeScale = 1.0f;
     sce->gm.lineardeactthreshold = 0.8f;
     sce->gm.angulardeactthreshold = 1.0f;
     sce->gm.deactivationtime = 2.0f;
+    sce->gm.erp = 0.2f;
+    sce->gm.erp2 = 0.8f;
+    sce->gm.cfm = 0.0f;
 
     sce->gm.obstacleSimulation = OBSTSIMULATION_NONE;
     sce->gm.levelHeight = 2.f;

--- a/source/blender/blenloader/intern/versioning_upbge.c
+++ b/source/blender/blenloader/intern/versioning_upbge.c
@@ -224,4 +224,12 @@ void blo_do_versions_upbge(FileData *fd, Library *lib, Main *main)
       }
     }
   }
+  if (!MAIN_VERSION_UPBGE_ATLEAST(main, 30, 2)) {
+    if (!DNA_struct_elem_find(fd->filesdna, "GameData", "float", "erp")) {
+      for (Scene *scene = main->scenes.first; scene; scene = scene->id.next) {
+        scene->gm.erp = 0.2f;
+        scene->gm.erp2 = 0.8f;
+      }
+    }
+  }
 }

--- a/source/blender/makesdna/DNA_scene_types.h
+++ b/source/blender/makesdna/DNA_scene_types.h
@@ -882,7 +882,7 @@ typedef struct GameData {
   float timeScale;
   float levelHeight;
   float deactivationtime, lineardeactthreshold, angulardeactthreshold;
-  int _pad2[2];
+  float erp, erp2, cfm, _pad1;
 
   /* Scene LoD */
   short lodflag, _pad3;

--- a/source/blender/makesrna/intern/rna_scene.c
+++ b/source/blender/makesrna/intern/rna_scene.c
@@ -5595,6 +5595,50 @@ static void rna_def_scene_game_data(BlenderRNA *brna)
       "threshold will deactivate (0.0 means no deactivation)");
   RNA_def_property_update(prop, NC_SCENE, NULL);
 
+  prop = RNA_def_property(srna, "erp_parameter", PROP_FLOAT, PROP_NONE);
+  RNA_def_property_float_sdna(prop, NULL, "erp");
+  RNA_def_property_range(prop, 0.0, 1.0);
+  RNA_def_property_float_default(prop, 0.2f);
+  RNA_def_property_ui_text(
+      prop,
+      "Error Reduction Parameter (ERP) for non-contact constraints",
+      "The Error Reduction Parameter (ERP) specifies what proportion of the joint error "
+      "will be fixed during the next simulation step. If ERP = 0 then no correcting force "
+      "is applied and the bodies will eventually drift apart as the simulation proceeds. "
+      "If ERP = 1 then the simulation will attempt to fix all joint error during the next time step. "
+      "However, setting ERP = 1 is not recommended, as the joint error will not be completely fixed due "
+      "to various internal approximations. A value of ERP = 0.1 to 0.8 is recommended");
+  RNA_def_property_update(prop, NC_SCENE, NULL);
+
+  prop = RNA_def_property(srna, "erp2_parameter", PROP_FLOAT, PROP_NONE);
+  RNA_def_property_float_sdna(prop, NULL, "erp2");
+  RNA_def_property_range(prop, 0.0, 1.0);
+  RNA_def_property_float_default(prop, 0.8f);
+  RNA_def_property_ui_text(
+      prop,
+      "Error Reduction Parameter (ERP) for contact constraints",
+      "The Error Reduction Parameter (ERP) specifies what proportion of the joint error "
+      "will be fixed during the next simulation step. If ERP = 0 then no correcting force "
+      "is applied and the bodies will eventually drift apart as the simulation proceeds. "
+      "If ERP = 1 then the simulation will attempt to fix all joint error during the next time step. "
+      "However, setting ERP = 1 is not recommended, as the joint error will not be completely fixed due "
+      "to various internal approximations. A value of ERP = 0.1 to 0.8 is recommended");
+  RNA_def_property_update(prop, NC_SCENE, NULL);
+
+  prop = RNA_def_property(srna, "cfm_parameter", PROP_FLOAT, PROP_NONE);
+  RNA_def_property_float_sdna(prop, NULL, "cfm");
+  RNA_def_property_ui_range(prop, 0.0, 100.0, 2, 3);
+  RNA_def_property_range(prop, 0.0, 10000.0);
+  RNA_def_property_float_default(prop, 0.2f);
+  RNA_def_property_ui_text(
+      prop,
+      "Constraint Force Mixing (CFM)",
+      "If the Constraint Force Mixing (CFM) is set to zero, the constraint will be hard. "
+      "If CFM is set to a positive value, it will be possible to violate the constraint by pushing on it "
+      "(for example, for contact constraints by forcing the two contacting objects together). "
+      "In other words the constraint will be soft, and the softness will increase as CFM increases.");
+  RNA_def_property_update(prop, NC_SCENE, NULL);
+
   /* not used  */ /* deprecated !!!!!!!!!!!!! */
   prop = RNA_def_property(srna, "activity_culling_box_radius", PROP_FLOAT, PROP_NONE);
   RNA_def_property_float_sdna(prop, NULL, "activityBoxRadius");

--- a/source/gameengine/Ketsji/KX_PyConstraintBinding.cpp
+++ b/source/gameengine/Ketsji/KX_PyConstraintBinding.cpp
@@ -104,12 +104,6 @@ PyDoc_STRVAR(gPySetSolverTau__doc__,
 PyDoc_STRVAR(gPySetSolverDamping__doc__,
              "setDamping(float damping)\n"
              "Very experimental, not recommended");
-PyDoc_STRVAR(gPySetLinearAirDamping__doc__,
-             "setLinearAirDamping(float damping)\n"
-             "Very experimental, not recommended");
-PyDoc_STRVAR(gPySetUseEpa__doc__,
-             "setUseEpa(int epa)\n"
-             "Very experimental, not recommended");
 PyDoc_STRVAR(gPySetSolverType__doc__,
              "setSolverType(int solverType)\n"
              "Very experimental, not recommended");
@@ -360,33 +354,6 @@ static PyObject *gPySetSolverDamping(PyObject *self, PyObject *args, PyObject *k
   Py_RETURN_NONE;
 }
 
-static PyObject *gPySetLinearAirDamping(PyObject *self, PyObject *args, PyObject *kwds)
-{
-  float damping;
-  if (PyArg_ParseTuple(args, "f", &damping)) {
-    if (PHY_GetActiveEnvironment()) {
-      PHY_GetActiveEnvironment()->SetLinearAirDamping(damping);
-    }
-  }
-  else {
-    return nullptr;
-  }
-  Py_RETURN_NONE;
-}
-
-static PyObject *gPySetUseEpa(PyObject *self, PyObject *args, PyObject *kwds)
-{
-  int epa;
-  if (PyArg_ParseTuple(args, "i", &epa)) {
-    if (PHY_GetActiveEnvironment()) {
-      PHY_GetActiveEnvironment()->SetUseEpa(epa);
-    }
-  }
-  else {
-    return nullptr;
-  }
-  Py_RETURN_NONE;
-}
 static PyObject *gPySetSolverType(PyObject *self, PyObject *args, PyObject *kwds)
 {
   int solverType;
@@ -692,12 +659,6 @@ static struct PyMethodDef physicsconstraints_methods[] = {
      METH_VARARGS,
      (const char *)gPySetSolverDamping__doc__},
 
-    {"setLinearAirDamping",
-     (PyCFunction)gPySetLinearAirDamping,
-     METH_VARARGS,
-     (const char *)gPySetLinearAirDamping__doc__},
-
-    {"setUseEpa", (PyCFunction)gPySetUseEpa, METH_VARARGS, (const char *)gPySetUseEpa__doc__},
     {"setSolverType",
      (PyCFunction)gPySetSolverType,
      METH_VARARGS,

--- a/source/gameengine/Ketsji/KX_PyConstraintBinding.cpp
+++ b/source/gameengine/Ketsji/KX_PyConstraintBinding.cpp
@@ -85,6 +85,16 @@ PyDoc_STRVAR(gPySetContactBreakingTreshold__doc__,
              "setContactBreakingTreshold(float breakingTreshold)\n"
              "Reasonable default is 0.02 (if units are meters)");
 
+PyDoc_STRVAR(gPySetERPNonContact__doc__,
+             "setERPNonContact(float erp)\n"
+             "");
+PyDoc_STRVAR(gPySetERPContact__doc__,
+             "setERPContact(float erp2)\n"
+             "");
+PyDoc_STRVAR(gPySetCFM__doc__,
+             "setCFM(float cfm)\n"
+             "");
+
 PyDoc_STRVAR(gPySetSorConstant__doc__,
              "setSorConstant(float sor)\n"
              "Very experimental, not recommended");
@@ -233,6 +243,78 @@ static PyObject *gPySetContactBreakingTreshold(PyObject *self, PyObject *args, P
   else {
     return nullptr;
   }
+  Py_RETURN_NONE;
+}
+
+static PyObject *gPySetERPNonContact(PyObject *self, PyObject *args, PyObject *kwds)
+{
+  float erp;
+  if (!PyArg_ParseTuple(args, "f", &erp)) {
+    return nullptr;
+  }
+
+  if ((erp < 0.0) || (erp > 1.0)) {
+    PyErr_SetString(PyExc_TypeError, "setERPNonContact, "
+                    "expected a float in range 0.0 - 1.0");
+    return nullptr;
+  }
+
+  if (PHY_GetActiveEnvironment()) {
+    PHY_GetActiveEnvironment()->SetERPNonContact(erp);
+  }
+  else {
+    PyErr_SetString(PyExc_TypeError, "No physics environment available");
+    return nullptr;
+  }
+
+  Py_RETURN_NONE;
+}
+
+static PyObject *gPySetERPContact(PyObject *self, PyObject *args, PyObject *kwds)
+{
+  float erp2;
+  if (!PyArg_ParseTuple(args, "f", &erp2)) {
+    return nullptr;
+  }
+
+  if ((erp2 < 0.0) || (erp2 > 1.0)) {
+    PyErr_SetString(PyExc_TypeError, "setERPContact, "
+                    "expected a float in range 0.0 - 1.0");
+    return nullptr;
+  }
+
+  if (PHY_GetActiveEnvironment()) {
+    PHY_GetActiveEnvironment()->SetERPContact(erp2);
+  }
+  else {
+    PyErr_SetString(PyExc_TypeError, "No physics environment available");
+    return nullptr;
+  }
+
+  Py_RETURN_NONE;
+}
+
+static PyObject *gPySetCFM(PyObject *self, PyObject *args, PyObject *kwds)
+{
+  float cfm;
+  if (!PyArg_ParseTuple(args, "f", &cfm)) {
+    return nullptr;
+  }
+
+  if ((cfm < 0.0) || (cfm > 10000.0)) {
+    PyErr_SetString(PyExc_TypeError, "setCFM, "
+                    "expected a float in range 0.0 - 10000.0");
+    return nullptr;
+  }
+
+  if (PHY_GetActiveEnvironment()) {
+    PHY_GetActiveEnvironment()->SetCFM(cfm);
+  }
+  else {
+    PyErr_SetString(PyExc_TypeError, "No physics environment available");
+    return nullptr;
+  }
+
   Py_RETURN_NONE;
 }
 
@@ -583,6 +665,20 @@ static struct PyMethodDef physicsconstraints_methods[] = {
      (PyCFunction)gPySetContactBreakingTreshold,
      METH_VARARGS,
      (const char *)gPySetContactBreakingTreshold__doc__},
+
+    {"setERPNonContact",
+     (PyCFunction)gPySetERPNonContact,
+     METH_VARARGS,
+     (const char *)gPySetERPNonContact__doc__},
+    {"setERPContact",
+     (PyCFunction)gPySetERPContact,
+     METH_VARARGS,
+     (const char *)gPySetERPContact__doc__},
+    {"setCFM",
+     (PyCFunction)gPySetCFM,
+     METH_VARARGS,
+     (const char *)gPySetCFM__doc__},
+
     {"setSorConstant",
      (PyCFunction)gPySetSorConstant,
      METH_VARARGS,

--- a/source/gameengine/Physics/Bullet/CMakeLists.txt
+++ b/source/gameengine/Physics/Bullet/CMakeLists.txt
@@ -26,7 +26,11 @@
 # since this includes bullet we get errors from the headers too
 remove_strict_flags()
 
-add_definitions(-DBT_USE_DOUBLE_PRECISION)
+# UPBGE - to recover double precision uncomment this definition, intern/rigidbody/CMakeLists.txt one
+# and source/gameengine/Physics/Bullet/CMakeLists.txt one.
+# Double precision is slower than float one but it will increase the precision in
+# open worlds games bigger than 10Km.
+#add_definitions(-DBT_USE_DOUBLE_PRECISION)
 
 set(INC
   .

--- a/source/gameengine/Physics/Bullet/CcdPhysicsEnvironment.cpp
+++ b/source/gameengine/Physics/Bullet/CcdPhysicsEnvironment.cpp
@@ -3001,7 +3001,7 @@ void CcdPhysicsEnvironment::ConvertObject(BL_BlenderSceneConverter *converter,
     }
     case OB_BOUND_CAPSULE: {
       shapeInfo->m_radius = MT_max(bounds_extends[0], bounds_extends[1]);
-      shapeInfo->m_height = 2.0f * bounds_extends[2];
+      shapeInfo->m_height = 2.0f * (bounds_extends[2] - shapeInfo->m_radius);
       if (shapeInfo->m_height < 0.0f)
         shapeInfo->m_height = 0.0f;
       shapeInfo->m_shapeType = PHY_SHAPE_CAPSULE;

--- a/source/gameengine/Physics/Bullet/CcdPhysicsEnvironment.cpp
+++ b/source/gameengine/Physics/Bullet/CcdPhysicsEnvironment.cpp
@@ -1009,16 +1009,6 @@ void CcdPhysicsEnvironment::SetSolverDamping(float damping)
   m_dynamicsWorld->getSolverInfo().m_damping = damping;
 }
 
-void CcdPhysicsEnvironment::SetLinearAirDamping(float damping)
-{
-  // gLinearAirDamping = damping;
-}
-
-void CcdPhysicsEnvironment::SetUseEpa(bool epa)
-{
-  // gUseEpa = epa;
-}
-
 void CcdPhysicsEnvironment::SetSolverType(PHY_SolverType solverType)
 {
 

--- a/source/gameengine/Physics/Bullet/CcdPhysicsEnvironment.cpp
+++ b/source/gameengine/Physics/Bullet/CcdPhysicsEnvironment.cpp
@@ -976,6 +976,20 @@ void CcdPhysicsEnvironment::SetDeactivationAngularTreshold(float angTresh)
   }
 }
 
+void CcdPhysicsEnvironment::SetERPNonContact(float erp)
+{
+  m_dynamicsWorld->getSolverInfo().m_erp = erp;
+}
+
+void CcdPhysicsEnvironment::SetERPContact(float erp2)
+{
+  m_dynamicsWorld->getSolverInfo().m_erp2 = erp2;
+}
+
+void CcdPhysicsEnvironment::SetCFM(float cfm)
+{
+  m_dynamicsWorld->getSolverInfo().m_globalCfm = cfm;
+}
 void CcdPhysicsEnvironment::SetContactBreakingTreshold(float contactBreakingTreshold)
 {
   m_contactBreakingThreshold = contactBreakingTreshold;
@@ -2743,6 +2757,9 @@ CcdPhysicsEnvironment *CcdPhysicsEnvironment::Create(Scene *blenderscene, bool v
   ccdPhysEnv->SetDeactivationLinearTreshold(blenderscene->gm.lineardeactthreshold);
   ccdPhysEnv->SetDeactivationAngularTreshold(blenderscene->gm.angulardeactthreshold);
   ccdPhysEnv->SetDeactivationTime(blenderscene->gm.deactivationtime);
+  ccdPhysEnv->SetERPNonContact(blenderscene->gm.erp);
+  ccdPhysEnv->SetERPContact(blenderscene->gm.erp2);
+  ccdPhysEnv->SetCFM(blenderscene->gm.cfm);
 
   if (visualizePhysics)
     ccdPhysEnv->SetDebugMode(btIDebugDraw::DBG_DrawWireframe | btIDebugDraw::DBG_DrawAabb |

--- a/source/gameengine/Physics/Bullet/CcdPhysicsEnvironment.h
+++ b/source/gameengine/Physics/Bullet/CcdPhysicsEnvironment.h
@@ -127,8 +127,6 @@ class CcdPhysicsEnvironment : public PHY_IPhysicsEnvironment {
   virtual void SetSolverSorConstant(float sor);
   virtual void SetSolverTau(float tau);
   virtual void SetSolverDamping(float damping);
-  virtual void SetLinearAirDamping(float damping);
-  virtual void SetUseEpa(bool epa);
 
   virtual int GetNumTimeSubSteps()
   {

--- a/source/gameengine/Physics/Bullet/CcdPhysicsEnvironment.h
+++ b/source/gameengine/Physics/Bullet/CcdPhysicsEnvironment.h
@@ -119,6 +119,9 @@ class CcdPhysicsEnvironment : public PHY_IPhysicsEnvironment {
   virtual void SetDeactivationTime(float dTime);
   virtual void SetDeactivationLinearTreshold(float linTresh);
   virtual void SetDeactivationAngularTreshold(float angTresh);
+  virtual void SetERPNonContact(float erp);
+  virtual void SetERPContact(float erp2);
+  virtual void SetCFM(float cfm);
   virtual void SetContactBreakingTreshold(float contactBreakingTreshold);
   virtual void SetSolverType(PHY_SolverType solverType);
   virtual void SetSolverSorConstant(float sor);

--- a/source/gameengine/Physics/Common/PHY_IPhysicsEnvironment.h
+++ b/source/gameengine/Physics/Common/PHY_IPhysicsEnvironment.h
@@ -157,6 +157,18 @@ class PHY_IPhysicsEnvironment {
   virtual void SetDeactivationAngularTreshold(float angTresh)
   {
   }
+  /// setERP sets the Error Reduction Parameter to reduce the joint error for non-contact constraints
+  virtual void SetERPNonContact(float erp)
+  {
+  }
+  /// setERP sets the Error Reduction Parameter to reduce the joint error for contact constraints
+  virtual void SetERPContact(float erp2)
+  {
+  }
+  /// setCFM sets the Constraint Force Mixing to allow soft constraints
+  virtual void SetCFM(float cfm)
+  {
+  }
   /// setContactBreakingTreshold sets tresholds to do with contact point management
   virtual void SetContactBreakingTreshold(float contactBreakingTreshold)
   {

--- a/source/gameengine/Physics/Common/PHY_IPhysicsEnvironment.h
+++ b/source/gameengine/Physics/Common/PHY_IPhysicsEnvironment.h
@@ -191,14 +191,6 @@ class PHY_IPhysicsEnvironment {
   virtual void SetSolverDamping(float damping)
   {
   }
-  /// linear air damping for rigidbodies
-  virtual void SetLinearAirDamping(float damping)
-  {
-  }
-  /// penetrationdepth setting
-  virtual void SetUseEpa(bool epa)
-  {
-  }
 
   virtual void SetGravity(float x, float y, float z) = 0;
   virtual void GetGravity(MT_Vector3 &grav) = 0;


### PR DESCRIPTION
We restore old m_erp2 value.
Thanks to @youle31 for investigating and pointing the solution. I checked the value for bullet 2.83.7 and older and it was 0.8. If you see that the behaviour is better with 1.0 with can change it to that value.

Additionally, we move back to float precision instead of double in Bullet library

Double precision is slower than float one because the float one can use SSE improvements. WE have around 5-15% better performance with float precision.

[stress_test.zip](https://github.com/UPBGE/upbge/files/5498100/stress_test.zip)

Double precision can be interesting in open world with more than 10Km from center.