### PR TITLE
UPBGE: ImageRender pre/post draw callbacks

### DIFF
--- a/source/gameengine/Ketsji/KX_Scene.cpp
+++ b/source/gameengine/Ketsji/KX_Scene.cpp
@@ -829,14 +829,6 @@ void KX_Scene::RenderAfterCameraSetupImageRender(KX_Camera *cam,
     return;
   }
 
-  SetCurrentGPUViewport(cam->GetGPUViewport());
-
-  /* Add a depsgraph notifier to trigger
-   * DRW_notify_view_update on next draw loop. */
-  DEG_id_tag_update(&cam->GetBlenderObject()->id, ID_RECALC_TRANSFORM);
-  /* We need the changes to be flushed before each draw loop! */
-  BKE_scene_graph_update_tagged(depsgraph, bmain);
-
   float winmat[4][4];
   cam->GetProjectionMatrix().getValue(&winmat[0][0]);
   CTX_wm_view3d(C)->camera = cam->GetBlenderObject();

--- a/source/gameengine/VideoTexture/ImageRender.cpp
+++ b/source/gameengine/VideoTexture/ImageRender.cpp
@@ -96,7 +96,9 @@ ImageRender::~ImageRender(void)
 #ifdef WITH_PYTHON
   // These may be nullptr but the macro checks.
   Py_CLEAR(m_preDrawCallbacks);
+  m_preDrawCallbacks = nullptr;
   Py_CLEAR(m_postDrawCallbacks);
+  m_postDrawCallbacks = nullptr;
 #endif
   m_scene->RemoveImageRenderCamera(m_camera);
 
@@ -366,7 +368,9 @@ bool ImageRender::Render()
   RunPostDrawCallbacks();
   // These may be nullptr but the macro checks.
   Py_CLEAR(m_preDrawCallbacks);
+  m_preDrawCallbacks = nullptr;
   Py_CLEAR(m_postDrawCallbacks);
+  m_postDrawCallbacks = nullptr;
 #endif
 
   m_canvas->EndFrame();
@@ -390,8 +394,7 @@ void ImageRender::RunPreDrawCallbacks()
     return;
   }
 
-  PyObject *args[1] = {(PyObject *)getSource(0)};
-  EXP_RunPythonCallBackList(list, args, 0, 1);
+  EXP_RunPythonCallBackList(list, nullptr, 0, 0);
 }
 
 void ImageRender::RunPostDrawCallbacks()
@@ -401,8 +404,11 @@ void ImageRender::RunPostDrawCallbacks()
     return;
   }
 
-  PyObject *args[1] = {(PyObject *)getSource(0)};
-  EXP_RunPythonCallBackList(list, args, 0, 1);
+  EXP_RunPythonCallBackList(list, nullptr, 0, 0);
+
+  /* Ensure DRW_notify_view_update will be called on next draw loop if we did
+   * changes related to scene_eval in ImageRender draw callbacks */
+  DEG_id_tag_update(&m_camera->GetBlenderObject()->id, ID_RECALC_TRANSFORM);
 }
 
 // cast Image pointer to ImageRender

--- a/source/gameengine/VideoTexture/ImageRender.cpp
+++ b/source/gameengine/VideoTexture/ImageRender.cpp
@@ -396,8 +396,8 @@ void ImageRender::RunPreDrawCallbacks()
 
   EXP_RunPythonCallBackList(list, nullptr, 0, 0);
 
-  /* Ensure DRW_notify_view_update will be called on next draw loop if we did
-   * changes related to scene_eval in ImageRender draw callbacks */
+  /* Ensure DRW_notify_view_update will be called next time BKE_scene_graph_update_tagged
+   * will be called if we did changes related to scene_eval in ImageRender draw callbacks */
   DEG_id_tag_update(&m_camera->GetBlenderObject()->id, ID_RECALC_TRANSFORM);
 }
 
@@ -410,8 +410,8 @@ void ImageRender::RunPostDrawCallbacks()
 
   EXP_RunPythonCallBackList(list, nullptr, 0, 0);
 
-  /* Ensure DRW_notify_view_update will be called on next draw loop if we did
-   * changes related to scene_eval in ImageRender draw callbacks */
+  /* Ensure DRW_notify_view_update will be called next time BKE_scene_graph_update_tagged
+   * will be called if we did changes related to scene_eval in ImageRender draw callbacks */
   DEG_id_tag_update(&m_camera->GetBlenderObject()->id, ID_RECALC_TRANSFORM);
 }
 

--- a/source/gameengine/VideoTexture/ImageRender.cpp
+++ b/source/gameengine/VideoTexture/ImageRender.cpp
@@ -36,6 +36,7 @@
 #include "GPU_viewport.h"
 #include "eevee_private.h"
 
+#include "EXP_PythonCallBack.h"
 #include "KX_Globals.h"
 #include "RAS_IVertex.h"
 #include "RAS_MeshObject.h"
@@ -62,6 +63,10 @@ ImageRender::ImageRender(KX_Scene *scene,
                          unsigned int height,
                          unsigned short samples)
     : ImageViewport(width, height),
+#ifdef WITH_PYTHON
+      m_preDrawCallbacks(nullptr),
+      m_postDrawCallbacks(nullptr),
+#endif
       m_render(true),
       m_done(false),
       m_scene(scene),
@@ -88,6 +93,11 @@ ImageRender::ImageRender(KX_Scene *scene,
 // destructor
 ImageRender::~ImageRender(void)
 {
+#ifdef WITH_PYTHON
+  // These may be nullptr but the macro checks.
+  Py_CLEAR(m_preDrawCallbacks);
+  Py_CLEAR(m_postDrawCallbacks);
+#endif
   m_scene->RemoveImageRenderCamera(m_camera);
 
   if (m_owncamera) {
@@ -328,9 +338,36 @@ bool ImageRender::Render()
 
   m_engine->UpdateAnimations(m_scene);
 
+  bContext *C = KX_GetActiveEngine()->GetContext();
+  Main *bmain = CTX_data_main(C);
+  Depsgraph *depsgraph = CTX_data_depsgraph_on_load(C);
+
+  if (!depsgraph) {
+    return false;
+  }
+
+  m_scene->SetCurrentGPUViewport(m_camera->GetGPUViewport());
+
+  /* Add a depsgraph notifier to trigger
+   * DRW_notify_view_update on next draw loop. */
+  DEG_id_tag_update(&m_camera->GetBlenderObject()->id, ID_RECALC_TRANSFORM);
+  /* We need the changes to be flushed before each draw loop! */
+  BKE_scene_graph_update_tagged(depsgraph, bmain);
+
+#ifdef WITH_PYTHON
+  RunPreDrawCallbacks();
+#endif
+
   /* viewport and window share the same values here */
   const rcti window = {viewport[0], viewport[2], viewport[1], viewport[3]};
   m_scene->RenderAfterCameraSetupImageRender(m_camera, m_rasterizer, &window);
+
+#ifdef WITH_PYTHON
+  RunPostDrawCallbacks();
+  // These may be nullptr but the macro checks.
+  Py_CLEAR(m_preDrawCallbacks);
+  Py_CLEAR(m_postDrawCallbacks);
+#endif
 
   m_canvas->EndFrame();
 
@@ -344,6 +381,28 @@ bool ImageRender::Render()
 void ImageRender::Unbind()
 {
   GPU_framebuffer_restore();
+}
+
+void ImageRender::RunPreDrawCallbacks()
+{
+  PyObject *list = m_preDrawCallbacks;
+  if (!list || PyList_GET_SIZE(list) == 0) {
+    return;
+  }
+
+  PyObject *args[1] = {(PyObject *)getSource(0)};
+  EXP_RunPythonCallBackList(list, args, 0, 1);
+}
+
+void ImageRender::RunPostDrawCallbacks()
+{
+  PyObject *list = m_postDrawCallbacks;
+  if (!list || PyList_GET_SIZE(list) == 0) {
+    return;
+  }
+
+  PyObject *args[1] = {(PyObject *)getSource(0)};
+  EXP_RunPythonCallBackList(list, args, 0, 1);
 }
 
 // cast Image pointer to ImageRender
@@ -463,6 +522,64 @@ static PyObject *getColorBindCode(PyImage *self, void *closure)
   return PyLong_FromLong(getImageRender(self)->GetColorBindCode());
 }
 
+static PyObject *getPreDrawCallbacks(PyImage *self, void *closure)
+{
+  ImageRender *imageRender = getImageRender(self);
+  if (!imageRender->m_preDrawCallbacks) {
+    imageRender->m_preDrawCallbacks = PyList_New(0);
+  }
+
+  Py_INCREF(imageRender->m_preDrawCallbacks);
+
+  return imageRender->m_preDrawCallbacks;
+}
+
+static int setPreDrawCallbacks(PyImage *self, PyObject *value, void *closure)
+{
+  ImageRender *imageRender = getImageRender(self);
+
+  if (!PyList_CheckExact(value)) {
+    PyErr_SetString(PyExc_ValueError, "Expected a list");
+    return PY_SET_ATTR_FAIL;
+  }
+
+  Py_XDECREF(imageRender->m_preDrawCallbacks);
+
+  Py_INCREF(value);
+  imageRender->m_preDrawCallbacks = value;
+
+  return PY_SET_ATTR_SUCCESS;
+}
+
+static PyObject *getPostDrawCallbacks(PyImage *self, void *closure)
+{
+  ImageRender *imageRender = getImageRender(self);
+  if (!imageRender->m_postDrawCallbacks) {
+    imageRender->m_postDrawCallbacks = PyList_New(0);
+  }
+
+  Py_INCREF(imageRender->m_postDrawCallbacks);
+
+  return imageRender->m_postDrawCallbacks;
+}
+
+static int setPostDrawCallbacks(PyImage *self, PyObject *value, void *closure)
+{
+  ImageRender *imageRender = getImageRender(self);
+
+  if (!PyList_CheckExact(value)) {
+    PyErr_SetString(PyExc_ValueError, "Expected a list");
+    return PY_SET_ATTR_FAIL;
+  }
+
+  Py_XDECREF(imageRender->m_postDrawCallbacks);
+
+  Py_INCREF(value);
+  imageRender->m_postDrawCallbacks = value;
+
+  return PY_SET_ATTR_SUCCESS;
+}
+
 // methods structure
 static PyMethodDef imageRenderMethods[] = {  // methods from ImageBase class
     {"refresh",
@@ -530,6 +647,16 @@ static PyGetSetDef imageRenderGetSets[] = {
      (getter)getColorBindCode,
      nullptr,
      (char *)"Off-screen color texture bind code",
+     nullptr},
+    {(char *)"pre_draw",
+     (getter)getPreDrawCallbacks,
+     (setter)setPreDrawCallbacks,
+     (char *)"Image Render pre-draw callbacks",
+     nullptr},
+    {(char *)"post_draw",
+     (getter)getPostDrawCallbacks,
+     (setter)setPostDrawCallbacks,
+     (char *)"Image Render post-draw callbacks",
      nullptr},
     {nullptr}};
 

--- a/source/gameengine/VideoTexture/ImageRender.cpp
+++ b/source/gameengine/VideoTexture/ImageRender.cpp
@@ -395,6 +395,10 @@ void ImageRender::RunPreDrawCallbacks()
   }
 
   EXP_RunPythonCallBackList(list, nullptr, 0, 0);
+
+  /* Ensure DRW_notify_view_update will be called on next draw loop if we did
+   * changes related to scene_eval in ImageRender draw callbacks */
+  DEG_id_tag_update(&m_camera->GetBlenderObject()->id, ID_RECALC_TRANSFORM);
 }
 
 void ImageRender::RunPostDrawCallbacks()

--- a/source/gameengine/VideoTexture/ImageRender.h
+++ b/source/gameengine/VideoTexture/ImageRender.h
@@ -33,6 +33,7 @@
 #include "DNA_screen_types.h"
 
 #include "Common.h"
+#include "EXP_Value.h"
 #include "ImageViewport.h"
 #include "KX_Camera.h"
 #include "KX_Scene.h"
@@ -84,6 +85,14 @@ class ImageRender : public ImageViewport {
   bool Render();
   /// in case fbo is used, method to unbind
   void Unbind();
+
+  void RunPreDrawCallbacks();
+  void RunPostDrawCallbacks();
+
+#ifdef WITH_PYTHON
+  PyObject *m_preDrawCallbacks;
+  PyObject *m_postDrawCallbacks;
+#endif
 
  protected:
   /// true if ready to render

--- a/source/gameengine/VideoTexture/ImageRender.h
+++ b/source/gameengine/VideoTexture/ImageRender.h
@@ -33,7 +33,6 @@
 #include "DNA_screen_types.h"
 
 #include "Common.h"
-#include "EXP_Value.h"
 #include "ImageViewport.h"
 #include "KX_Camera.h"
 #include "KX_Scene.h"


### PR DESCRIPTION
With recent custom bge loop refactor, it was not possible anymore to set evaluated scene render options before ImageRender pass.

It can be interesting to set these options:

- It is better to use evaluated scene before when we set the render options because the depsgraph is not notified to do an extra draw pass for no reason.
- We might want to set background transparent or disable post processing effects before ImageRender pass.

To make this possible again, pre_draw callbacks are implemented and inserted after BKE_scene_graph_update_tagged and before the image render bge draw loop.

I have no usecase for post_draw callbacks yet but it costs nothing to add it.

Test file: https://ufile.io/kx28163c

Python API:

![1](https://user-images.githubusercontent.com/10052509/110218682-5978b880-7ebb-11eb-85a3-8901835f7194.PNG)
![2](https://user-images.githubusercontent.com/10052509/110218684-5bdb1280-7ebb-11eb-8210-1ef97e608c9d.PNG)

Side note:

ImageRender often requires to hide some objects before the ImageRender pass. I think that for performances, it would be better to use ob_eval.hide_viewport = True than to use kxob.visible = False because KX_GameObject::SetVisible is using depsgraph which can be a bit slow. Furthermore, there if ob_eval visibility state is changed, it is just during ImageRender pass, there should be no need to restore visibility after bge.tex.refresh() contrarly to if we use kxob.visible
