### PR TITLE
UPBGE: Recover panzergame Time refactor (without std::sleep_for)

### DIFF
--- a/source/gameengine/Common/CM_Clock.cpp
+++ b/source/gameengine/Common/CM_Clock.cpp
@@ -2,21 +2,21 @@
 
 CM_Clock::CM_Clock()
 {
-	Reset();
+  Reset();
 }
 
 void CM_Clock::Reset()
 {
-	m_start = m_clock.now();
+  m_start = m_clock.now();
 }
 
 double CM_Clock::GetTimeSecond() const
 {
-	return GetTimeNano() * 1e-9;
+  return GetTimeNano() * 1e-9;
 }
 
 CM_Clock::Rep CM_Clock::GetTimeNano() const
 {
-	const std::chrono::high_resolution_clock::time_point now = m_clock.now();
-	return std::chrono::duration_cast<std::chrono::nanoseconds>(now - m_start).count();
+  const std::chrono::high_resolution_clock::time_point now = m_clock.now();
+  return std::chrono::duration_cast<std::chrono::nanoseconds>(now - m_start).count();
 }

--- a/source/gameengine/Common/CM_Clock.cpp
+++ b/source/gameengine/Common/CM_Clock.cpp
@@ -1,0 +1,22 @@
+#include "CM_Clock.h"
+
+CM_Clock::CM_Clock()
+{
+	Reset();
+}
+
+void CM_Clock::Reset()
+{
+	m_start = m_clock.now();
+}
+
+double CM_Clock::GetTimeSecond() const
+{
+	return GetTimeNano() * 1e-9;
+}
+
+CM_Clock::Rep CM_Clock::GetTimeNano() const
+{
+	const std::chrono::high_resolution_clock::time_point now = m_clock.now();
+	return std::chrono::duration_cast<std::chrono::nanoseconds>(now - m_start).count();
+}

--- a/source/gameengine/Common/CM_Clock.h
+++ b/source/gameengine/Common/CM_Clock.h
@@ -1,0 +1,24 @@
+#ifndef __CM_CLOCK_H__
+#define __CM_CLOCK_H__
+
+#include <chrono>
+
+class CM_Clock
+{
+public:
+	using Rep = std::chrono::nanoseconds::rep;
+
+private:
+	std::chrono::high_resolution_clock::time_point m_start;
+	std::chrono::high_resolution_clock m_clock;
+
+public:
+	CM_Clock();
+
+	void Reset();
+
+	double GetTimeSecond() const;
+	Rep GetTimeNano() const;
+};
+
+#endif  // __CM_CLOCK_H__

--- a/source/gameengine/Common/CM_Clock.h
+++ b/source/gameengine/Common/CM_Clock.h
@@ -1,24 +1,21 @@
-#ifndef __CM_CLOCK_H__
-#define __CM_CLOCK_H__
+#pragma once
 
 #include <chrono>
 
 class CM_Clock
 {
 public:
-	using Rep = std::chrono::nanoseconds::rep;
+  using Rep = std::chrono::nanoseconds::rep;
 
 private:
-	std::chrono::high_resolution_clock::time_point m_start;
-	std::chrono::high_resolution_clock m_clock;
+  std::chrono::high_resolution_clock::time_point m_start;
+  std::chrono::high_resolution_clock m_clock;
 
 public:
-	CM_Clock();
+  CM_Clock();
 
-	void Reset();
+  void Reset();
 
-	double GetTimeSecond() const;
-	Rep GetTimeNano() const;
+  double GetTimeSecond() const;
+  Rep GetTimeNano() const;
 };
-
-#endif  // __CM_CLOCK_H__

--- a/source/gameengine/Common/CMakeLists.txt
+++ b/source/gameengine/Common/CMakeLists.txt
@@ -40,10 +40,12 @@ set(INC_SYS
 )
 
 set(SRC
+  CM_clock.cpp
   CM_Message.cpp
   CM_Thread.cpp
   CM_Utils.cpp
 
+  CM_clock.h
   CM_Format.h
   CM_List.h
   CM_Message.h

--- a/source/gameengine/Ketsji/KX_KetsjiEngine.h
+++ b/source/gameengine/Ketsji/KX_KetsjiEngine.h
@@ -145,6 +145,19 @@ class KX_KetsjiEngine {
 #endif
   SCA_IInputDevice *m_inputDevice;
 
+  struct FrameTimes
+  {
+    // Number of frames to proceed.
+    int frames;
+    // Real duration of a frame.
+    double timestep;
+    // Scaled duration of a frame.
+    double framestep;
+  };
+
+  CM_Clock m_clock;
+
+
   /// Lists of scenes scheduled to be removed at the end of the frame.
   std::vector<std::string> m_removingScenes;
   /// Lists of scenes scheduled to be replaced at the end of the frame.

--- a/source/gameengine/Ketsji/KX_KetsjiEngine.h
+++ b/source/gameengine/Ketsji/KX_KetsjiEngine.h
@@ -35,6 +35,7 @@
 #include <string>
 #include <vector>
 
+#include "CM_Clock.h"
 #include "EXP_Python.h"
 #include "KX_ISystem.h"
 #include "KX_Scene.h"
@@ -285,6 +286,7 @@ class KX_KetsjiEngine {
   void PostProcessScene(KX_Scene *scene);
 
   void BeginFrame();
+  FrameTimes GetFrameTimes();
 
  public:
   KX_KetsjiEngine(KX_ISystem *system,

--- a/source/gameengine/Ketsji/KX_TimeCategoryLogger.cpp
+++ b/source/gameengine/Ketsji/KX_TimeCategoryLogger.cpp
@@ -31,8 +31,10 @@
 
 #include "KX_TimeCategoryLogger.h"
 
-KX_TimeCategoryLogger::KX_TimeCategoryLogger(unsigned int maxNumMeasurements)
-    : m_maxNumMeasurements(maxNumMeasurements), m_lastCategory(-1)
+KX_TimeCategoryLogger::KX_TimeCategoryLogger(const CM_Clock &clock,
+                                             unsigned int maxNumMeasurements)
+
+    : m_clock(clock), m_maxNumMeasurements(maxNumMeasurements), m_lastCategory(-1)
 {
 }
 
@@ -61,8 +63,9 @@ void KX_TimeCategoryLogger::AddCategory(TimeCategory tc)
   }
 }
 
-void KX_TimeCategoryLogger::StartLog(TimeCategory tc, double now)
+void KX_TimeCategoryLogger::StartLog(TimeCategory tc)
 {
+  const double now = m_clock.GetTimeSecond();
   if (m_lastCategory != -1) {
     m_loggers[m_lastCategory].EndLog(now);
   }
@@ -70,19 +73,22 @@ void KX_TimeCategoryLogger::StartLog(TimeCategory tc, double now)
   m_lastCategory = tc;
 }
 
-void KX_TimeCategoryLogger::EndLog(TimeCategory tc, double now)
+void KX_TimeCategoryLogger::EndLog(TimeCategory tc)
 {
+  const double now = m_clock.GetTimeSecond();
   m_loggers[tc].EndLog(now);
 }
 
-void KX_TimeCategoryLogger::EndLog(double now)
+void KX_TimeCategoryLogger::EndLog()
 {
+  const double now = m_clock.GetTimeSecond();
   m_loggers[m_lastCategory].EndLog(now);
   m_lastCategory = -1;
 }
 
-void KX_TimeCategoryLogger::NextMeasurement(double now)
+void KX_TimeCategoryLogger::NextMeasurement()
 {
+  const double now = m_clock.GetTimeSecond();
   for (TimeLoggerMap::value_type &pair : m_loggers) {
     pair.second.NextMeasurement(now);
   }

--- a/source/gameengine/Ketsji/KX_TimeCategoryLogger.h
+++ b/source/gameengine/Ketsji/KX_TimeCategoryLogger.h
@@ -37,6 +37,7 @@
 
 #include <map>
 
+#include "CM_Clock.h"
 #include "KX_TimeLogger.h"
 
 /**
@@ -54,7 +55,7 @@ class KX_TimeCategoryLogger {
    * Constructor.
    * \param maxNumMesasurements Maximum number of measurements stored (> 1).
    */
-  KX_TimeCategoryLogger(unsigned int maxNumMeasurements = 10);
+  KX_TimeCategoryLogger(const CM_Clock &clock, unsigned int maxNumMeasurements = 10);
 
   /**
    * Destructor.
@@ -82,26 +83,24 @@ class KX_TimeCategoryLogger {
    * \param tc					The category to log to.
    * \param now					The current time.
    */
-  void StartLog(TimeCategory tc, double now);
+  void StartLog(TimeCategory tc);
 
-  /**
+	/**
    * End logging in current measurement for the given category.
    * \param tc	The category to log to.
-   * \param now	The current time.
    */
-  void EndLog(TimeCategory tc, double now);
+  void EndLog(TimeCategory tc);
 
   /**
    * End logging in current measurement for all categories.
-   * \param now	The current time.
    */
-  void EndLog(double now);
+  void EndLog();
 
   /**
    * Logs time in next measurement.
    * \param now	The current time.
    */
-  void NextMeasurement(double now);
+  void NextMeasurement();
 
   /**
    * Returns average of all but the current measurement time.
@@ -115,6 +114,7 @@ class KX_TimeCategoryLogger {
   double GetAverage();
 
  protected:
+  const CM_Clock &m_clock;
   /// Storage for the loggers.
   TimeLoggerMap m_loggers;
   /// Maximum number of measurements.


### PR DESCRIPTION
Several users said that they prefered time management as in 0.2.4.

Then I recovered panzergame Time management refactor:

Mainly this:

e9b07807f99d97dde7162b3fbb7439ea70fea0b5

+ that:

dfb83b57e0ca5f4451122e3eadc732f9a784df37