### PR TITLE
UPBGE: Convert objects list function

### DIFF
--- a/doc/python_api/rst/bge_types/bge.types.KX_Scene.rst
+++ b/doc/python_api/rst/bge_types/bge.types.KX_Scene.rst
@@ -211,6 +211,18 @@ base class --- :class:`PyObjectPlus`
       Note: When you append an Object with a "module" python controller, you need to append
       the script (Text) corresponding to the module too.
 
+   .. method:: convertBlenderObjectsList(blenderObjectsList, asynchronous)
+
+      Converts all bpy.types.Object inside a python List into its correspondent :class:`KX_GameObject` during runtime.
+      For example, you can append an Object List during bge runtime using: ob = object_data_add(...) and ML.append(ob) then convert the Objects 
+      inside the List into several KX_GameObject to have logic bricks, physics... converted. This is meant to replace libload. 
+      The conversion can be asynchronous or synchronous.
+
+      :arg blenderObjectsList: The collection to be converted.
+      :type blenderObjectsList: bpy.types.Object list
+      :arg asynchronous: The Object list conversion can be asynchronous or not.
+      :type asynchronous: boolean
+      
    .. method:: convertBlenderCollection(blenderCollection, asynchronous)
 
       Converts all bpy.types.Object inside a Collection into its correspondent :class:`KX_GameObject` during runtime.

--- a/source/gameengine/Converter/BL_BlenderDataConversion.cpp
+++ b/source/gameengine/Converter/BL_BlenderDataConversion.cpp
@@ -1248,6 +1248,8 @@ void BL_ConvertBlenderObjects(struct Main *maggie,
       /* Force OB_RESTRICT_VIEWPORT to avoid not needed depsgraph operations in some cases */
       kxscene->BackupRestrictFlag(blenderobject, blenderobject->restrictflag);
       blenderobject->restrictflag |= OB_RESTRICT_VIEWPORT;
+      BKE_main_collection_sync_remap(maggie);
+      DEG_relations_tag_update(maggie);
     }
 
     bool converting_during_runtime = single_object != nullptr;
@@ -1275,10 +1277,6 @@ void BL_ConvertBlenderObjects(struct Main *maggie,
       gameobj->Release();
     }
   }
-
-  /* Flush restrictflag updates for obj in inactive list */
-  BKE_main_collection_sync_remap(maggie);
-  DEG_relations_tag_update(maggie);
 
   if (!grouplist.empty()) {
     // now convert the group referenced by dupli group object

--- a/source/gameengine/Ketsji/KX_Scene.cpp
+++ b/source/gameengine/Ketsji/KX_Scene.cpp
@@ -2960,7 +2960,7 @@ KX_PYMETHODDEF_DOC(KX_Scene,
                    "convertBlenderObjectsList()\n"
                    "\n")
 {
-  std::vector<Object> objectlist;
+  std::vector<Object *> objectlist;
   PyObject *list;
   int asynchronous = 0;
 

--- a/source/gameengine/Ketsji/KX_Scene.cpp
+++ b/source/gameengine/Ketsji/KX_Scene.cpp
@@ -36,6 +36,7 @@
 
 #include "KX_Scene.h"
 
+#include "BKE_collection.h"
 #include "BKE_lib_id.h"
 #include "BKE_object.h"
 #include "BKE_screen.h"
@@ -855,30 +856,26 @@ struct ConvertBlenderObjectsListTaskData {
   std::vector<Object *> objectslist;
   KX_KetsjiEngine *engine;
   e_PhysicsEngine physics_engine;
-  KX_Scene *scene;
+  KX_Scene *kxscene;
   BL_BlenderSceneConverter *converter;
+  RAS_Rasterizer *rasty;
+  RAS_ICanvas *canvas;
+  Depsgraph *depsgraph;
+  Main *bmain;
 };
 
-void convert_blender_objects_list_thread_func(TaskPool *__restrict UNUSED(pool),
-                                            void *taskdata,
-                                            int UNUSED(threadid))
+static void convert_blender_objects_list_thread_func(TaskPool *__restrict UNUSED(pool), void *taskdata)
 {
   ConvertBlenderObjectsListTaskData *task = static_cast<ConvertBlenderObjectsListTaskData *>(taskdata);
 
-  RAS_Rasterizer *rasty = task->engine->GetRasterizer();
-  RAS_ICanvas *canvas = task->engine->GetCanvas();
-  bContext *C = task->engine->GetContext();
-  Depsgraph *depsgraph = CTX_data_expect_evaluated_depsgraph(C);
-  Main *bmain = CTX_data_main(C);
-
   for (Object *obj : task->objectslist) {
-    BL_ConvertBlenderObjects(bmain,
-                             depsgraph,
-                             task->scene,
+    BL_ConvertBlenderObjects(task->bmain,
+                             task->depsgraph,
+                             task->kxscene,
                              task->engine,
                              task->physics_engine,
-                             rasty,
-                             canvas,
+                             task->rasty,
+                             task->canvas,
                              task->converter,
                              obj,
                              false,
@@ -886,28 +883,41 @@ void convert_blender_objects_list_thread_func(TaskPool *__restrict UNUSED(pool),
   }
 }
 
-void KX_Scene::ConvertBlenderObjectsList(const std::vector<Object *> objectslist, bool asynchronous)
+void KX_Scene::ConvertBlenderObjectsList(std::vector<Object *> objectslist, bool asynchronous)
 {
   if (asynchronous) {
-    TaskPool *taskpool = BLI_task_pool_create(nullptr, TASK_PRIORITY_LOW);
-
-    /* Convert the Blender collection in a different thread, so that the
+    /* Convert the Blender Objects list in a different thread, so that the
      * game engine can keep running at full speed. */
-    ConvertBlenderObjectsListTaskData *task = (ConvertBlenderObjectsListTaskData *)MEM_mallocN(sizeof(ConvertBlenderObjectsListTaskData),
-                                                                                             "convertblenderobjectslist-data");
-
+    ConvertBlenderObjectsListTaskData *task = new ConvertBlenderObjectsListTaskData();
     task->engine = KX_GetActiveEngine();
     task->physics_engine = UseBullet;
-    task->objectslist = objectslist;
-    task->scene = this;
+    task->kxscene = this;
     task->converter = m_sceneConverter;
+    task->rasty = task->engine->GetRasterizer();
+    task->canvas = task->engine->GetCanvas();
+    bContext *C = task->engine->GetContext();
+    task->depsgraph = CTX_data_expect_evaluated_depsgraph(C);
+    task->bmain = CTX_data_main(C);
+    task->objectslist = objectslist;
+
+    TaskPool *taskpool = BLI_task_pool_create(task, TASK_PRIORITY_LOW);
 
     BLI_task_pool_push(taskpool,
-                       (TaskRunFunction)convert_blender_objects_list_thread_func,
+                       convert_blender_objects_list_thread_func,
                        task,
-                       true,  // free task data
+                       false,  // We will clean the objectslist std::vector of pointers ourself later
                        NULL);
     BLI_task_pool_work_and_wait(taskpool);
+
+    /* delete the objectslist ourself as it gives error if the work
+     * has to do it the BLI_task_pool_work_and_wait function */
+    while (!task->objectslist.size() != 0) {
+      Object *temp = task->objectslist.back();
+      task->objectslist.pop_back();
+      delete temp;
+    }
+    delete task;
+
     BLI_task_pool_free(taskpool);
     taskpool = nullptr;
   }
@@ -947,30 +957,26 @@ struct ConvertBlenderCollectionTaskData {
   Collection *co;
   KX_KetsjiEngine *engine;
   e_PhysicsEngine physics_engine;
-  KX_Scene *scene;
+  KX_Scene *kxscene;
   BL_BlenderSceneConverter *converter;
+  RAS_Rasterizer *rasty;
+  RAS_ICanvas *canvas;
+  Depsgraph *depsgraph;
+  Main *bmain;
 };
 
-void convert_blender_collection_thread_func(TaskPool *__restrict UNUSED(pool),
-                                            void *taskdata,
-                                            int UNUSED(threadid))
+static void convert_blender_collection_thread_func(TaskPool *__restrict UNUSED(pool), void *taskdata)
 {
   ConvertBlenderCollectionTaskData *task = static_cast<ConvertBlenderCollectionTaskData *>(taskdata);
 
-  RAS_Rasterizer *rasty = task->engine->GetRasterizer();
-  RAS_ICanvas *canvas = task->engine->GetCanvas();
-  bContext *C = task->engine->GetContext();
-  Depsgraph *depsgraph = CTX_data_expect_evaluated_depsgraph(C);
-  Main *bmain = CTX_data_main(C);
-
   FOREACH_COLLECTION_OBJECT_RECURSIVE_BEGIN (task->co, obj) {
-    BL_ConvertBlenderObjects(bmain,
-                             depsgraph,
-                             task->scene,
+    BL_ConvertBlenderObjects(task->bmain,
+                             task->depsgraph,
+                             task->kxscene,
                              task->engine,
                              task->physics_engine,
-                             rasty,
-                             canvas,
+                             task->rasty,
+                             task->canvas,
                              task->converter,
                              obj,
                              false,
@@ -982,7 +988,6 @@ void convert_blender_collection_thread_func(TaskPool *__restrict UNUSED(pool),
 void KX_Scene::ConvertBlenderCollection(Collection *co, bool asynchronous)
 {
   if (asynchronous) {
-    TaskPool *taskpool = BLI_task_pool_create(nullptr, TASK_PRIORITY_LOW);
 
     /* Convert the Blender collection in a different thread, so that the
      * game engine can keep running at full speed. */
@@ -992,11 +997,18 @@ void KX_Scene::ConvertBlenderCollection(Collection *co, bool asynchronous)
     task->engine = KX_GetActiveEngine();
     task->physics_engine = UseBullet;
     task->co = co;
-    task->scene = this;
+    task->kxscene = this;
     task->converter = m_sceneConverter;
+    task->rasty = task->engine->GetRasterizer();
+    task->canvas = task->engine->GetCanvas();
+    bContext *C = task->engine->GetContext();
+    task->depsgraph = CTX_data_ensure_evaluated_depsgraph(C);
+    task->bmain = CTX_data_main(C);
+
+    TaskPool *taskpool = BLI_task_pool_create(task, TASK_PRIORITY_LOW);
 
     BLI_task_pool_push(taskpool,
-                       (TaskRunFunction)convert_blender_collection_thread_func,
+                       convert_blender_collection_thread_func,
                        task,
                        true,  // free task data
                        NULL);

--- a/source/gameengine/Ketsji/KX_Scene.cpp
+++ b/source/gameengine/Ketsji/KX_Scene.cpp
@@ -39,6 +39,7 @@
 #include "BKE_lib_id.h"
 #include "BKE_object.h"
 #include "BKE_screen.h"
+#include "BLI_listbase.h"
 #include "BLI_task.h"
 #include "BLI_threads.h"
 #include "DNA_property_types.h"
@@ -822,6 +823,97 @@ void KX_Scene::ConvertBlenderObject(Object *ob)
                            false,
                            false);
 
+}
+
+void KX_Scene::convert_blender_objects_list_synchronous(std::vector<Object *> objectslist)
+{
+  KX_KetsjiEngine *engine = KX_GetActiveEngine();
+  e_PhysicsEngine physics_engine = UseBullet;
+  RAS_Rasterizer *rasty = engine->GetRasterizer();
+  RAS_ICanvas *canvas = engine->GetCanvas();
+  bContext *C = engine->GetContext();
+  Depsgraph *depsgraph = CTX_data_expect_evaluated_depsgraph(C);
+  Main *bmain = CTX_data_main(C);
+
+  for (Object *obj : objectslist) {
+    BL_ConvertBlenderObjects(bmain,
+                             depsgraph,
+                             this,
+                             engine,
+                             physics_engine,
+                             rasty,
+                             canvas,
+                             m_sceneConverter,
+                             obj,
+                             false,
+                             false);
+  }
+}
+
+// Task data for convertBlenderCollection in a different thread.
+struct ConvertBlenderObjectsListTaskData {
+  std::vector<Object *> objectslist;
+  KX_KetsjiEngine *engine;
+  e_PhysicsEngine physics_engine;
+  KX_Scene *scene;
+  BL_BlenderSceneConverter *converter;
+};
+
+void convert_blender_objects_list_thread_func(TaskPool *__restrict UNUSED(pool),
+                                            void *taskdata,
+                                            int UNUSED(threadid))
+{
+  ConvertBlenderObjectsListTaskData *task = static_cast<ConvertBlenderObjectsListTaskData *>(taskdata);
+
+  RAS_Rasterizer *rasty = task->engine->GetRasterizer();
+  RAS_ICanvas *canvas = task->engine->GetCanvas();
+  bContext *C = task->engine->GetContext();
+  Depsgraph *depsgraph = CTX_data_expect_evaluated_depsgraph(C);
+  Main *bmain = CTX_data_main(C);
+
+  for (Object *obj : task->objectslist) {
+    BL_ConvertBlenderObjects(bmain,
+                             depsgraph,
+                             task->scene,
+                             task->engine,
+                             task->physics_engine,
+                             rasty,
+                             canvas,
+                             task->converter,
+                             obj,
+                             false,
+                             false);
+  }
+}
+
+void KX_Scene::ConvertBlenderObjectsList(const std::vector<Object *> objectslist, bool asynchronous)
+{
+  if (asynchronous) {
+    TaskPool *taskpool = BLI_task_pool_create(nullptr, TASK_PRIORITY_LOW);
+
+    /* Convert the Blender collection in a different thread, so that the
+     * game engine can keep running at full speed. */
+    ConvertBlenderObjectsListTaskData *task = (ConvertBlenderObjectsListTaskData *)MEM_mallocN(sizeof(ConvertBlenderObjectsListTaskData),
+                                                                                             "convertblenderobjectslist-data");
+
+    task->engine = KX_GetActiveEngine();
+    task->physics_engine = UseBullet;
+    task->objectslist = objectslist;
+    task->scene = this;
+    task->converter = m_sceneConverter;
+
+    BLI_task_pool_push(taskpool,
+                       (TaskRunFunction)convert_blender_objects_list_thread_func,
+                       task,
+                       true,  // free task data
+                       NULL);
+    BLI_task_pool_work_and_wait(taskpool);
+    BLI_task_pool_free(taskpool);
+    taskpool = nullptr;
+  }
+  else {
+    convert_blender_objects_list_synchronous(objectslist);
+  }
 }
 
 void KX_Scene::convert_blender_collection_synchronous(Collection *co)
@@ -2418,6 +2510,7 @@ PyMethodDef KX_Scene::Methods[] = {
     KX_PYMETHODTABLE(KX_Scene, replace),
     KX_PYMETHODTABLE(KX_Scene, drawObstacleSimulation),
     KX_PYMETHODTABLE(KX_Scene, convertBlenderObject),
+    KX_PYMETHODTABLE(KX_Scene, convertBlenderObjectsList),
     KX_PYMETHODTABLE(KX_Scene, convertBlenderCollection),
 
     /* dict style access */
@@ -2860,6 +2953,40 @@ KX_PYMETHODDEF_DOC(KX_Scene,
   Object *ob = (Object *)id;
   ConvertBlenderObject(ob);
   return GetObjectList()->GetBack()->GetProxy();
+}
+
+KX_PYMETHODDEF_DOC(KX_Scene,
+                   convertBlenderObjectsList,
+                   "convertBlenderObjectsList()\n"
+                   "\n")
+{
+  std::vector<Object> objectlist;
+  PyObject *list;
+  int asynchronous = 0;
+
+  if (!PyArg_ParseTuple(args, "O!i:", &PyList_Type, &list, &asynchronous)) {
+    std::cout << "Expected a bpy.types.Object list." << std::endl;
+    return nullptr;
+  }
+
+  std::vector<Object *> objectslist;
+  Py_ssize_t list_size = PyList_Size(list);
+
+  for (Py_ssize_t i = 0; i < list_size; i++) {
+    PyObject* bl_object = PyList_GetItem(list, i);
+
+    ID *id;
+    if (!pyrna_id_FromPyObject(bl_object, &id)) {
+      std::cout << "Failed to convert object." << std::endl;
+      return nullptr;
+    }
+
+    Object *ob = (Object *)id;
+    objectslist.push_back(ob);
+  }
+
+  ConvertBlenderObjectsList(objectlist, asynchronous);
+  Py_RETURN_NONE;
 }
 
 KX_PYMETHODDEF_DOC(KX_Scene,

--- a/source/gameengine/Ketsji/KX_Scene.cpp
+++ b/source/gameengine/Ketsji/KX_Scene.cpp
@@ -909,9 +909,9 @@ void KX_Scene::ConvertBlenderObjectsList(std::vector<Object *> objectslist, bool
 
     /* delete the objectslist ourself as it gives error if the work
      * has to do it the BLI_task_pool_work_and_wait function */
-    while (!task->objectslist.size() != 0) {
-      Object *temp = task->objectslist.back();
-      task->objectslist.pop_back();
+    while (!task.objectslist.size() != 0) {
+      Object *temp = task.objectslist.back();
+      task.objectslist.pop_back();
       delete temp;
     }
 

--- a/source/gameengine/Ketsji/KX_Scene.cpp
+++ b/source/gameengine/Ketsji/KX_Scene.cpp
@@ -2960,7 +2960,6 @@ KX_PYMETHODDEF_DOC(KX_Scene,
                    "convertBlenderObjectsList()\n"
                    "\n")
 {
-  std::vector<Object *> objectlist;
   PyObject *list;
   int asynchronous = 0;
 
@@ -2985,7 +2984,7 @@ KX_PYMETHODDEF_DOC(KX_Scene,
     objectslist.push_back(ob);
   }
 
-  ConvertBlenderObjectsList(objectlist, asynchronous);
+  ConvertBlenderObjectsList(objectslist, asynchronous);
   Py_RETURN_NONE;
 }
 

--- a/source/gameengine/Ketsji/KX_Scene.h
+++ b/source/gameengine/Ketsji/KX_Scene.h
@@ -305,7 +305,8 @@ class KX_Scene : public CValue, public SCA_IScene {
   bool m_isActivedHysteresis;
   int m_lodHysteresisValue;
 
-  // Convert collection helper
+  // Convert objects list & collection helpers
+  void convert_blender_objects_list_synchronous(std::vector<Object *> objectslist);
   void convert_blender_collection_synchronous(Collection *co);
 
  public:
@@ -322,6 +323,7 @@ class KX_Scene : public CValue, public SCA_IScene {
   bool ObjectsAreStatic();
   void ResetTaaSamples();
   void ConvertBlenderObject(struct Object *ob);
+  void ConvertBlenderObjectsList(std::vector<Object *> objectslist, bool asynchronous);
   void ConvertBlenderCollection(struct Collection *co, bool asynchronous);
 
   bool m_isRuntime;  // Too lazy to put that in protected
@@ -571,6 +573,7 @@ class KX_Scene : public CValue, public SCA_IScene {
   KX_PYMETHOD_DOC(KX_Scene, get);
   KX_PYMETHOD_DOC(KX_Scene, drawObstacleSimulation);
   KX_PYMETHOD_DOC(KX_Scene, convertBlenderObject);
+  KX_PYMETHOD_DOC(KX_Scene, convertBlenderObjectsList);
   KX_PYMETHOD_DOC(KX_Scene, convertBlenderCollection);
 
   /* attributes */


### PR DESCRIPTION
With this new function it is possible to convert a list of objects from python:
```
    i=0
    ML = []
    
    for x in range(100):
        for y in range(10):
            added_mesh = bpy.data.objects['Plane'].data.copy()
            added_mesh.name = "Plane" + str(i)
            ob = object_data_add(bpy.context, added_mesh, operator=None)
            i += 1 
            ML.append(ob)
            ob.location = (x, y, 0)
    
    own.scene.convertBlenderObjectsList(ML, True)
```
[Convert_objects_list_async.zip](https://github.com/UPBGE/upbge/files/5515102/Convert_objects_list_async.zip)

Also, add the possibility to choose if the conversion is asynchronous or not. For convertBlenderCollection too.

NOTE: I had to revert an improvement commit to avoid crashes. Is it ok, @youle31 ? Or we can do it in another way....