### PR TITLE
UPBGE: Enable support of SoftBody volumes (when we uncheck Shape Match)

### DIFF
--- a/source/gameengine/Physics/Bullet/CcdPhysicsController.cpp
+++ b/source/gameengine/Physics/Bullet/CcdPhysicsController.cpp
@@ -795,7 +795,7 @@ bool CcdPhysicsController::SynchronizeMotionStates(float time)
 
   btSoftBody *sb = GetSoftBody();
   if (sb) {  // EXPERIMENTAL
-    if (sb->m_pose.m_bframe) {
+    if (sb->m_pose.m_bframe || sb->m_pose.m_bvolume) {
       // btVector3 worldPos = sb->m_pose.m_com;
       // btQuaternion worldquat;
       // btMatrix3x3 trs = sb->m_pose.m_rot * sb->m_pose.m_scl;
@@ -843,7 +843,7 @@ void CcdPhysicsController::UpdateSoftBody()
 {
   btSoftBody *sb = GetSoftBody();
   if (sb && sb->getActivationState() != ISLAND_SLEEPING) {
-    if (sb->m_pose.m_bframe) {
+    if (sb->m_pose.m_bframe || sb->m_pose.m_bvolume) {
 
       RAS_MeshObject *rasMesh = GetShapeInfo()->GetMesh();
 


### PR DESCRIPTION
I don't know what it means but it is just to not have the softbody
inactive when we uncheck CCD_BSB_SHAPE_MATCHING (Shape Match -
use_shape_match) option.

EDIT: In 2.79 official, the simulation was running when we unchecked Shape Match, not in upbge 0.2.5