### PR TITLE
Fix build problem regarding missing WITH_XR_OPENXR

### DIFF
--- a/source/blender/editors/space_view3d/view3d_view.c
+++ b/source/blender/editors/space_view3d/view3d_view.c
@@ -1925,12 +1925,14 @@ static int game_engine_exec(bContext *C, wmOperator *op)
   if (!ED_view3d_context_activate(C))
     return OPERATOR_CANCELLED;
 
+#ifdef WITH_XR_OPENXR
   wmWindowManager *wm = CTX_wm_manager(C);
   if (WM_xr_session_exists(&wm->xr)) {
     if (WM_xr_session_is_ready(&wm->xr)) {
       startscene->flag |= SCE_IS_GAME_XR_SESSION;
     }
   }
+#endif
 
   /* Calling this seems to avoid some UI flickering on windows
    * later during runtime. */


### PR DESCRIPTION
Fixes a build problem caused by missing preprocessor directive `WITH_XR_OPENXR` in view3d_view.c.