### PR TITLE
UPBGE: Fix endObject() didn't free blenderObject for converted objects during runtime

### DIFF
--- a/source/gameengine/Converter/BL_BlenderDataConversion.cpp
+++ b/source/gameengine/Converter/BL_BlenderDataConversion.cpp
@@ -1169,7 +1169,6 @@ void BL_ConvertBlenderObjects(struct Main *maggie,
         blenderobject, kxscene, rendertools, converter, libloading, converting_during_runtime);
 
     if (gameobj && converting_during_runtime) {
-      gameobj->SetIsConvertedDuringRuntime();
       gameobj->SetIsReplicaObject();
     }
 

--- a/source/gameengine/Converter/BL_BlenderDataConversion.cpp
+++ b/source/gameengine/Converter/BL_BlenderDataConversion.cpp
@@ -1168,6 +1168,11 @@ void BL_ConvertBlenderObjects(struct Main *maggie,
     KX_GameObject *gameobj = BL_gameobject_from_blenderobject(
         blenderobject, kxscene, rendertools, converter, libloading, converting_during_runtime);
 
+    if (gameobj && converting_during_runtime) {
+      gameobj->SetIsConvertedDuringRuntime();
+      gameobj->SetIsReplicaObject();
+    }
+
     if (gameobj) {
       /* macro calls object conversion funcs */
       BL_CONVERTBLENDEROBJECT_SINGLE;

--- a/source/gameengine/Ketsji/KX_GameObject.cpp
+++ b/source/gameengine/Ketsji/KX_GameObject.cpp
@@ -432,14 +432,7 @@ void KX_GameObject::RemoveReplicaObject()
   if (ob && m_isReplica) {
     bContext *C = KX_GetActiveEngine()->GetContext();
     Main *bmain = CTX_data_main(C);
-    Scene *scene = GetScene()->GetBlenderScene();
-
-    /* For converted objects during runtime, idk why calling free user
-     * in BKE_object_collection_remove causes an issue during undo step
-     * then we set it to false (last argument).
-     */
-    BKE_scene_collections_object_remove(bmain, scene, ob, !m_isConvertedDuringRuntime);
-    BKE_id_free(bmain, &ob->id);
+    BKE_id_delete(bmain, ob);
     SetBlenderObject(nullptr);
     DEG_relations_tag_update(bmain);
   }

--- a/source/gameengine/Ketsji/KX_GameObject.cpp
+++ b/source/gameengine/Ketsji/KX_GameObject.cpp
@@ -84,11 +84,11 @@ static MT_Matrix3x3 dummy_orientation = MT_Matrix3x3(
 
 KX_GameObject::KX_GameObject(void *sgReplicationInfo, SG_Callbacks callbacks)
     : SCA_IObject(),
-      m_isReplica(false),           // eevee
+      m_isReplica(false),                // eevee
       m_isConvertedDuringRuntime(false), // eevee
-      m_staticObject(true),         // eevee
-      m_visibleAtGameStart(false),  // eevee
-      m_forceIgnoreParentTx(false), // eevee
+      m_staticObject(true),              // eevee
+      m_visibleAtGameStart(false),       // eevee
+      m_forceIgnoreParentTx(false),      // eevee
       m_layer(0),
       m_lodManager(nullptr),
       m_currentLodLevel(0),
@@ -433,7 +433,12 @@ void KX_GameObject::RemoveReplicaObject()
     bContext *C = KX_GetActiveEngine()->GetContext();
     Main *bmain = CTX_data_main(C);
     Scene *scene = GetScene()->GetBlenderScene();
-    BKE_scene_collections_object_remove(bmain, scene, ob, true);
+
+    /* For converted objects during runtime, idk why calling free user
+     * in BKE_object_collection_remove causes an issue during undo step
+     * then we don't set it to false (last argument).
+     */
+    BKE_scene_collections_object_remove(bmain, scene, ob, !m_isConvertedDuringRuntime);
     BKE_id_free(bmain, &ob->id);
     SetBlenderObject(nullptr);
     DEG_relations_tag_update(bmain);

--- a/source/gameengine/Ketsji/KX_GameObject.cpp
+++ b/source/gameengine/Ketsji/KX_GameObject.cpp
@@ -432,7 +432,7 @@ void KX_GameObject::RemoveReplicaObject()
     bContext *C = KX_GetActiveEngine()->GetContext();
     Main *bmain = CTX_data_main(C);
     Scene *scene = GetScene()->GetBlenderScene();
-    BKE_scene_collections_object_remove(bmain, scene, ob, true);
+    BKE_scene_collections_object_remove(bmain, scene, ob, false);
     BKE_id_free(bmain, &ob->id);
     SetBlenderObject(nullptr);
     DEG_relations_tag_update(bmain);
@@ -586,6 +586,11 @@ void KX_GameObject::AddDummyLodManager(RAS_MeshObject *meshObj, Object *ob)
 bool KX_GameObject::IsReplica()
 {
   return m_isReplica;
+}
+
+void KX_GameObject::SetIsReplicaObject(bool isReplica)
+{
+  m_isReplica = isReplica;
 }
 
 void KX_GameObject::BackupObmat(Object *ob)

--- a/source/gameengine/Ketsji/KX_GameObject.cpp
+++ b/source/gameengine/Ketsji/KX_GameObject.cpp
@@ -436,7 +436,7 @@ void KX_GameObject::RemoveReplicaObject()
 
     /* For converted objects during runtime, idk why calling free user
      * in BKE_object_collection_remove causes an issue during undo step
-     * then we don't set it to false (last argument).
+     * then we set it to false (last argument).
      */
     BKE_scene_collections_object_remove(bmain, scene, ob, !m_isConvertedDuringRuntime);
     BKE_id_free(bmain, &ob->id);

--- a/source/gameengine/Ketsji/KX_GameObject.cpp
+++ b/source/gameengine/Ketsji/KX_GameObject.cpp
@@ -85,6 +85,7 @@ static MT_Matrix3x3 dummy_orientation = MT_Matrix3x3(
 KX_GameObject::KX_GameObject(void *sgReplicationInfo, SG_Callbacks callbacks)
     : SCA_IObject(),
       m_isReplica(false),           // eevee
+      m_isConvertedDuringRuntime(false), // eevee
       m_staticObject(true),         // eevee
       m_visibleAtGameStart(false),  // eevee
       m_forceIgnoreParentTx(false), // eevee
@@ -432,7 +433,7 @@ void KX_GameObject::RemoveReplicaObject()
     bContext *C = KX_GetActiveEngine()->GetContext();
     Main *bmain = CTX_data_main(C);
     Scene *scene = GetScene()->GetBlenderScene();
-    BKE_scene_collections_object_remove(bmain, scene, ob, false);
+    BKE_scene_collections_object_remove(bmain, scene, ob, true);
     BKE_id_free(bmain, &ob->id);
     SetBlenderObject(nullptr);
     DEG_relations_tag_update(bmain);
@@ -447,7 +448,7 @@ bool KX_GameObject::IsStatic()
 void KX_GameObject::HideOriginalObject()
 {
   Object *ob = GetBlenderObject();
-  if (ob && !m_isReplica &&
+  if (ob && !m_isReplica && !m_isConvertedDuringRuntime &&
       (ob->base_flag & (BASE_VISIBLE_VIEWLAYER | BASE_VISIBLE_DEPSGRAPH)) != 0) {
     Scene *scene = GetScene()->GetBlenderScene();
     ViewLayer *view_layer = BKE_view_layer_default_view(scene);
@@ -588,9 +589,14 @@ bool KX_GameObject::IsReplica()
   return m_isReplica;
 }
 
-void KX_GameObject::SetIsReplicaObject(bool isReplica)
+void KX_GameObject::SetIsReplicaObject()
 {
-  m_isReplica = isReplica;
+  m_isReplica = true;
+}
+
+void KX_GameObject::SetIsConvertedDuringRuntime()
+{
+  m_isConvertedDuringRuntime = true;
 }
 
 void KX_GameObject::BackupObmat(Object *ob)

--- a/source/gameengine/Ketsji/KX_GameObject.cpp
+++ b/source/gameengine/Ketsji/KX_GameObject.cpp
@@ -85,7 +85,6 @@ static MT_Matrix3x3 dummy_orientation = MT_Matrix3x3(
 KX_GameObject::KX_GameObject(void *sgReplicationInfo, SG_Callbacks callbacks)
     : SCA_IObject(),
       m_isReplica(false),                // eevee
-      m_isConvertedDuringRuntime(false), // eevee
       m_staticObject(true),              // eevee
       m_visibleAtGameStart(false),       // eevee
       m_forceIgnoreParentTx(false),      // eevee
@@ -446,7 +445,7 @@ bool KX_GameObject::IsStatic()
 void KX_GameObject::HideOriginalObject()
 {
   Object *ob = GetBlenderObject();
-  if (ob && !m_isReplica && !m_isConvertedDuringRuntime &&
+  if (ob && !m_isReplica &&
       (ob->base_flag & (BASE_VISIBLE_VIEWLAYER | BASE_VISIBLE_DEPSGRAPH)) != 0) {
     Scene *scene = GetScene()->GetBlenderScene();
     ViewLayer *view_layer = BKE_view_layer_default_view(scene);
@@ -590,11 +589,6 @@ bool KX_GameObject::IsReplica()
 void KX_GameObject::SetIsReplicaObject()
 {
   m_isReplica = true;
-}
-
-void KX_GameObject::SetIsConvertedDuringRuntime()
-{
-  m_isConvertedDuringRuntime = true;
 }
 
 void KX_GameObject::BackupObmat(Object *ob)

--- a/source/gameengine/Ketsji/KX_GameObject.h
+++ b/source/gameengine/Ketsji/KX_GameObject.h
@@ -157,6 +157,7 @@ class KX_GameObject : public SCA_IObject {
   void ForceIgnoreParentTx();
   bool OrigObCanBeTransformedInRealtime(Object *ob);
   void SyncTransformWithDepsgraph();
+  void SetIsReplicaObject(bool isReplica);
   /* END OF EEVEE INTEGRATION */
 
   /**

--- a/source/gameengine/Ketsji/KX_GameObject.h
+++ b/source/gameengine/Ketsji/KX_GameObject.h
@@ -92,6 +92,7 @@ class KX_GameObject : public SCA_IObject {
   float m_origObmat[4][4];
   float m_prevObmat[4][4];
   bool m_isReplica;
+  bool m_isConvertedDuringRuntime;
   bool m_staticObject;
   bool m_useCopy;
   bool m_visibleAtGameStart;
@@ -157,7 +158,8 @@ class KX_GameObject : public SCA_IObject {
   void ForceIgnoreParentTx();
   bool OrigObCanBeTransformedInRealtime(Object *ob);
   void SyncTransformWithDepsgraph();
-  void SetIsReplicaObject(bool isReplica);
+  void SetIsReplicaObject();
+  void SetIsConvertedDuringRuntime();
   /* END OF EEVEE INTEGRATION */
 
   /**

--- a/source/gameengine/Ketsji/KX_GameObject.h
+++ b/source/gameengine/Ketsji/KX_GameObject.h
@@ -92,7 +92,6 @@ class KX_GameObject : public SCA_IObject {
   float m_origObmat[4][4];
   float m_prevObmat[4][4];
   bool m_isReplica;
-  bool m_isConvertedDuringRuntime;
   bool m_staticObject;
   bool m_useCopy;
   bool m_visibleAtGameStart;
@@ -159,7 +158,6 @@ class KX_GameObject : public SCA_IObject {
   bool OrigObCanBeTransformedInRealtime(Object *ob);
   void SyncTransformWithDepsgraph();
   void SetIsReplicaObject();
-  void SetIsConvertedDuringRuntime();
   /* END OF EEVEE INTEGRATION */
 
   /**

--- a/source/gameengine/Ketsji/KX_Scene.cpp
+++ b/source/gameengine/Ketsji/KX_Scene.cpp
@@ -871,6 +871,9 @@ void KX_Scene::ConvertBlenderObject(Object *ob)
                            false,
                            false);
 
+
+  KX_GameObject *newGameob = GetObjectList()->GetBack();
+  newGameob->SetIsReplicaObject(true);
 }
 
 void KX_Scene::convert_blender_objects_list_synchronous(std::vector<Object *> objectslist)

--- a/source/gameengine/Ketsji/KX_Scene.cpp
+++ b/source/gameengine/Ketsji/KX_Scene.cpp
@@ -870,6 +870,7 @@ void KX_Scene::ConvertBlenderObject(Object *ob)
                            ob,
                            false,
                            false);
+
 }
 
 void KX_Scene::convert_blender_objects_list_synchronous(std::vector<Object *> objectslist)

--- a/source/gameengine/Ketsji/KX_Scene.cpp
+++ b/source/gameengine/Ketsji/KX_Scene.cpp
@@ -870,10 +870,6 @@ void KX_Scene::ConvertBlenderObject(Object *ob)
                            ob,
                            false,
                            false);
-
-
-  KX_GameObject *newGameob = GetObjectList()->GetBack();
-  newGameob->SetIsReplicaObject(true);
 }
 
 void KX_Scene::convert_blender_objects_list_synchronous(std::vector<Object *> objectslist)


### PR DESCRIPTION
convertBlenderObject() function didn't tag the gameobject as a replica object. As only replica blenderObjects are freed, when we were calling endObject() for a converted object during runtime, the blenderObject was not freed.

This patch is an attempt to fix this issue.

I had to deal with other specificities related to objects converted during runtime and this result with something a bit experimental.

This is the reason why before merge, it would be nice if you @BluePrintRandom , @mysticfall , @lordloki could test it with your files using convertBlenderObject/convertBlenderCollection/convertObjectList and tell me if it works for you, when you will have a moment to test.

Also don't hesitate if you have remarks about the code.

Thanks!