### PR TITLE
UPBGE: Allow to change .blend in embedded in "viewport render mode"

### DIFF
--- a/source/blender/windowmanager/intern/wm_window.c
+++ b/source/blender/windowmanager/intern/wm_window.c
@@ -2586,6 +2586,21 @@ void wm_window_ghostwindow_embedded_ensure(wmWindowManager *wm, wmWindow *win)
 {
   wm_window_clear_drawable(wm);
   wm_window_set_drawable(wm, win, true);
+
+  GHOST_RectangleHandle bounds;
+  /* store actual window size in blender window */
+  bounds = GHOST_GetClientBounds(win->ghostwin);
+  /* win32: gives undefined window size when minimized */
+  if (GHOST_GetWindowState(win->ghostwin) != GHOST_kWindowStateMinimized) {
+    win->sizex = GHOST_GetWidthRectangle(bounds);
+    win->sizey = GHOST_GetHeightRectangle(bounds);
+  }
+  GHOST_DisposeRectangle(bounds);
+  /* until screens get drawn, make it black */
+  GPU_clear_color(0.0f, 0.0f, 0.0f, 0.0f);
+
+  /* needed here, because it's used before it reads userdef */
+  WM_window_set_dpi(win);
 }
 /* End of Game engine transition */
 /** \} */

--- a/source/gameengine/BlenderRoutines/BL_KetsjiEmbedStart.cpp
+++ b/source/gameengine/BlenderRoutines/BL_KetsjiEmbedStart.cpp
@@ -43,6 +43,7 @@
 #include "BLI_blenlib.h"
 #include "BLO_readfile.h"
 #include "DNA_space_types.h"
+#include "draw/DRW_engine.h"
 #include "ED_screen.h"
 #include "WM_api.h"
 #include "wm_window.h"
@@ -231,6 +232,11 @@ extern "C" void StartKetsjiShell(struct bContext *C,
         wm_window_ghostwindow_embedded_ensure(wm, win);
         WM_check(C);
 
+        bScreen *screen = CTX_wm_screen(C);
+        for (ScrArea *area = (ScrArea *)screen->areabase.first; area; area = area->next) {
+          ED_area_tag_redraw(area);
+        }
+
         if (blenderdata) {
           BLI_strncpy(pathname, blenderdata->name, sizeof(pathname));
           // Change G_MAIN path to ensure loading of data using relative paths.
@@ -351,6 +357,10 @@ extern "C" void StartKetsjiShell(struct bContext *C,
     wm_backup->message_bus = (wmMsgBus *)msgbus_backup;
     InitBlenderContextVariables(C, wm_backup, startscene);
     WM_check(C);
+    bScreen *screen = CTX_wm_screen(C);
+    for (ScrArea *area = (ScrArea *)screen->areabase.first; area; area = area->next) {
+      ED_area_tag_redraw(area);
+    }
   }
 
   /* Undo System */

--- a/source/gameengine/BlenderRoutines/BL_KetsjiEmbedStart.cpp
+++ b/source/gameengine/BlenderRoutines/BL_KetsjiEmbedStart.cpp
@@ -43,7 +43,6 @@
 #include "BLI_blenlib.h"
 #include "BLO_readfile.h"
 #include "DNA_space_types.h"
-#include "draw/DRW_engine.h"
 #include "ED_screen.h"
 #include "WM_api.h"
 #include "wm_window.h"

--- a/source/gameengine/BlenderRoutines/BL_KetsjiEmbedStart.cpp
+++ b/source/gameengine/BlenderRoutines/BL_KetsjiEmbedStart.cpp
@@ -356,10 +356,11 @@ extern "C" void StartKetsjiShell(struct bContext *C,
     wm_backup->message_bus = (wmMsgBus *)msgbus_backup;
     InitBlenderContextVariables(C, wm_backup, startscene);
     WM_check(C);
-    bScreen *screen = CTX_wm_screen(C);
-    ED_screen_areas_iter(win_backup, screen, area_iter) {
-      ED_area_tag_redraw(area_iter);
-    }
+  }
+
+  bScreen *screen = CTX_wm_screen(C);
+  ED_screen_areas_iter (win_backup, screen, area_iter) {
+    ED_area_tag_redraw(area_iter);
   }
 
   /* Undo System */

--- a/source/gameengine/BlenderRoutines/BL_KetsjiEmbedStart.cpp
+++ b/source/gameengine/BlenderRoutines/BL_KetsjiEmbedStart.cpp
@@ -43,6 +43,7 @@
 #include "BLI_blenlib.h"
 #include "BLO_readfile.h"
 #include "DNA_space_types.h"
+#include "ED_screen.h"
 #include "WM_api.h"
 #include "wm_window.h"
 
@@ -165,6 +166,8 @@ extern "C" void StartKetsjiShell(struct bContext *C,
   void *msgbus_backup = wm_backup->message_bus;
   void *gpuctx_backup = win_backup->gpuctx;
   void *ghostwin_backup = win_backup->ghostwin;
+
+  bool useViewportRender = startscene->gm.flag & GAME_USE_VIEWPORT_RENDER;
 
   do {
     // if we got an exitcode 3 (KX_ExitRequest::START_OTHER_GAME) load a different file
@@ -294,7 +297,8 @@ extern "C" void StartKetsjiShell(struct bContext *C,
                                                      C,
                                                      cam_frame,
                                                      CTX_wm_region(C),
-                                                     always_use_expand_framing);
+                                                     always_use_expand_framing,
+                                                     useViewportRender);
 #ifdef WITH_PYTHON
     launcher.SetPythonGlobalDict(globalDict);
 #endif  // WITH_PYTHON
@@ -310,6 +314,21 @@ extern "C" void StartKetsjiShell(struct bContext *C,
     gs = *launcher.GetGlobalSettings();
 
     launcher.ExitEngine();
+
+    /* refer to WM_exit_ext() and BKE_blender_free(),
+     * these are not called in the player but we need to match some of there behavior here,
+     * if the order of function calls or blenders state isn't matching that of blender
+     * proper, we may get troubles later on */
+    WM_jobs_kill_all(CTX_wm_manager(C));
+
+    for (wmWindow *win = (wmWindow *)CTX_wm_manager(C)->windows.first; win; win = win->next) {
+
+      CTX_wm_window_set(C, win); /* needed by operator close callbacks */
+      WM_event_remove_handlers(C, &win->handlers);
+      WM_event_remove_handlers(C, &win->modalhandlers);
+      ED_screen_exit(C, win, WM_window_get_active_screen(win));
+    }
+    ED_screens_init(G_MAIN, CTX_wm_manager(C));
 
   } while (exitrequested == KX_ExitRequest::RESTART_GAME ||
            exitrequested == KX_ExitRequest::START_OTHER_GAME);

--- a/source/gameengine/BlenderRoutines/BL_KetsjiEmbedStart.cpp
+++ b/source/gameengine/BlenderRoutines/BL_KetsjiEmbedStart.cpp
@@ -320,21 +320,6 @@ extern "C" void StartKetsjiShell(struct bContext *C,
 
     launcher.ExitEngine();
 
-    /* refer to WM_exit_ext() and BKE_blender_free(),
-     * these are not called in the player but we need to match some of there behavior here,
-     * if the order of function calls or blenders state isn't matching that of blender
-     * proper, we may get troubles later on */
-    WM_jobs_kill_all(CTX_wm_manager(C));
-
-    for (wmWindow *win = (wmWindow *)CTX_wm_manager(C)->windows.first; win; win = win->next) {
-
-      CTX_wm_window_set(C, win); /* needed by operator close callbacks */
-      WM_event_remove_handlers(C, &win->handlers);
-      WM_event_remove_handlers(C, &win->modalhandlers);
-      ED_screen_exit(C, win, WM_window_get_active_screen(win));
-    }
-    ED_screens_init(G_MAIN, CTX_wm_manager(C));
-
   } while (exitrequested == KX_ExitRequest::RESTART_GAME ||
            exitrequested == KX_ExitRequest::START_OTHER_GAME);
 

--- a/source/gameengine/BlenderRoutines/BL_KetsjiEmbedStart.cpp
+++ b/source/gameengine/BlenderRoutines/BL_KetsjiEmbedStart.cpp
@@ -374,12 +374,13 @@ extern "C" void StartKetsjiShell(struct bContext *C,
     win_backup->ghostwin = ghostwin_backup;
     win_backup->gpuctx = gpuctx_backup;
     wm_backup->message_bus = (wmMsgBus *)msgbus_backup;
-    InitBlenderContextVariables(C, wm_backup, startscene);
-
-    WM_check(C);
-    ED_screen_change(C, WM_window_get_active_screen(win_backup));
-    ED_screen_refresh(wm_backup, win_backup);
   }
+
+  InitBlenderContextVariables(C, wm_backup, startscene);
+
+  WM_check(C);
+  ED_screen_change(C, WM_window_get_active_screen(win_backup));
+  ED_screen_refresh(wm_backup, win_backup);
 
   /* Restore shading type we had before game start */
   CTX_wm_view3d(C)->shading.type = shadingTypeBackup;

--- a/source/gameengine/BlenderRoutines/BL_KetsjiEmbedStart.cpp
+++ b/source/gameengine/BlenderRoutines/BL_KetsjiEmbedStart.cpp
@@ -353,16 +353,15 @@ extern "C" void StartKetsjiShell(struct bContext *C,
      * these are not called in the player but we need to match some of there behavior here,
      * if the order of function calls or blenders state isn't matching that of blender
      * proper, we may get troubles later on */
-    WM_jobs_kill_all(CTX_wm_manager(C));
+    wmWindowManager *wm = CTX_wm_manager(C);
+    WM_jobs_kill_all(wm);
 
-    for (wmWindow *win = (wmWindow *)CTX_wm_manager(C)->windows.first; win; win = win->next) {
-
+    LISTBASE_FOREACH (wmWindow *, win, &wm->windows) {
       CTX_wm_window_set(C, win); /* needed by operator close callbacks */
       WM_event_remove_handlers(C, &win->handlers);
       WM_event_remove_handlers(C, &win->modalhandlers);
       ED_screen_exit(C, win, WM_window_get_active_screen(win));
     }
-
   } while (exitrequested == KX_ExitRequest::RESTART_GAME ||
            exitrequested == KX_ExitRequest::START_OTHER_GAME);
 

--- a/source/gameengine/BlenderRoutines/BL_KetsjiEmbedStart.cpp
+++ b/source/gameengine/BlenderRoutines/BL_KetsjiEmbedStart.cpp
@@ -233,8 +233,8 @@ extern "C" void StartKetsjiShell(struct bContext *C,
         WM_check(C);
 
         bScreen *screen = CTX_wm_screen(C);
-        for (ScrArea *area = (ScrArea *)screen->areabase.first; area; area = area->next) {
-          ED_area_tag_redraw(area);
+        ED_screen_areas_iter (win, screen, area_iter) {
+          ED_area_tag_redraw(area_iter);
         }
 
         if (blenderdata) {
@@ -358,8 +358,8 @@ extern "C" void StartKetsjiShell(struct bContext *C,
     InitBlenderContextVariables(C, wm_backup, startscene);
     WM_check(C);
     bScreen *screen = CTX_wm_screen(C);
-    for (ScrArea *area = (ScrArea *)screen->areabase.first; area; area = area->next) {
-      ED_area_tag_redraw(area);
+    ED_screen_areas_iter(win_backup, screen, area_iter) {
+      ED_area_tag_redraw(area_iter);
     }
   }
 

--- a/source/gameengine/GamePlayer/GPG_ghost.cpp
+++ b/source/gameengine/GamePlayer/GPG_ghost.cpp
@@ -1615,11 +1615,10 @@ int main(int argc,
            * these are not called in the player but we need to match some of there behavior here,
            * if the order of function calls or blenders state isn't matching that of blender
            * proper, we may get troubles later on */
-          WM_jobs_kill_all(CTX_wm_manager(C));
+          wmWindowManager *wm = CTX_wm_manager(C);
+          WM_jobs_kill_all(wm);
 
-          for (wmWindow *win = (wmWindow *)CTX_wm_manager(C)->windows.first; win;
-               win = win->next) {
-
+          LISTBASE_FOREACH (wmWindow *, win, &wm->windows) {
             CTX_wm_window_set(C, win); /* needed by operator close callbacks */
             WM_event_remove_handlers(C, &win->handlers);
             WM_event_remove_handlers(C, &win->modalhandlers);

--- a/source/gameengine/GamePlayer/GPG_ghost.cpp
+++ b/source/gameengine/GamePlayer/GPG_ghost.cpp
@@ -1371,10 +1371,12 @@ int main(int argc,
             CTX_data_scene_set(C, scene);
             G.main = maggie;
             G_MAIN = G.main;
+            bool useViewportRender = false;
 
             if (firstTimeRunning) {
               G.fileflags = bfd->fileflags;
               gs.glslflag = scene->gm.flag;
+              useViewportRender = scene->gm.flag & GAME_USE_VIEWPORT_RENDER;
             }
 
             titlename = maggie->name;
@@ -1560,7 +1562,8 @@ int main(int argc,
                                        argc,
                                        argv,
                                        pythonControllerFile,
-                                       C);
+                                       C,
+                                       useViewportRender);
 #ifdef WITH_PYTHON
             if (!globalDict) {
               globalDict = PyDict_New();

--- a/source/gameengine/GamePlayer/GPG_ghost.cpp
+++ b/source/gameengine/GamePlayer/GPG_ghost.cpp
@@ -1278,9 +1278,10 @@ int main(int argc,
 #ifdef WITH_PYTHON
         initGamePlayerPythonScripting(argc, argv, C);
 #endif
-
+        /* Set Viewport render mode and shading type for the whole runtime */
         bool first_time_window = true;
         int shadingTypeRuntime = 0;
+        bool useViewportRender = false;
 
         do {
           // Read the Blender file
@@ -1383,7 +1384,6 @@ int main(int argc,
             CTX_data_scene_set(C, scene);
             G.main = maggie;
             G_MAIN = G.main;
-            bool useViewportRender = false;
 
             if (firstTimeRunning) {
               G.fileflags = bfd->fileflags;

--- a/source/gameengine/Ketsji/KX_BlenderMaterial.cpp
+++ b/source/gameengine/Ketsji/KX_BlenderMaterial.cpp
@@ -59,7 +59,7 @@ KX_BlenderMaterial::KX_BlenderMaterial(RAS_Rasterizer *rasty,
    * (m_textures list won't be available for these object)
    */
   if (m_material->use_nodes && m_material->nodetree && !converting_during_runtime) {
-    if ((m_scene->GetBlenderScene()->gm.flag & GAME_USE_VIEWPORT_RENDER) == 0) {
+    if (!KX_GetActiveEngine()->UseViewportRender()) {
       EEVEE_Data *vedata = EEVEE_engine_data_get();
       EEVEE_EffectsInfo *effects = vedata->stl->effects;
       const bool use_ssrefract = ((m_material->blend_flag & MA_BL_SS_REFRACTION) != 0) &&

--- a/source/gameengine/Ketsji/KX_KetsjiEngine.cpp
+++ b/source/gameengine/Ketsji/KX_KetsjiEngine.cpp
@@ -118,9 +118,10 @@ const std::string KX_KetsjiEngine::m_profileLabels[tc_numCategories] = {
 /**
  * Constructor of the Ketsji Engine
  */
-KX_KetsjiEngine::KX_KetsjiEngine(KX_ISystem *system, bContext *C, bool useViewportRender)
-    : m_context(C),
-      m_useViewportRender(useViewportRender),
+KX_KetsjiEngine::KX_KetsjiEngine(KX_ISystem *system, bContext *C, bool useViewportRender, int shadingTypeRuntime)
+    : m_context(C),                             // eevee
+      m_useViewportRender(useViewportRender),   // eevee
+      m_shadingTypeRuntime(shadingTypeRuntime), // eevee
       m_canvas(nullptr),
       m_rasterizer(nullptr),
       m_kxsystem(system),
@@ -182,6 +183,11 @@ bContext *KX_KetsjiEngine::GetContext()
 bool KX_KetsjiEngine::UseViewportRender()
 {
   return m_useViewportRender;
+}
+
+int KX_KetsjiEngine::ShadingTypeRuntime()
+{
+  return m_shadingTypeRuntime;
 }
 
 /* include Depsgraph update time in tc_depsgraph category

--- a/source/gameengine/Ketsji/KX_KetsjiEngine.cpp
+++ b/source/gameengine/Ketsji/KX_KetsjiEngine.cpp
@@ -118,8 +118,9 @@ const std::string KX_KetsjiEngine::m_profileLabels[tc_numCategories] = {
 /**
  * Constructor of the Ketsji Engine
  */
-KX_KetsjiEngine::KX_KetsjiEngine(KX_ISystem *system, bContext *C)
+KX_KetsjiEngine::KX_KetsjiEngine(KX_ISystem *system, bContext *C, bool useViewportRender)
     : m_context(C),
+      m_useViewportRender(useViewportRender),
       m_canvas(nullptr),
       m_rasterizer(nullptr),
       m_kxsystem(system),
@@ -176,6 +177,11 @@ KX_KetsjiEngine::~KX_KetsjiEngine()
 bContext *KX_KetsjiEngine::GetContext()
 {
   return m_context;
+}
+
+bool KX_KetsjiEngine::UseViewportRender()
+{
+  return m_useViewportRender;
 }
 
 /* include Depsgraph update time in tc_depsgraph category
@@ -724,8 +730,8 @@ void KX_KetsjiEngine::Render()
       }
     }
   }
-  Scene *first_scene = m_scenes->GetFront()->GetBlenderScene();
-  if (!(first_scene->gm.flag & GAME_USE_VIEWPORT_RENDER)) {
+
+  if (!UseViewportRender()) {
     int v[4];
     v[0] = m_canvas->GetViewportArea().GetLeft();
     v[1] = m_canvas->GetViewportArea().GetBottom();
@@ -1291,11 +1297,6 @@ KX_Scene *KX_KetsjiEngine::CreateScene(const std::string &scenename)
 
 bool KX_KetsjiEngine::ReplaceScene(const std::string &oldscene, const std::string &newscene)
 {
-  bool useViewportRender = (m_scenes->GetFront()->GetBlenderScene()->gm.flag & GAME_USE_VIEWPORT_RENDER) != 0;
-  if (useViewportRender && !m_canvas->IsBlenderPlayer()) {
-    std::cout << "Replace Scene is not available in viewport render mode in embedded." << std::endl;
-    return false;
-  }
   // Don't allow replacement if the new scene doesn't exist.
   // Allows smarter game design (used to have no check here).
   // Note that it creates a small backward compatbility issue

--- a/source/gameengine/Ketsji/KX_KetsjiEngine.h
+++ b/source/gameengine/Ketsji/KX_KetsjiEngine.h
@@ -129,6 +129,7 @@ class KX_KetsjiEngine {
   };
 
   struct bContext *m_context;
+  bool m_useViewportRender;
 
   /// 2D Canvas (2D Rendering Device Context)
   RAS_ICanvas *m_canvas;
@@ -271,11 +272,12 @@ class KX_KetsjiEngine {
   void BeginFrame();
 
  public:
-  KX_KetsjiEngine(KX_ISystem *system, struct bContext *C);
+  KX_KetsjiEngine(KX_ISystem *system, struct bContext *C, bool useViewportRender);
   virtual ~KX_KetsjiEngine();
 
   /* EEVEE integration */
   struct bContext *GetContext();
+  bool UseViewportRender();
   // include depsgraph time in tc_depsgraph category
   void CountDepsgraphTime();
   void EndCountDepsgraphTime();

--- a/source/gameengine/Ketsji/KX_KetsjiEngine.h
+++ b/source/gameengine/Ketsji/KX_KetsjiEngine.h
@@ -275,7 +275,7 @@ class KX_KetsjiEngine {
   void BeginFrame();
 
  public:
-  KX_KetsjiEngine(KX_ISystem *system, struct bContext *C, bool useViewportRender, int shadingTypeBackup);
+  KX_KetsjiEngine(KX_ISystem *system, struct bContext *C, bool useViewportRender, int shadingTypeRuntime);
   virtual ~KX_KetsjiEngine();
 
   /******** EEVEE integration *********/

--- a/source/gameengine/Ketsji/KX_KetsjiEngine.h
+++ b/source/gameengine/Ketsji/KX_KetsjiEngine.h
@@ -128,8 +128,11 @@ class KX_KetsjiEngine {
     std::vector<SceneRenderData> m_sceneDataList;
   };
 
+  /***************EEVEE INTEGRATION*****************/
   struct bContext *m_context;
   bool m_useViewportRender;
+  int m_shadingTypeRuntime;
+  /*************************************************/
 
   /// 2D Canvas (2D Rendering Device Context)
   RAS_ICanvas *m_canvas;
@@ -272,17 +275,18 @@ class KX_KetsjiEngine {
   void BeginFrame();
 
  public:
-  KX_KetsjiEngine(KX_ISystem *system, struct bContext *C, bool useViewportRender);
+  KX_KetsjiEngine(KX_ISystem *system, struct bContext *C, bool useViewportRender, int shadingTypeBackup);
   virtual ~KX_KetsjiEngine();
 
-  /* EEVEE integration */
+  /******** EEVEE integration *********/
   struct bContext *GetContext();
   bool UseViewportRender();
+  int ShadingTypeRuntime();
   // include depsgraph time in tc_depsgraph category
   void CountDepsgraphTime();
   void EndCountDepsgraphTime();
   void EndFrameViewportRender();
-  /* End of EEVEE integration */
+  /***** End of EEVEE integration *****/
 
   void EndFrame();
 

--- a/source/gameengine/Ketsji/KX_Scene.cpp
+++ b/source/gameengine/Ketsji/KX_Scene.cpp
@@ -313,6 +313,9 @@ KX_Scene::~KX_Scene()
     DRW_game_viewport_render_loop_end();
   }
 
+  /* Fixes issue when switching .blend erm...*/
+  GPU_shader_force_unbind();
+
   for (Object *hiddenOb : m_hiddenObjectsDuringRuntime) {
     Base *base = BKE_view_layer_base_find(view_layer, hiddenOb);
     base->flag &= ~BASE_HIDDEN;

--- a/source/gameengine/Ketsji/KX_Scene.h
+++ b/source/gameengine/Ketsji/KX_Scene.h
@@ -122,7 +122,6 @@ class KX_Scene : public CValue, public SCA_IScene {
   bool m_resetTaaSamples;
   Object *m_lastReplicatedParentObject;
   Object *m_gameDefaultCamera;
-  int m_shadingTypeBackup;
   std::vector<struct Collection *> m_overlay_collections;
   struct GPUViewport *m_currentGPUViewport;
   /* In the current state of the code, we need this
@@ -333,7 +332,7 @@ class KX_Scene : public CValue, public SCA_IScene {
   void ResetLastReplicatedParentObject();
   Object *GetGameDefaultCamera();
   void ReinitBlenderContextVariables();
-  void BackupShadingType();
+  void ConfigureOverlays();
   void AddOverlayCollection(KX_Camera *overlay_cam, struct Collection *collection);
   void RemoveOverlayCollection(struct Collection *collection);
   void SetCurrentGPUViewport(struct GPUViewport *viewport);

--- a/source/gameengine/Launcher/LA_BlenderLauncher.cpp
+++ b/source/gameengine/Launcher/LA_BlenderLauncher.cpp
@@ -52,8 +52,9 @@ LA_BlenderLauncher::LA_BlenderLauncher(GHOST_ISystem *system,
                                        bContext *context,
                                        rcti *camframe,
                                        ARegion *ar,
-                                       int alwaysUseExpandFraming)
-    : LA_Launcher(system, maggie, scene, gs, stereoMode, scene->gm.aasamples, argc, argv, context),
+                                       int alwaysUseExpandFraming,
+                                       bool useViewportRender)
+    : LA_Launcher(system, maggie, scene, gs, stereoMode, scene->gm.aasamples, argc, argv, context, useViewportRender),
       m_context(context),
       m_ar(ar),
       m_camFrame(camframe),

--- a/source/gameengine/Launcher/LA_BlenderLauncher.cpp
+++ b/source/gameengine/Launcher/LA_BlenderLauncher.cpp
@@ -53,8 +53,9 @@ LA_BlenderLauncher::LA_BlenderLauncher(GHOST_ISystem *system,
                                        rcti *camframe,
                                        ARegion *ar,
                                        int alwaysUseExpandFraming,
-                                       bool useViewportRender)
-    : LA_Launcher(system, maggie, scene, gs, stereoMode, scene->gm.aasamples, argc, argv, context, useViewportRender),
+                                       bool useViewportRender,
+                                       int shadingTypeRuntime)
+    : LA_Launcher(system, maggie, scene, gs, stereoMode, scene->gm.aasamples, argc, argv, context, useViewportRender, shadingTypeRuntime),
       m_context(context),
       m_ar(ar),
       m_camFrame(camframe),

--- a/source/gameengine/Launcher/LA_BlenderLauncher.h
+++ b/source/gameengine/Launcher/LA_BlenderLauncher.h
@@ -71,7 +71,8 @@ class LA_BlenderLauncher : public LA_Launcher {
                      bContext *context,
                      rcti *camframe,
                      ARegion *ar,
-                     int alwaysUseExpandFraming);
+                     int alwaysUseExpandFraming,
+                     bool useViewportRender);
   virtual ~LA_BlenderLauncher();
 
   virtual void InitEngine();

--- a/source/gameengine/Launcher/LA_BlenderLauncher.h
+++ b/source/gameengine/Launcher/LA_BlenderLauncher.h
@@ -72,7 +72,8 @@ class LA_BlenderLauncher : public LA_Launcher {
                      rcti *camframe,
                      ARegion *ar,
                      int alwaysUseExpandFraming,
-                     bool useViewportRender);
+                     bool useViewportRender,
+                     int shadingTypeRuntime);
   virtual ~LA_BlenderLauncher();
 
   virtual void InitEngine();

--- a/source/gameengine/Launcher/LA_Launcher.cpp
+++ b/source/gameengine/Launcher/LA_Launcher.cpp
@@ -64,12 +64,14 @@ LA_Launcher::LA_Launcher(GHOST_ISystem *system,
                          int samples,
                          int argc,
                          char **argv,
-                         bContext *C)
+                         bContext *C,
+                         bool useViewportRender)
     : m_startSceneName(scene->id.name + 2),
       m_startScene(scene),
       m_maggie(maggie),
       m_context(C),
       m_kxStartScene(nullptr),
+      m_useViewportRender(useViewportRender),
       m_exitRequested(KX_ExitRequest::NO_REQUEST),
       m_globalSettings(gs),
       m_system(system),
@@ -199,7 +201,7 @@ void LA_Launcher::InitEngine()
   m_networkMessageManager = new KX_NetworkMessageManager();
 
   // Create the ketsjiengine.
-  m_ketsjiEngine = new KX_KetsjiEngine(m_kxsystem, m_context);
+  m_ketsjiEngine = new KX_KetsjiEngine(m_kxsystem, m_context, m_useViewportRender);
   KX_SetActiveEngine(m_ketsjiEngine);
 
   // Set the devices.

--- a/source/gameengine/Launcher/LA_Launcher.cpp
+++ b/source/gameengine/Launcher/LA_Launcher.cpp
@@ -65,13 +65,15 @@ LA_Launcher::LA_Launcher(GHOST_ISystem *system,
                          int argc,
                          char **argv,
                          bContext *C,
-                         bool useViewportRender)
+                         bool useViewportRender,
+                         int shadingTypeRuntime)
     : m_startSceneName(scene->id.name + 2),
       m_startScene(scene),
       m_maggie(maggie),
       m_context(C),
       m_kxStartScene(nullptr),
       m_useViewportRender(useViewportRender),
+      m_shadingTypeRuntime(shadingTypeRuntime),
       m_exitRequested(KX_ExitRequest::NO_REQUEST),
       m_globalSettings(gs),
       m_system(system),
@@ -201,7 +203,7 @@ void LA_Launcher::InitEngine()
   m_networkMessageManager = new KX_NetworkMessageManager();
 
   // Create the ketsjiengine.
-  m_ketsjiEngine = new KX_KetsjiEngine(m_kxsystem, m_context, m_useViewportRender);
+  m_ketsjiEngine = new KX_KetsjiEngine(m_kxsystem, m_context, m_useViewportRender, m_shadingTypeRuntime);
   KX_SetActiveEngine(m_ketsjiEngine);
 
   // Set the devices.

--- a/source/gameengine/Launcher/LA_Launcher.h
+++ b/source/gameengine/Launcher/LA_Launcher.h
@@ -54,6 +54,7 @@ class LA_Launcher {
   struct bContext *m_context;
   KX_Scene *m_kxStartScene;
   bool m_useViewportRender;
+  int m_shadingTypeRuntime;
 
   /// \section Exit state.
   KX_ExitRequest m_exitRequested;
@@ -142,7 +143,8 @@ class LA_Launcher {
               int argc,
               char **argv,
               struct bContext *C,
-              bool useViewportRender);
+              bool useViewportRender,
+              int shadingTypeRuntime);
   virtual ~LA_Launcher();
 
 #ifdef WITH_PYTHON

--- a/source/gameengine/Launcher/LA_Launcher.h
+++ b/source/gameengine/Launcher/LA_Launcher.h
@@ -53,6 +53,7 @@ class LA_Launcher {
   Main *m_maggie;
   struct bContext *m_context;
   KX_Scene *m_kxStartScene;
+  bool m_useViewportRender;
 
   /// \section Exit state.
   KX_ExitRequest m_exitRequested;
@@ -140,7 +141,8 @@ class LA_Launcher {
               int samples,
               int argc,
               char **argv,
-              struct bContext *C);
+              struct bContext *C,
+              bool useViewportRender);
   virtual ~LA_Launcher();
 
 #ifdef WITH_PYTHON

--- a/source/gameengine/Launcher/LA_PlayerLauncher.cpp
+++ b/source/gameengine/Launcher/LA_PlayerLauncher.cpp
@@ -55,8 +55,9 @@ LA_PlayerLauncher::LA_PlayerLauncher(GHOST_ISystem *system,
                                      int argc,
                                      char **argv,
                                      const std::string &pythonMainLoop,
-                                     bContext *C)
-    : LA_Launcher(system, maggie, scene, gs, stereoMode, samples, argc, argv, C),
+                                     bContext *C,
+                                     bool useViewportRender)
+    : LA_Launcher(system, maggie, scene, gs, stereoMode, samples, argc, argv, C, useViewportRender),
       m_mainWindow(window),
       m_pythonMainLoop(pythonMainLoop)
 {

--- a/source/gameengine/Launcher/LA_PlayerLauncher.cpp
+++ b/source/gameengine/Launcher/LA_PlayerLauncher.cpp
@@ -56,8 +56,9 @@ LA_PlayerLauncher::LA_PlayerLauncher(GHOST_ISystem *system,
                                      char **argv,
                                      const std::string &pythonMainLoop,
                                      bContext *C,
-                                     bool useViewportRender)
-    : LA_Launcher(system, maggie, scene, gs, stereoMode, samples, argc, argv, C, useViewportRender),
+                                     bool useViewportRender,
+                                     int shadingTypeRuntime)
+    : LA_Launcher(system, maggie, scene, gs, stereoMode, samples, argc, argv, C, useViewportRender, shadingTypeRuntime),
       m_mainWindow(window),
       m_pythonMainLoop(pythonMainLoop)
 {

--- a/source/gameengine/Launcher/LA_PlayerLauncher.h
+++ b/source/gameengine/Launcher/LA_PlayerLauncher.h
@@ -69,7 +69,8 @@ class LA_PlayerLauncher : public LA_Launcher {
                     char **argv,
                     const std::string &pythonMainLoop,
                     struct bContext *C,
-                    bool useViewportRender);
+                    bool useViewportRender,
+                    int shadingTypeRuntime);
   virtual ~LA_PlayerLauncher();
 
   virtual void InitEngine();

--- a/source/gameengine/Launcher/LA_PlayerLauncher.h
+++ b/source/gameengine/Launcher/LA_PlayerLauncher.h
@@ -68,7 +68,8 @@ class LA_PlayerLauncher : public LA_Launcher {
                     int argc,
                     char **argv,
                     const std::string &pythonMainLoop,
-                    struct bContext *C);
+                    struct bContext *C,
+                    bool useViewportRender);
   virtual ~LA_PlayerLauncher();
 
   virtual void InitEngine();

--- a/source/gameengine/Rasterizer/RAS_OpenGLRasterizer/RAS_OpenGLDebugDraw.cpp
+++ b/source/gameengine/Rasterizer/RAS_OpenGLRasterizer/RAS_OpenGLDebugDraw.cpp
@@ -139,8 +139,7 @@ void RAS_OpenGLDebugDraw::Flush(RAS_Rasterizer *rasty,
   //  UnbindVBO();*/
   //}
 
-  Scene *mainScene = KX_GetActiveEngine()->CurrentScenes()->GetFront()->GetBlenderScene();
-  if (mainScene->gm.flag & GAME_USE_VIEWPORT_RENDER) {
+  if (KX_GetActiveEngine()->UseViewportRender()) {
     /* Draw Debug lines */
     if (!debugDraw->m_lines.empty()) {
       for (int i = 0; i < debugDraw->m_lines.size(); i++) {

--- a/source/gameengine/Rasterizer/RAS_OpenGLRasterizer/RAS_OpenGLDebugDraw.cpp
+++ b/source/gameengine/Rasterizer/RAS_OpenGLRasterizer/RAS_OpenGLDebugDraw.cpp
@@ -149,7 +149,7 @@ void RAS_OpenGLDebugDraw::Flush(RAS_Rasterizer *rasty,
     }
     /* The Performances profiler */
     const unsigned int left = canvas->GetViewportArea().GetLeft();
-    const unsigned int top = canvas->GetViewportArea().GetTop();
+    const unsigned int top = canvas->GetWindowArea().GetTop() - canvas->GetViewportArea().GetBottom();
     if (!debugDraw->m_boxes2D.empty()) {
       for (const RAS_DebugDraw::Box2D &b : debugDraw->m_boxes2D) {
         DRW_debug_box_2D_bge(left + b.m_pos[0], top - b.m_pos[1], b.m_size[0], b.m_size[1]);


### PR DESCRIPTION
it contains several changes:

- Make useViewportRender option persistent during the whole runtime
(because changing of mode when we load another scene or another .blend
can disturb the pipeline) (both embedded and blenderplayer)

- Make shading type persistent during the whole runtime (both embedded and blenderplayer). I think it's better as default and if people want to change shading type they can do it with bpy during runtime.

- We call ED_area_tag_redraw for all ScrAreas when we change .blend to avoid to have not drawn (black) areas and also at game engine exit to refresh the screen. For now, I didn't notice the need to redraw areas when we change scene (only when we change .blend)

- To limit memory leaks count when we change .blend, we use BKE_screen_exit which does a good enough cleaning job. In counterpart, we have to refresh screen (ED_screen_change + ED_screen_refresh) when we launch a new .blend.

- I tried to fix profile drawing alignment but there are still cases where the alignment is not good in viewport render mode.

- I fixed an issue related to window size when we launch a new .blend and when blender window size is minimized.

I tested mainly with this:

- launcher: https://pasteall.org/blend/2eb75c8916c7484f89a22d27c3032d07
- loaded .blend: https://pasteall.org/blend/639e3f6610e34a22ab70a30fac062ce9
- scenes switch test: https://pasteall.org/blend/84ed9f02ce744409a47e2cd660d7eacd

Remaining noticed issues:

- profile alignment not always correct
- little memory usage increase when switching .blend (it was existing before, but i didn't notice). I didn't found for now how to get rid of it (maybe we have to get code from wm_window_free, maybe we can track totblocks count too when we switch scene/.blend)

I think that even it is not perfect, it can be commited, but more tests are welcome.