### PR TITLE
UPBGE: Special treatment to convert linked objects

### DIFF
--- a/source/gameengine/Converter/BL_BlenderDataConversion.cpp
+++ b/source/gameengine/Converter/BL_BlenderDataConversion.cpp
@@ -1175,7 +1175,7 @@ void BL_ConvertBlenderObjects(struct Main *maggie,
   // Beware of name conflict in linked data, it will not crash but will create confusion
   // in Python scripting and in certain actuators (replace mesh). Linked scene *should* have
   // no conflicting name for Object, Object data and Action.
-  std::vector<Collection *> linked_collections = {};
+  std::vector<Object *> linked_objects = {};
   for (SETLOOPER(blenderscene, sce_iter, base)) {
     Object *blenderobject = base->object;
 
@@ -1194,9 +1194,8 @@ void BL_ConvertBlenderObjects(struct Main *maggie,
       bool is_linked_collection = false;
       FOREACH_COLLECTION_OBJECT_RECURSIVE_BEGIN (blenderobject->instance_collection, obj) {
         if (ID_IS_LINKED(&obj->id)) {
-          linked_collections.push_back(blenderobject->instance_collection);
+          linked_objects.push_back(obj);
           is_linked_collection = true;
-          break;
         }
       }
       FOREACH_COLLECTION_OBJECT_RECURSIVE_END;
@@ -1251,57 +1250,49 @@ void BL_ConvertBlenderObjects(struct Main *maggie,
   }
 
   /* In 2.8+, convert linked objects now */
-  for (Collection *linked_col : linked_collections) {
-    FOREACH_COLLECTION_OBJECT_RECURSIVE_BEGIN (linked_col, blenderobject) {
+  for (Object *blenderobject : linked_objects) {
 
-      /* Only convert linked objects */
-      if (!ID_IS_LINKED(&blenderobject->id)) {
+    if (converter->FindGameObject(blenderobject) != nullptr) {
+      continue;
+    }
+
+    if (blenderobject == kxscene->GetGameDefaultCamera()) {
+      continue;
+    }
+
+    if (single_object) {
+      if (blenderobject != single_object) {
         continue;
-      }
-
-      if (converter->FindGameObject(blenderobject) != nullptr) {
-        continue;
-      }
-
-      if (blenderobject == kxscene->GetGameDefaultCamera()) {
-        continue;
-      }
-
-      if (single_object) {
-        if (blenderobject != single_object) {
-          continue;
-        }
-      }
-
-      bool isInActiveLayer = (blenderobject->base_flag &
-                              (BASE_VISIBLE_VIEWLAYER | BASE_VISIBLE_DEPSGRAPH)) != 0;
-      blenderobject->lay = (blenderobject->base_flag &
-                            (BASE_VISIBLE_VIEWLAYER | BASE_VISIBLE_DEPSGRAPH)) != 0;
-
-      if (!isInActiveLayer) {
-        /* Force OB_RESTRICT_VIEWPORT to avoid not needed depsgraph operations in some cases */
-        kxscene->BackupRestrictFlag(blenderobject, blenderobject->restrictflag);
-        blenderobject->restrictflag |= OB_RESTRICT_VIEWPORT;
-        BKE_main_collection_sync_remap(maggie);
-        DEG_relations_tag_update(maggie);
-      }
-
-      bool converting_during_runtime = single_object != nullptr;
-
-      KX_GameObject *gameobj = BL_gameobject_from_blenderobject(
-          blenderobject, kxscene, rendertools, converter, libloading, converting_during_runtime);
-
-      if (gameobj && converting_during_runtime) {
-        gameobj->SetIsReplicaObject();
-      }
-
-      if (gameobj) {
-        /* macro calls object conversion funcs */
-        BL_CONVERTBLENDEROBJECT_SINGLE;
-        gameobj->Release();
       }
     }
-    FOREACH_COLLECTION_OBJECT_RECURSIVE_END;
+
+    bool isInActiveLayer = (blenderobject->base_flag &
+                            (BASE_VISIBLE_VIEWLAYER | BASE_VISIBLE_DEPSGRAPH)) != 0;
+    blenderobject->lay = (blenderobject->base_flag &
+                       (BASE_VISIBLE_VIEWLAYER | BASE_VISIBLE_DEPSGRAPH)) != 0;
+
+    if (!isInActiveLayer) {
+      /* Force OB_RESTRICT_VIEWPORT to avoid not needed depsgraph operations in some cases */
+      kxscene->BackupRestrictFlag(blenderobject, blenderobject->restrictflag);
+      blenderobject->restrictflag |= OB_RESTRICT_VIEWPORT;
+      BKE_main_collection_sync_remap(maggie);
+      DEG_relations_tag_update(maggie);
+    }
+
+    bool converting_during_runtime = single_object != nullptr;
+
+    KX_GameObject *gameobj = BL_gameobject_from_blenderobject(
+        blenderobject, kxscene, rendertools, converter, libloading, converting_during_runtime);
+
+    if (gameobj && converting_during_runtime) {
+      gameobj->SetIsReplicaObject();
+    }
+
+    if (gameobj) {
+      /* macro calls object conversion funcs */
+      BL_CONVERTBLENDEROBJECT_SINGLE;
+      gameobj->Release();
+    }
   }
   /* End of linked objects conversion */
 

--- a/source/gameengine/Converter/BL_BlenderDataConversion.cpp
+++ b/source/gameengine/Converter/BL_BlenderDataConversion.cpp
@@ -1249,6 +1249,7 @@ void BL_ConvertBlenderObjects(struct Main *maggie,
     }
   }
 
+  /* In 2.8+, convert linked objects now */
   for (Object *blenderobject : linked_objects) {
 
     if (converter->FindGameObject(blenderobject) != nullptr) {
@@ -1293,6 +1294,7 @@ void BL_ConvertBlenderObjects(struct Main *maggie,
       gameobj->Release();
     }
   }
+  /* End of linked objects conversion */
 
   if (!grouplist.empty()) {
     // now convert the group referenced by dupli group object

--- a/source/gameengine/Converter/BL_BlenderDataConversion.cpp
+++ b/source/gameengine/Converter/BL_BlenderDataConversion.cpp
@@ -1200,7 +1200,9 @@ void BL_ConvertBlenderObjects(struct Main *maggie,
       }
       FOREACH_COLLECTION_OBJECT_RECURSIVE_END;
       if (is_linked_collection) {
-        /* blenderobject->instance_collection seems not a dupligroup but a collection with linked objects */
+        /* blenderobject seems not a "dupligroup" but a collection with linked objects.
+         * We don't convert this blenderobject but only the linked objects from
+         * blenderobject->instance_collection to imitate 0.2.5 behaviour */
         continue;
       }
     }

--- a/source/gameengine/Converter/BL_BlenderDataConversion.cpp
+++ b/source/gameengine/Converter/BL_BlenderDataConversion.cpp
@@ -1175,7 +1175,7 @@ void BL_ConvertBlenderObjects(struct Main *maggie,
   // Beware of name conflict in linked data, it will not crash but will create confusion
   // in Python scripting and in certain actuators (replace mesh). Linked scene *should* have
   // no conflicting name for Object, Object data and Action.
-  std::vector<Object *> linked_objects = {};
+  std::vector<Collection *> linked_collections = {};
   for (SETLOOPER(blenderscene, sce_iter, base)) {
     Object *blenderobject = base->object;
 
@@ -1194,8 +1194,9 @@ void BL_ConvertBlenderObjects(struct Main *maggie,
       bool is_linked_collection = false;
       FOREACH_COLLECTION_OBJECT_RECURSIVE_BEGIN (blenderobject->instance_collection, obj) {
         if (ID_IS_LINKED(&obj->id)) {
-          linked_objects.push_back(obj);
+          linked_collections.push_back(blenderobject->instance_collection);
           is_linked_collection = true;
+          break;
         }
       }
       FOREACH_COLLECTION_OBJECT_RECURSIVE_END;
@@ -1250,49 +1251,57 @@ void BL_ConvertBlenderObjects(struct Main *maggie,
   }
 
   /* In 2.8+, convert linked objects now */
-  for (Object *blenderobject : linked_objects) {
+  for (Collection *linked_col : linked_collections) {
+    FOREACH_COLLECTION_OBJECT_RECURSIVE_BEGIN (linked_col, blenderobject) {
 
-    if (converter->FindGameObject(blenderobject) != nullptr) {
-      continue;
-    }
-
-    if (blenderobject == kxscene->GetGameDefaultCamera()) {
-      continue;
-    }
-
-    if (single_object) {
-      if (blenderobject != single_object) {
+      /* Only convert linked objects */
+      if (!ID_IS_LINKED(&blenderobject->id)) {
         continue;
       }
-    }
 
-    bool isInActiveLayer = (blenderobject->base_flag &
+      if (converter->FindGameObject(blenderobject) != nullptr) {
+        continue;
+      }
+
+      if (blenderobject == kxscene->GetGameDefaultCamera()) {
+        continue;
+      }
+
+      if (single_object) {
+        if (blenderobject != single_object) {
+          continue;
+        }
+      }
+
+      bool isInActiveLayer = (blenderobject->base_flag &
+                              (BASE_VISIBLE_VIEWLAYER | BASE_VISIBLE_DEPSGRAPH)) != 0;
+      blenderobject->lay = (blenderobject->base_flag &
                             (BASE_VISIBLE_VIEWLAYER | BASE_VISIBLE_DEPSGRAPH)) != 0;
-    blenderobject->lay = (blenderobject->base_flag &
-                       (BASE_VISIBLE_VIEWLAYER | BASE_VISIBLE_DEPSGRAPH)) != 0;
 
-    if (!isInActiveLayer) {
-      /* Force OB_RESTRICT_VIEWPORT to avoid not needed depsgraph operations in some cases */
-      kxscene->BackupRestrictFlag(blenderobject, blenderobject->restrictflag);
-      blenderobject->restrictflag |= OB_RESTRICT_VIEWPORT;
-      BKE_main_collection_sync_remap(maggie);
-      DEG_relations_tag_update(maggie);
+      if (!isInActiveLayer) {
+        /* Force OB_RESTRICT_VIEWPORT to avoid not needed depsgraph operations in some cases */
+        kxscene->BackupRestrictFlag(blenderobject, blenderobject->restrictflag);
+        blenderobject->restrictflag |= OB_RESTRICT_VIEWPORT;
+        BKE_main_collection_sync_remap(maggie);
+        DEG_relations_tag_update(maggie);
+      }
+
+      bool converting_during_runtime = single_object != nullptr;
+
+      KX_GameObject *gameobj = BL_gameobject_from_blenderobject(
+          blenderobject, kxscene, rendertools, converter, libloading, converting_during_runtime);
+
+      if (gameobj && converting_during_runtime) {
+        gameobj->SetIsReplicaObject();
+      }
+
+      if (gameobj) {
+        /* macro calls object conversion funcs */
+        BL_CONVERTBLENDEROBJECT_SINGLE;
+        gameobj->Release();
+      }
     }
-
-    bool converting_during_runtime = single_object != nullptr;
-
-    KX_GameObject *gameobj = BL_gameobject_from_blenderobject(
-        blenderobject, kxscene, rendertools, converter, libloading, converting_during_runtime);
-
-    if (gameobj && converting_during_runtime) {
-      gameobj->SetIsReplicaObject();
-    }
-
-    if (gameobj) {
-      /* macro calls object conversion funcs */
-      BL_CONVERTBLENDEROBJECT_SINGLE;
-      gameobj->Release();
-    }
+    FOREACH_COLLECTION_OBJECT_RECURSIVE_END;
   }
   /* End of linked objects conversion */
 

--- a/source/gameengine/Converter/BL_BlenderDataConversion.cpp
+++ b/source/gameengine/Converter/BL_BlenderDataConversion.cpp
@@ -1175,7 +1175,7 @@ void BL_ConvertBlenderObjects(struct Main *maggie,
   // Beware of name conflict in linked data, it will not crash but will create confusion
   // in Python scripting and in certain actuators (replace mesh). Linked scene *should* have
   // no conflicting name for Object, Object data and Action.
-  std::vector<Collection *> linked_collections = {};
+  std::vector<Object *> linked_objects = {};
   for (SETLOOPER(blenderscene, sce_iter, base)) {
     Object *blenderobject = base->object;
 
@@ -1189,22 +1189,18 @@ void BL_ConvertBlenderObjects(struct Main *maggie,
       }
     }
 
+    /* in 2.8+, SETLOOPER doesn't find linked objects, we'll convert the linked objects after */
     if (blenderobject->instance_collection) {
       bool is_linked_collection = false;
       FOREACH_COLLECTION_OBJECT_RECURSIVE_BEGIN (blenderobject->instance_collection, obj) {
         if (ID_IS_LINKED(&obj->id)) {
+          linked_objects.push_back(obj);
           is_linked_collection = true;
-          break;
         }
       }
       FOREACH_COLLECTION_OBJECT_RECURSIVE_END;
       if (is_linked_collection) {
-        std::vector<Collection *>::iterator it = std::find(linked_collections.begin(),
-                                                           linked_collections.end(),
-                                                           blenderobject->instance_collection);
-        if (it == linked_collections.end()) {
-          linked_collections.push_back(blenderobject->instance_collection);
-        }
+        /* blenderobject->instance_collection seems not a dupligroup but a collection with linked objects */
         continue;
       }
     }
@@ -1251,51 +1247,49 @@ void BL_ConvertBlenderObjects(struct Main *maggie,
     }
   }
 
-  for (Collection *linked_col : linked_collections) {
-    FOREACH_COLLECTION_OBJECT_RECURSIVE_BEGIN (linked_col, blenderobject) {
-      if (converter->FindGameObject(blenderobject) != nullptr) {
+  for (Object *blenderobject : linked_objects) {
+
+    if (converter->FindGameObject(blenderobject) != nullptr) {
+      continue;
+    }
+
+    if (blenderobject == kxscene->GetGameDefaultCamera()) {
+      continue;
+    }
+
+    if (single_object) {
+      if (blenderobject != single_object) {
         continue;
-      }
-
-      if (blenderobject == kxscene->GetGameDefaultCamera()) {
-        continue;
-      }
-
-      if (single_object) {
-        if (blenderobject != single_object) {
-          continue;
-        }
-      }
-
-      bool isInActiveLayer = (blenderobject->base_flag &
-                              (BASE_VISIBLE_VIEWLAYER | BASE_VISIBLE_DEPSGRAPH)) != 0;
-      blenderobject->lay = (blenderobject->base_flag &
-                            (BASE_VISIBLE_VIEWLAYER | BASE_VISIBLE_DEPSGRAPH)) != 0;
-
-      if (!isInActiveLayer) {
-        /* Force OB_RESTRICT_VIEWPORT to avoid not needed depsgraph operations in some cases */
-        kxscene->BackupRestrictFlag(blenderobject, blenderobject->restrictflag);
-        blenderobject->restrictflag |= OB_RESTRICT_VIEWPORT;
-        BKE_main_collection_sync_remap(maggie);
-        DEG_relations_tag_update(maggie);
-      }
-
-      bool converting_during_runtime = single_object != nullptr;
-
-      KX_GameObject *gameobj = BL_gameobject_from_blenderobject(
-          blenderobject, kxscene, rendertools, converter, libloading, converting_during_runtime);
-
-      if (gameobj && converting_during_runtime) {
-        gameobj->SetIsReplicaObject();
-      }
-
-      if (gameobj) {
-        /* macro calls object conversion funcs */
-        BL_CONVERTBLENDEROBJECT_SINGLE;
-        gameobj->Release();
       }
     }
-    FOREACH_COLLECTION_OBJECT_RECURSIVE_END;
+
+    bool isInActiveLayer = (blenderobject->base_flag &
+                            (BASE_VISIBLE_VIEWLAYER | BASE_VISIBLE_DEPSGRAPH)) != 0;
+    blenderobject->lay = (blenderobject->base_flag &
+                       (BASE_VISIBLE_VIEWLAYER | BASE_VISIBLE_DEPSGRAPH)) != 0;
+
+    if (!isInActiveLayer) {
+      /* Force OB_RESTRICT_VIEWPORT to avoid not needed depsgraph operations in some cases */
+      kxscene->BackupRestrictFlag(blenderobject, blenderobject->restrictflag);
+      blenderobject->restrictflag |= OB_RESTRICT_VIEWPORT;
+      BKE_main_collection_sync_remap(maggie);
+      DEG_relations_tag_update(maggie);
+    }
+
+    bool converting_during_runtime = single_object != nullptr;
+
+    KX_GameObject *gameobj = BL_gameobject_from_blenderobject(
+        blenderobject, kxscene, rendertools, converter, libloading, converting_during_runtime);
+
+    if (gameobj && converting_during_runtime) {
+      gameobj->SetIsReplicaObject();
+    }
+
+    if (gameobj) {
+      /* macro calls object conversion funcs */
+      BL_CONVERTBLENDEROBJECT_SINGLE;
+      gameobj->Release();
+    }
   }
 
   if (!grouplist.empty()) {

--- a/source/gameengine/Ketsji/KX_GameObject.h
+++ b/source/gameengine/Ketsji/KX_GameObject.h
@@ -503,6 +503,7 @@ class KX_GameObject : public SCA_IObject {
   bool IsDupliGroup()
   {
     return (m_pBlenderObject && (m_pBlenderObject->transflag & OB_DUPLICOLLECTION) &&
+            !ID_IS_LINKED(&m_pBlenderObject->id) &&
             m_pBlenderObject->instance_collection != nullptr) ?
                true :
                false;


### PR DESCRIPTION
I add this as pull request just to have a better overview of the code, but i'm not sure it is right.

This is an attempt to fix: https://github.com/UPBGE/upbge/issues/1430

As far I understood, blenderobject->intance_collection are either what was called "dupligroups" in 2.7, either collections which contain linked objects from another .blend file and which were not treated as "duligroups" (DupliGroupRecurse was not called).