### PR TITLE
Support data (ID) type properties for Python components

### DIFF
--- a/source/blender/blenkernel/BKE_python_component.h
+++ b/source/blender/blenkernel/BKE_python_component.h
@@ -26,6 +26,10 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+typedef void (*BKEPyComponentIDFunc)(struct PythonComponent *comp,
+                                  struct ID **idpoin,
+                                  void *userdata,
+                                  int cb_flag);
 
 struct PythonComponent *BKE_python_component_new(char *import,
                                                  struct ReportList *reports,
@@ -39,6 +43,8 @@ void BKE_python_component_reload(struct PythonComponent *pc,
 void BKE_python_component_copy_list(struct ListBase *lbn, const struct ListBase *lbo);
 void BKE_python_component_free(struct PythonComponent *pc);
 void BKE_python_component_free_list(struct ListBase *base);
+
+void BKE_python_components_id_loop(struct ListBase *complist, BKEPyComponentIDFunc func, void *userdata);
 
 void *BKE_python_component_argument_dict_new(struct PythonComponent *pc);
 

--- a/source/blender/blenkernel/BKE_sca.h
+++ b/source/blender/blenkernel/BKE_sca.h
@@ -76,7 +76,7 @@ void sca_move_sensor(struct bSensor *sens_to_move, struct Object *ob, int move_u
 void sca_move_controller(struct bController *cont_to_move, struct Object *ob, int move_up);
 void sca_move_actuator(struct bActuator *act_to_move, struct Object *ob, int move_up);
 
-/* Callback format for performing operations on ID-pointers for sensors/controllers/actuators/components. */
+/* Callback format for performing operations on ID-pointers for sensors/controllers/actuators. */
 typedef void (*SCASensorIDFunc)(struct bSensor *sensor,
                                 struct ID **idpoin,
                                 void *userdata,

--- a/source/blender/blenkernel/BKE_sca.h
+++ b/source/blender/blenkernel/BKE_sca.h
@@ -89,17 +89,12 @@ typedef void (*SCAActuatorIDFunc)(struct bActuator *actuator,
                                   struct ID **idpoin,
                                   void *userdata,
                                   int cb_flag);
-typedef void (*SCAComponentIDFunc)(struct PythonComponent *comp,
-                                  struct ID **idpoin,
-                                  void *userdata,
-                                  int cb_flag);
 
 void BKE_sca_sensors_id_loop(struct ListBase *senslist, SCASensorIDFunc func, void *userdata);
 void BKE_sca_controllers_id_loop(struct ListBase *contlist,
                                  SCAControllerIDFunc func,
                                  void *userdata);
 void BKE_sca_actuators_id_loop(struct ListBase *atclist, SCAActuatorIDFunc func, void *userdata);
-void BKE_sca_components_id_loop(struct ListBase *complist, SCAComponentIDFunc func, void *userdata);
 
 const char *sca_state_name_get(Object *ob, short bit);
 

--- a/source/blender/blenkernel/BKE_sca.h
+++ b/source/blender/blenkernel/BKE_sca.h
@@ -76,7 +76,7 @@ void sca_move_sensor(struct bSensor *sens_to_move, struct Object *ob, int move_u
 void sca_move_controller(struct bController *cont_to_move, struct Object *ob, int move_up);
 void sca_move_actuator(struct bActuator *act_to_move, struct Object *ob, int move_up);
 
-/* Callback format for performing operations on ID-pointers for sensors/controllers/actuators. */
+/* Callback format for performing operations on ID-pointers for sensors/controllers/actuators/components. */
 typedef void (*SCASensorIDFunc)(struct bSensor *sensor,
                                 struct ID **idpoin,
                                 void *userdata,
@@ -89,12 +89,17 @@ typedef void (*SCAActuatorIDFunc)(struct bActuator *actuator,
                                   struct ID **idpoin,
                                   void *userdata,
                                   int cb_flag);
+typedef void (*SCAComponentIDFunc)(struct PythonComponent *comp,
+                                  struct ID **idpoin,
+                                  void *userdata,
+                                  int cb_flag);
 
 void BKE_sca_sensors_id_loop(struct ListBase *senslist, SCASensorIDFunc func, void *userdata);
 void BKE_sca_controllers_id_loop(struct ListBase *contlist,
                                  SCAControllerIDFunc func,
                                  void *userdata);
 void BKE_sca_actuators_id_loop(struct ListBase *atclist, SCAActuatorIDFunc func, void *userdata);
+void BKE_sca_components_id_loop(struct ListBase *complist, SCAComponentIDFunc func, void *userdata);
 
 const char *sca_state_name_get(Object *ob, short bit);
 

--- a/source/blender/blenkernel/intern/object.c
+++ b/source/blender/blenkernel/intern/object.c
@@ -613,7 +613,7 @@ static void object_foreach_id(ID *id, LibraryForeachIDData *data)
   BKE_sca_controllers_id_loop(
       &object->controllers, library_foreach_controllersObjectLooper, data);
   BKE_sca_actuators_id_loop(&object->actuators, library_foreach_actuatorsObjectLooper, data);
-  BKE_sca_components_id_loop(&object->components, library_foreach_componentsObjectLooper, data);
+  BKE_python_components_id_loop(&object->components, library_foreach_componentsObjectLooper, data);
 
   if (object->lodlevels.first) {
     LISTBASE_FOREACH (LodLevel *, level, &object->lodlevels) {
@@ -1492,8 +1492,8 @@ static void object_blend_read_lib(BlendLibReader *reader, ID *id)
     }
   }
 
-  for (PythonComponent *comp = ob->components.first; comp; comp = comp->next) {
-    for (PythonComponentProperty *prop = comp->properties.first; prop; prop = prop->next) {
+  LISTBASE_FOREACH (PythonComponent *, comp, &ob->components) {
+    LISTBASE_FOREACH (PythonComponentProperty *, prop, &comp->properties) {
 #define PT_DEF(name, lower, upper) \
       BLO_read_id_address(reader, ob->id.lib, &prop->lower);
       POINTER_TYPES
@@ -1747,8 +1747,8 @@ static void object_blend_read_expand(BlendExpander *expander, ID *id)
     }
   }
 
-  for (comp = ob->components.first; comp; comp = comp->next) {
-    for (prop = comp->properties.first; prop; prop = prop->next) {
+  LISTBASE_FOREACH (PythonComponent *, comp, &ob->components) {
+    LISTBASE_FOREACH (PythonComponentProperty *, prop, &comp->properties) {
 #define PT_DEF(name, lower, upper) \
       BLO_expand(expander, prop->lower);
       POINTER_TYPES

--- a/source/blender/blenkernel/intern/python_component.c
+++ b/source/blender/blenkernel/intern/python_component.c
@@ -33,6 +33,7 @@
 
 #include "BKE_appdir.h"
 #include "BKE_context.h"
+#include "BKE_lib_query.h"
 #include "BKE_main.h"
 #include "BKE_python_component.h"
 #include "BKE_report.h"
@@ -850,4 +851,21 @@ void *BKE_python_component_argument_dict_new(PythonComponent *pc)
   return NULL;
 
 #endif /* WITH_PYTHON */
+}
+
+void BKE_python_components_id_loop(ListBase *complist, BKEPyComponentIDFunc func, void *userdata)
+{
+  PythonComponent *comp;
+
+  for (comp = complist->first; comp; comp = comp->next) {
+      ListBase *properties = &comp->properties;
+      PythonComponentProperty *prop;
+
+      for (prop = properties->first; prop; prop = prop->next) {
+#define PT_DEF(name, lower, upper) \
+          func(comp, (ID **)&prop->lower, userdata, IDWALK_CB_USER);
+          POINTER_TYPES
+#undef PT_DEF
+      }
+  }
 }

--- a/source/blender/blenkernel/intern/python_component.c
+++ b/source/blender/blenkernel/intern/python_component.c
@@ -43,6 +43,7 @@
 
 #ifdef WITH_PYTHON
 #  include "Python.h"
+#  include "../../python/intern/bpy_rna.h"
 #  include "generic/bpy_internal_import.h"
 #  include "generic/py_capi_utils.h"
 #endif
@@ -377,6 +378,25 @@ static void create_properties(PythonComponent *pycomp, PyObject *cls)
           Py_DECREF(item);
         }
       }
+    }
+    else if (PyType_Check(pyvalue)) {
+        const char *tp_name = ((PyTypeObject *) pyvalue)->tp_name;
+
+        free = true;
+
+#define PT_DEF(name, lower, upper) \
+        if (!strcmp(tp_name, STRINGIFY(name))) { \
+            cprop->type = CPROP_TYPE_ ## upper; \
+            free = false; \
+        }
+        POINTER_TYPES
+#undef PT_DEF
+
+        if (free) {
+            printf("Unsupported pointer type %s found for property \"%s\", skipping\n",
+                   Py_TYPE(pyvalue)->tp_name,
+                   name);
+        }
     }
     else {
       // Unsupported type
@@ -795,6 +815,22 @@ void *BKE_python_component_argument_dict_new(PythonComponent *pc)
         PyList_SetItem(value, i, PyFloat_FromDouble(cprop->vec[i]));
       }
     }
+#define PT_DEF(name, lower, upper) \
+    else if (cprop->type == CPROP_TYPE_ ## upper && cprop->lower) { \
+        ID *id = &cprop->lower->id; \
+        if (id) { \
+            if (!id->py_instance) { \
+                id -> py_instance = pyrna_id_CreatePyObject(id); \
+            } \
+            value = (PyObject *)id->py_instance; \
+        } \
+        else { \
+            cprop = cprop->next; \
+            continue; \
+        } \
+    }
+    POINTER_TYPES
+#undef PT_DEF
     else {
       cprop = cprop->next;
       continue;

--- a/source/blender/blenkernel/intern/sca.c
+++ b/source/blender/blenkernel/intern/sca.c
@@ -1104,7 +1104,7 @@ void BKE_sca_actuators_id_loop(ListBase *actlist, SCAActuatorIDFunc func, void *
       }
       case ACT_ACTION: {
         bActionActuator *aa = actuator->data;
-        func(actuator, (ID **)&aa->act, userdata, IDWALK_CB_NOP);
+        func(actuator, (ID **)&aa->act, userdata, IDWALK_CB_USER);
         break;
       }
       case ACT_SOUND: {
@@ -1115,7 +1115,7 @@ void BKE_sca_actuators_id_loop(ListBase *actlist, SCAActuatorIDFunc func, void *
       case ACT_EDIT_OBJECT: {
         bEditObjectActuator *eoa = actuator->data;
         func(actuator, (ID **)&eoa->ob, userdata, IDWALK_CB_NOP);
-        func(actuator, (ID **)&eoa->me, userdata, IDWALK_CB_NOP);
+        func(actuator, (ID **)&eoa->me, userdata, IDWALK_CB_USER);
         break;
       }
       case ACT_SCENE: {
@@ -1126,7 +1126,7 @@ void BKE_sca_actuators_id_loop(ListBase *actlist, SCAActuatorIDFunc func, void *
       }
       case ACT_COLLECTION: {
         bCollectionActuator *ca = actuator->data;
-        func(actuator, (ID **)&ca->collection, userdata, IDWALK_CB_NOP);
+        func(actuator, (ID **)&ca->collection, userdata, IDWALK_CB_USER);
         func(actuator, (ID **)&ca->camera, userdata, IDWALK_CB_NOP);
         break;
       }
@@ -1152,7 +1152,7 @@ void BKE_sca_actuators_id_loop(ListBase *actlist, SCAActuatorIDFunc func, void *
       }
       case ACT_2DFILTER: {
         bTwoDFilterActuator *tdfa = actuator->data;
-        func(actuator, (ID **)&tdfa->text, userdata, IDWALK_CB_NOP);
+        func(actuator, (ID **)&tdfa->text, userdata, IDWALK_CB_USER);
         break;
       }
       case ACT_PARENT: {
@@ -1201,7 +1201,7 @@ void BKE_python_components_id_loop(ListBase *complist, BKEPyComponentIDFunc func
 
       for (prop = properties->first; prop; prop = prop->next) {
 #define PT_DEF(name, lower, upper) \
-          func(comp, (ID **)&prop->lower, userdata, IDWALK_CB_NOP);
+          func(comp, (ID **)&prop->lower, userdata, IDWALK_CB_USER);
           POINTER_TYPES
 #undef PT_DEF
       }

--- a/source/blender/blenkernel/intern/sca.c
+++ b/source/blender/blenkernel/intern/sca.c
@@ -1095,6 +1095,13 @@ void BKE_sca_actuators_id_loop(ListBase *actlist, SCAActuatorIDFunc func, void *
   for (actuator = actlist->first; actuator; actuator = actuator->next) {
     func(actuator, (ID **)&actuator->ob, userdata, IDWALK_CB_NOP);
 
+    /*
+     * Using IDWALK_CB_USER for pointer references to prevent a problem
+     * with recomputing refcount upon loading. Needs more testing to
+     * see if it has potential side-effects.
+     *
+     * (See https://github.com/UPBGE/upbge/pull/1371 for details.)
+     */
     switch (actuator->type) {
       case ACT_ADD_OBJECT: /* DEPRECATED */
       {

--- a/source/blender/blenkernel/intern/sca.c
+++ b/source/blender/blenkernel/intern/sca.c
@@ -1198,23 +1198,6 @@ void BKE_sca_actuators_id_loop(ListBase *actlist, SCAActuatorIDFunc func, void *
   }
 }
 
-void BKE_python_components_id_loop(ListBase *complist, BKEPyComponentIDFunc func, void *userdata)
-{
-  PythonComponent *comp;
-
-  for (comp = complist->first; comp; comp = comp->next) {
-      ListBase *properties = &comp->properties;
-      PythonComponentProperty *prop;
-
-      for (prop = properties->first; prop; prop = prop->next) {
-#define PT_DEF(name, lower, upper) \
-          func(comp, (ID **)&prop->lower, userdata, IDWALK_CB_USER);
-          POINTER_TYPES
-#undef PT_DEF
-      }
-  }
-}
-
 const char *sca_state_name_get(Object *ob, short bit)
 {
   bController *cont;

--- a/source/blender/blenkernel/intern/sca.c
+++ b/source/blender/blenkernel/intern/sca.c
@@ -42,6 +42,7 @@
 #include "DNA_controller_types.h"
 #include "DNA_object_types.h"
 #include "DNA_sensor_types.h"
+#include "DNA_python_component_types.h"
 
 #include "BLI_blenlib.h"
 #include "BLI_ghash.h"
@@ -593,6 +594,7 @@ void set_sca_new_poins_ob(Object *ob)
   bSensor *sens;
   bController *cont;
   bActuator *act;
+
   int a;
 
   sens = ob->sensors.first;
@@ -1185,6 +1187,23 @@ void BKE_sca_actuators_id_loop(ListBase *actlist, SCAActuatorIDFunc func, void *
       default:
         break;
     }
+  }
+}
+
+void BKE_sca_components_id_loop(ListBase *complist, SCAComponentIDFunc func, void *userdata)
+{
+  PythonComponent *comp;
+
+  for (comp = complist->first; comp; comp = comp->next) {
+      ListBase *properties = &comp->properties;
+      PythonComponentProperty *prop;
+
+      for (prop = properties->first; prop; prop = prop->next) {
+#define PT_DEF(name, lower, upper) \
+          func(comp, (ID **)&prop->lower, userdata, IDWALK_CB_NOP);
+          POINTER_TYPES
+#undef PT_DEF
+      }
   }
 }
 

--- a/source/blender/blenkernel/intern/sca.c
+++ b/source/blender/blenkernel/intern/sca.c
@@ -52,6 +52,7 @@
 #include "BKE_lib_query.h"
 #include "BKE_main.h"
 #include "BKE_sca.h"
+#include "BKE_python_component.h"
 
 /* ******************* SENSORS ************************ */
 
@@ -1190,7 +1191,7 @@ void BKE_sca_actuators_id_loop(ListBase *actlist, SCAActuatorIDFunc func, void *
   }
 }
 
-void BKE_sca_components_id_loop(ListBase *complist, SCAComponentIDFunc func, void *userdata)
+void BKE_python_components_id_loop(ListBase *complist, BKEPyComponentIDFunc func, void *userdata)
 {
   PythonComponent *comp;
 

--- a/source/blender/makesdna/DNA_python_component_types.h
+++ b/source/blender/makesdna/DNA_python_component_types.h
@@ -22,6 +22,24 @@
 
 #pragma once
 
+#include "DNA_armature_types.h"
+#include "DNA_camera_types.h"
+#include "DNA_collection_types.h"
+#include "DNA_curve_types.h"
+#include "DNA_key_types.h"
+#include "DNA_light_types.h"
+#include "DNA_material_types.h"
+#include "DNA_mesh_types.h"
+#include "DNA_node_types.h"
+#include "DNA_particle_types.h"
+#include "DNA_sound_types.h"
+#include "DNA_speaker_types.h"
+#include "DNA_text_types.h"
+#include "DNA_texture_types.h"
+#include "DNA_vfont_types.h"
+#include "DNA_volume_types.h"
+#include "DNA_world_types.h"
+
 #include "DNA_listBase.h"
 
 #ifdef __cplusplus
@@ -39,6 +57,28 @@ typedef struct PythonComponentProperty {
   int itemval;
   float vec[4];
   ListBase enumval;
+  struct bAction *action;
+  struct bArmature *armature;
+  struct Camera *camera;
+  struct Collection *collection;
+  struct Curve *curve;
+  struct Image *image;
+  struct Key *key;
+  struct Library *library;
+  struct Light *light;
+  struct Material *material;
+  struct Mesh *mesh;
+  struct MovieClip *movie_clip;
+  struct bNodeTree *node_tree;
+  struct Object *object;
+  struct ParticleSettings *particle_settings;
+  struct bSound *sound;
+  struct Speaker *speaker;
+  struct Text *text;
+  struct Tex *texture;
+  struct VFont *vector_font;
+  struct Volume *volume;
+  struct World *world;
 } PythonComponentProperty;
 
 typedef struct PythonComponent {
@@ -61,6 +101,52 @@ typedef struct PythonComponent {
 #define CPROP_TYPE_VEC4 7
 #define CPROP_TYPE_COL3 8
 #define CPROP_TYPE_COL4 9
+#define CPROP_TYPE_ACTION 10
+#define CPROP_TYPE_ARMATURE 11
+#define CPROP_TYPE_CAMERA 12
+#define CPROP_TYPE_COLLECTION 13
+#define CPROP_TYPE_CURVE 14
+#define CPROP_TYPE_IMAGE 15
+#define CPROP_TYPE_KEY 16
+#define CPROP_TYPE_LIBRARY 17
+#define CPROP_TYPE_LIGHT 18
+#define CPROP_TYPE_MATERIAL 19
+#define CPROP_TYPE_MESH 20
+#define CPROP_TYPE_MOVIE_CLIP 21
+#define CPROP_TYPE_NODE_TREE 22
+#define CPROP_TYPE_OBJECT 23
+#define CPROP_TYPE_PARTICLE_SETTINGS 24
+#define CPROP_TYPE_SOUND 25
+#define CPROP_TYPE_SPEAKER 26
+#define CPROP_TYPE_TEXT 27
+#define CPROP_TYPE_TEXTURE 28
+#define CPROP_TYPE_VECTOR_FONT 29
+#define CPROP_TYPE_VOLUME 30
+#define CPROP_TYPE_WORLD 31
+
+#define POINTER_TYPES \
+    PT_DEF(Action, action, ACTION) \
+    PT_DEF(Armature, armature, ARMATURE) \
+    PT_DEF(Collection, collection, COLLECTION) \
+    PT_DEF(Camera, camera, CAMERA) \
+    PT_DEF(Curve, curve, CURVE) \
+    PT_DEF(Image, image, IMAGE) \
+    PT_DEF(Key, key, KEY) \
+    PT_DEF(Library, library, LIBRARY) \
+    PT_DEF(Light, light, LIGHT) \
+    PT_DEF(Material, material, MATERIAL) \
+    PT_DEF(Mesh, mesh, MESH) \
+    PT_DEF(MovieClip, movie_clip, MOVIE_CLIP) \
+    PT_DEF(NodeTree, node_tree, NODE_TREE) \
+    PT_DEF(Object, object, OBJECT) \
+    PT_DEF(ParticleSettings, particle_settings, PARTICLE_SETTINGS) \
+    PT_DEF(Sound, sound, SOUND) \
+    PT_DEF(Speaker, speaker, SPEAKER) \
+    PT_DEF(Text, text, TEXT) \
+    PT_DEF(Texture, texture, TEXTURE) \
+    PT_DEF(VectorFont, vector_font, VECTOR_FONT) \
+    PT_DEF(Volume, volume, VOLUME) \
+    PT_DEF(World, world, WORLD)
 
 enum { COMPONENT_SHOW = (1 << 0) };
 

--- a/source/blender/makesrna/intern/rna_python_component.c
+++ b/source/blender/makesrna/intern/rna_python_component.c
@@ -57,6 +57,11 @@ static StructRNA *rna_PythonComponentProperty_refine(struct PointerRNA *ptr)
       return &RNA_ComponentColor3Property;
     case CPROP_TYPE_COL4:
       return &RNA_ComponentColor4Property;
+#define PT_DEF(name, lower, upper) \
+    case CPROP_TYPE_ ## upper: \
+      return &RNA_Component ## name ## Property;
+    POINTER_TYPES
+#undef PT_DEF
     default:
       return &RNA_PythonComponentProperty;
   }
@@ -279,6 +284,22 @@ static void rna_def_py_component_property(BlenderRNA *brna)
   RNA_def_property_array(prop, 4);
   RNA_def_property_ui_text(prop, "Value", "Property value");
   RNA_def_property_update(prop, NC_LOGIC, NULL);
+
+#define PT_DEF(name, lower, upper) \
+  srna = RNA_def_struct(brna, STRINGIFY(Component ## name ## Property), "PythonComponentProperty"); \
+  RNA_def_struct_sdna(srna, "PythonComponentProperty"); \
+  RNA_def_struct_ui_text(srna, \
+                         STRINGIFY(Python Component ## name ## Property), \
+                         STRINGIFY(name ## property of a Python Component)); \
+  prop = RNA_def_property(srna, "value", PROP_POINTER, PROP_NONE); \
+  RNA_def_property_pointer_sdna(prop, NULL, STRINGIFY(lower)); \
+  RNA_def_property_struct_type(prop, STRINGIFY(name)); \
+  RNA_def_property_ui_text(prop, "Value", "Property value"); \
+  RNA_def_property_flag(prop, PROP_EDITABLE); \
+  RNA_def_property_update(prop, NC_LOGIC, NULL);
+
+  POINTER_TYPES
+#undef PT_DEF
 }
 
 void RNA_def_py_component(BlenderRNA *brna)


### PR DESCRIPTION
This commit adds support for Python component properties which can accept Blender data types like Mesh or Object as their values. In short, now you can do something like this:

![image](https://user-images.githubusercontent.com/2367032/103473694-ba621280-4dde-11eb-9c3e-b08d6d24e695.png)

In order to declare an `ID` type property, you can initialise the component `args` property with a proper type object like this:
```python
class Bootstrap(KX_PythonComponent):
    args = OrderedDict((
        ("key", "alleycat"),
        ("config", "//config.json"),
        ("Action", bpy.types.Action),
        ("Armature", bpy.types.Armature),
        ("Camera", bpy.types.Camera),
        ("Collection", bpy.types.Collection),
        ("Curve", bpy.types.Curve),
        ("Image", bpy.types.Image),
        ("Key", bpy.types.Key),
        ("Library", bpy.types.Library),
        ("Light", bpy.types.Light),
        ("Material", bpy.types.Material),
        ("Mesh", bpy.types.Mesh),
        ("Movie Clip", bpy.types.MovieClip),
        ("Node Tree", bpy.types.NodeTree),
        ("Object", bpy.types.Object),
        ("Particle", bpy.types.ParticleSettings),
        ("Sound", bpy.types.Sound),
        ("Speaker", bpy.types.Speaker),
        ("Text", bpy.types.Text),
        ("Texture", bpy.types.Texture),
        ("Vector Font", bpy.types.VectorFont),
        ("Volume", bpy.types.Volume),
        ("World", bpy.types.World),
    ))
```
This is an attempt to fill the gap between UPBGE and other popular engines like Unity or Godot which already support a similar feature.

There's an important caveat, however. If you reference non-object data types like `Action` or `Mesh`, it's strongly recommended to add a fake user to prevent unintentional deletion because clearing an once assigned property of such a type may result in wrong user count (`ID->us`).

This behaviour, however, doesn't seem to be related to my changes as you can reproduce the symptom with `ActionActuator` also. As such, I'll just ignore the problem for now and advise users to prefer `bpy.types.Object` which is safe from this problem, or add a fake user to the target data item.

Even though I've tested it quite rigorously including a scenario involving appending an object with such properties from a different file, more tests might be prudent before merging this PR.

Special thanks to @youle31 for the help! :)