### PR TITLE
UPBGE: Try to recover 0.2.5 behaviour for compound things

### DIFF
--- a/source/gameengine/Physics/Bullet/CcdPhysicsController.cpp
+++ b/source/gameengine/Physics/Bullet/CcdPhysicsController.cpp
@@ -196,7 +196,7 @@ CcdPhysicsController::CcdPhysicsController(const CcdConstructionInfo &ci) : m_cc
   m_newClientInfo = 0;
   m_registerCount = 0;
   m_softBodyTransformInitialized = false;
-  m_parentCtrl = 0;
+  m_parentRoot = nullptr;
   // copy pointers locally to allow smart release
   m_MotionState = ci.m_MotionState;
   m_collisionShape = ci.m_collisionShape;
@@ -949,7 +949,7 @@ void CcdPhysicsController::WriteDynamicsToMotionState()
 void CcdPhysicsController::PostProcessReplica(class PHY_IMotionState *motionstate,
                                               class PHY_IPhysicsController *parentctrl)
 {
-  SetParentCtrl((CcdPhysicsController *)parentctrl);
+  SetParentRoot((CcdPhysicsController *)parentctrl);
   m_softBodyTransformInitialized = false;
   m_MotionState = motionstate;
   m_registerCount = 0;

--- a/source/gameengine/Physics/Bullet/CcdPhysicsController.h
+++ b/source/gameengine/Physics/Bullet/CcdPhysicsController.h
@@ -578,7 +578,7 @@ class CcdPhysicsController : public PHY_IPhysicsController {
   int m_registerCount;        // needed when multiple sensors use the same controller
   CcdConstructionInfo m_cci;  // needed for replication
 
-  CcdPhysicsController *m_parentCtrl;
+  CcdPhysicsController *m_parentRoot;
 
   int m_savedCollisionFlags;
   short m_savedCollisionFilterGroup;
@@ -844,19 +844,14 @@ class CcdPhysicsController : public PHY_IPhysicsController {
     return m_cci.m_physicsEnv;
   }
 
-  void SetParentCtrl(CcdPhysicsController *parentCtrl)
+  void SetParentRoot(CcdPhysicsController *parentCtrl)
   {
-    m_parentCtrl = parentCtrl;
+    m_parentRoot = parentCtrl;
   }
 
-  CcdPhysicsController *GetParentCtrl()
+  CcdPhysicsController *GetParentRoot() const
   {
-    return m_parentCtrl;
-  }
-
-  const CcdPhysicsController *GetParentCtrl() const
-  {
-    return m_parentCtrl;
+    return m_parentRoot;
   }
 
   virtual bool IsDynamic()


### PR DESCRIPTION
- It recovers something in BlenderDataConversion to take into account compound children. My guess is that as I didn't know what was compound, I disabled it during 0.3 development.
- It recovers a commit just after 0.2.2: 067da32bf00a0917f2deceb7dbe8e88ef6f6f9a1 (I saw you already had recovered another previous commit related to compound just before 0.2.2)

wuaeio told me that it was not working then I did that. He tested and told me that it was working as excpected according to him.

I saw you already pushed a commit related to compound a long time ago in official bge, then maybe you know what it is and can evaluate better than me if it sounds ok to you.

parenthesis: I left dm argument in physenv->ConvertObject(...., DerivedMesh *dm, ....) but it is always nullpr.

