### PR TITLE
Ensure Python components of a game object started before those on its ancestors

### DIFF
--- a/source/gameengine/Ketsji/KX_PythonComponentManager.cpp
+++ b/source/gameengine/Ketsji/KX_PythonComponentManager.cpp
@@ -2,6 +2,11 @@
 #include "KX_PythonComponent.h"
 #include "KX_GameObject.h"
 
+static bool compareObjectDepth(KX_GameObject *o1, KX_GameObject *o2)
+{
+  return o1->GetSGNode()->GetDepth() > o2->GetSGNode()->GetDepth();
+}
+
 KX_PythonComponentManager::KX_PythonComponentManager()
 {
 }
@@ -14,6 +19,7 @@ void KX_PythonComponentManager::RegisterObject(KX_GameObject *gameobj)
 {
   // Always register only once an object.
   m_objects.push_back(gameobj);
+  m_objects_changed = true;
 }
 
 void KX_PythonComponentManager::UnregisterObject(KX_GameObject *gameobj)
@@ -22,10 +28,17 @@ void KX_PythonComponentManager::UnregisterObject(KX_GameObject *gameobj)
   if (it != m_objects.end()) {
     m_objects.erase(it);
   }
+  m_objects_changed = true;
 }
 
 void KX_PythonComponentManager::UpdateComponents()
 {
+  if (m_objects_changed) {
+    std::sort(m_objects.begin(), m_objects.end(), compareObjectDepth);
+
+    m_objects_changed = false;
+  }
+
   /* Update object components, we copy the object pointer in a second list to make
    * sure that we iterate on a list which will not be modified, indeed components
    * can add objects in theirs update.

--- a/source/gameengine/Ketsji/KX_PythonComponentManager.cpp
+++ b/source/gameengine/Ketsji/KX_PythonComponentManager.cpp
@@ -12,8 +12,8 @@ KX_PythonComponentManager::~KX_PythonComponentManager()
 
 void KX_PythonComponentManager::RegisterObject(KX_GameObject *gameobj)
 {
-	// Always register only once an object.
-	m_objects.push_back(gameobj);
+  // Always register only once an object.
+  m_objects.push_back(gameobj);
 }
 
 void KX_PythonComponentManager::UnregisterObject(KX_GameObject *gameobj)
@@ -26,12 +26,12 @@ void KX_PythonComponentManager::UnregisterObject(KX_GameObject *gameobj)
 
 void KX_PythonComponentManager::UpdateComponents()
 {
-	/* Update object components, we copy the object pointer in a second list to make
-	 * sure that we iterate on a list which will not be modified, indeed components
-	 * can add objects in theirs update.
-	 */
-	const std::vector<KX_GameObject *> objects = m_objects;
-	for (KX_GameObject *gameobj : objects) {
-		gameobj->UpdateComponents();
-	}
+  /* Update object components, we copy the object pointer in a second list to make
+   * sure that we iterate on a list which will not be modified, indeed components
+   * can add objects in theirs update.
+   */
+  const std::vector<KX_GameObject *> objects = m_objects;
+  for (KX_GameObject *gameobj : objects) {
+    gameobj->UpdateComponents();
+  }
 }

--- a/source/gameengine/Ketsji/KX_PythonComponentManager.h
+++ b/source/gameengine/Ketsji/KX_PythonComponentManager.h
@@ -9,6 +9,7 @@ class KX_PythonComponentManager
 {
 private:
   std::vector<KX_GameObject *> m_objects;
+  bool m_objects_changed = false;
 
 public:
   KX_PythonComponentManager();

--- a/source/gameengine/Ketsji/KX_PythonComponentManager.h
+++ b/source/gameengine/Ketsji/KX_PythonComponentManager.h
@@ -8,15 +8,15 @@ class KX_GameObject;
 class KX_PythonComponentManager
 {
 private:
-	std::vector<KX_GameObject *> m_objects;
+  std::vector<KX_GameObject *> m_objects;
 
 public:
-	KX_PythonComponentManager();
-	~KX_PythonComponentManager();
+  KX_PythonComponentManager();
+  ~KX_PythonComponentManager();
 
-	void RegisterObject(KX_GameObject *gameobj);
-	void UnregisterObject(KX_GameObject *gameobj);
+  void RegisterObject(KX_GameObject *gameobj);
+  void UnregisterObject(KX_GameObject *gameobj);
 
-	void UpdateComponents();
+  void UpdateComponents();
 };
 

--- a/source/gameengine/SceneGraph/SG_Node.cpp
+++ b/source/gameengine/SceneGraph/SG_Node.cpp
@@ -182,6 +182,15 @@ void SG_Node::SetSGParent(SG_Node *parent)
   }
 }
 
+short SG_Node::GetDepth()
+{
+  if (!m_SGparent) {
+    return 0;
+  }
+
+  return 1 + m_SGparent->GetDepth();
+}
+
 void SG_Node::DisconnectFromParent()
 {
   if (m_SGparent) {

--- a/source/gameengine/SceneGraph/SG_Node.h
+++ b/source/gameengine/SceneGraph/SG_Node.h
@@ -164,6 +164,11 @@ class SG_Node : public SG_QList {
   const SG_Node *GetRootSGParent() const;
 
   /**
+   * Return the depth of the current node in the Scene graph hierarchy.
+   */
+  short GetDepth();
+
+  /**
    * Disconnect this node from it's parent
    */
   void DisconnectFromParent();


### PR DESCRIPTION
### Summary

This PR intends to change the invocation order of `KX_PythonComponent` so that a component on a game object would get invoked before those attached to its ancestors.

### Rationale

Consider a case where a Python component `P` requires other components `C1` and `C2` as its dependency. We can imagine they are attached in a game object tree which looks like below:
```
P -*- C1
     |
     *- C2
```
As a component is often initialised from arguments given in its `start(args)` callback, `C1` and `C2` may still remain in an invalid state when `P`'s `start` method gets called, because UPBGE currently does not guaranteed the invocation order in such cases.

Apparently, the engine invokes game objects in an alphabetical order of their names regardless of their respective depth which is not a very useful behaviour, IMO.

In comparison, Godot ensures that `OnReady()` callback on child nodes get invoked before that of the parent which can be useful to avoid the problem described in the above example.

This change intends to introduce a similar behaviour to UPBGE, although it still doesn't guarantee the invocation order between siblings, which we might consider implementing later.