### PR TITLE
UPBGE: Use userprefs to load addons in blenderplayer

### DIFF
--- a/source/gameengine/GamePlayer/GPG_ghost.cpp
+++ b/source/gameengine/GamePlayer/GPG_ghost.cpp
@@ -941,7 +941,6 @@ int main(int argc,
   /* Try to load existing user preferences from config folder:
    * Either from exported Game folder, either from blender userprefs file
    */
-  char filepath_startup[FILE_MAX] = "";
   char filepath_userdef[FILE_MAX] = "";
   UserDef *userdef = nullptr;
 

--- a/source/gameengine/GamePlayer/GPG_ghost.cpp
+++ b/source/gameengine/GamePlayer/GPG_ghost.cpp
@@ -945,14 +945,13 @@ int main(int argc,
   char filepath_userdef[FILE_MAX] = "";
   UserDef *userdef = nullptr;
 
-  const char *const cfgdir = BKE_appdir_folder_id(BLENDER_USER_CONFIG, NULL);
+  const char *const cfgdir = BKE_appdir_folder_id(BLENDER_USER_CONFIG, nullptr);
   if (cfgdir) {
-    BLI_path_join(filepath_startup, sizeof(filepath_startup), cfgdir, BLENDER_STARTUP_FILE, NULL);
-    BLI_path_join(filepath_userdef, sizeof(filepath_startup), cfgdir, BLENDER_USERPREF_FILE, NULL);
+    BLI_path_join(filepath_userdef, sizeof(filepath_userdef), cfgdir, BLENDER_USERPREF_FILE, nullptr);
 
     /* load preferences */
     if (BLI_exists(filepath_userdef)) {
-      userdef = BKE_blendfile_userdef_read(filepath_userdef, NULL);
+      userdef = BKE_blendfile_userdef_read(filepath_userdef, nullptr);
     }
   }
 


### PR DESCRIPTION
Addons need to read userpref.blend file to know which addons are
registered.

It allows to use registered addons in blendeprlayer.

If no userpref.blend is found, default user preferences are
loaded.

Code picked from wm_files > wm_homefile_read