### PR TITLE
UPBGE: BL_Action: Add checks to try to ensure we're playing the right action

### DIFF
--- a/source/gameengine/Ketsji/BL_Action.cpp
+++ b/source/gameengine/Ketsji/BL_Action.cpp
@@ -428,8 +428,8 @@ void BL_Action::Update(float curtime, bool applyToObject)
          md = (ModifierData *)md->next) {
       bool isRightAction = false;
       /* action - check for F-Curves with paths containing 'modifiers[' */
-      if (ob->adt && ob->adt->action && ob->adt->action->curves.first) {
-        for (FCurve *fcu = (FCurve *)ob->adt->action->curves.first; fcu != NULL;
+      if (m_action->curves.first) {
+        for (FCurve *fcu = (FCurve *)m_action->curves.first; fcu != NULL;
              fcu = (FCurve *)fcu->next) {
           if (fcu->rna_path) {
             std::string fcu_name(fcu->rna_path);

--- a/source/gameengine/Ketsji/BL_Action.cpp
+++ b/source/gameengine/Ketsji/BL_Action.cpp
@@ -324,7 +324,6 @@ static bool ActionMatchesName(bAction *action, char *name)
         return true;
       }
     }
-    return false;
   }
   return false;
 }

--- a/source/gameengine/Ketsji/BL_Action.cpp
+++ b/source/gameengine/Ketsji/BL_Action.cpp
@@ -316,7 +316,7 @@ void BL_Action::BlendShape(Key *key, float srcweight, std::vector<float> &blends
 static bool ActionMatchesName(bAction *action, char *name)
 {
   if (action->curves.first) {
-    for (FCurve *fcu = (FCurve *)action->curves.first; fcu != NULL; fcu = (FCurve *)fcu->next) {
+    LISTBASE_FOREACH (FCurve *, fcu, &action->curves) {
       if (fcu->rna_path) {
         std::string fcu_name(fcu->rna_path);
         std::string data_name(name);
@@ -442,8 +442,7 @@ void BL_Action::Update(float curtime, bool applyToObject)
      * then another check should be found to ensure to play the right action.
      */
     // TEST KEYFRAMED MODIFIERS (WRONG CODE BUT JUST FOR TESTING PURPOSE)
-    for (ModifierData *md = (ModifierData *)ob->modifiers.first; md;
-         md = (ModifierData *)md->next) {
+    LISTBASE_FOREACH (ModifierData *, md, &ob->modifiers) {
       bool isRightAction = ActionMatchesName(m_action, md->name);
       // TODO: We need to find the good notifier per action
       if (isRightAction && !BKE_modifier_is_non_geometrical(md)) {
@@ -459,9 +458,7 @@ void BL_Action::Update(float curtime, bool applyToObject)
     }
 
     if (!actionIsUpdated) {
-      for (GpencilModifierData *gpmd = (GpencilModifierData *)ob->greasepencil_modifiers.first;
-           gpmd;
-           gpmd = (GpencilModifierData *)gpmd->next) {
+      LISTBASE_FOREACH (GpencilModifierData *, gpmd, &ob->greasepencil_modifiers) {
         // TODO: We need to find the good notifier per action (maybe all ID_RECALC_GEOMETRY except
         // the Color ones)
         bool isRightAction = ActionMatchesName(m_action, gpmd->name);
@@ -478,8 +475,7 @@ void BL_Action::Update(float curtime, bool applyToObject)
 
     if (!actionIsUpdated) {
       // TEST FollowPath action
-      for (bConstraint *con = (bConstraint *)ob->constraints.first; con;
-           con = (bConstraint *)con->next) {
+      LISTBASE_FOREACH (bConstraint *, con, &ob->constraints) {
         if (ActionMatchesName(m_action, con->name)) {
           if (!scene->OrigObCanBeTransformedInRealtime(ob)) {
             break;

--- a/source/gameengine/Ketsji/BL_Action.cpp
+++ b/source/gameengine/Ketsji/BL_Action.cpp
@@ -427,13 +427,13 @@ void BL_Action::Update(float curtime, bool applyToObject)
     for (ModifierData *md = (ModifierData *)ob->modifiers.first; md;
          md = (ModifierData *)md->next) {
       bool isRightAction = false;
-      /* action - check for F-Curves with paths containing 'modifiers[' */
       if (m_action->curves.first) {
         for (FCurve *fcu = (FCurve *)m_action->curves.first; fcu != NULL;
              fcu = (FCurve *)fcu->next) {
           if (fcu->rna_path) {
             std::string fcu_name(fcu->rna_path);
             std::string md_name(md->name);
+            /* Find a correspondance between ob->modifier and actuator action (m_action) */
             if (fcu_name.find(md_name) != std::string::npos) {
               isRightAction = true;
               break;

--- a/source/gameengine/Ketsji/BL_Action.cpp
+++ b/source/gameengine/Ketsji/BL_Action.cpp
@@ -315,15 +315,13 @@ void BL_Action::BlendShape(Key *key, float srcweight, std::vector<float> &blends
 /* Ensure name of data (ModifierData, bConstraint...) matches m_action's FCurve rna path */
 static bool ActionMatchesName(bAction *action, char *name)
 {
-  if (action->curves.first) {
-    LISTBASE_FOREACH (FCurve *, fcu, &action->curves) {
-      if (fcu->rna_path) {
-        std::string fcu_name(fcu->rna_path);
-        std::string data_name(name);
-        /* Find a correspondance between ob->modifier/ob->constraint... and actuator action (m_action) */
-        if (fcu_name.find(data_name) != std::string::npos) {
-          return true;
-        }
+  LISTBASE_FOREACH (FCurve *, fcu, &action->curves) {
+    if (fcu->rna_path) {
+      std::string fcu_name(fcu->rna_path);
+      std::string data_name(name);
+      /* Find a correspondance between ob->modifier/ob->constraint... and actuator action (m_action) */
+      if (fcu_name.find(data_name) != std::string::npos) {
+        return true;
       }
     }
     return false;

--- a/source/gameengine/Ketsji/BL_Action.cpp
+++ b/source/gameengine/Ketsji/BL_Action.cpp
@@ -539,11 +539,11 @@ void BL_Action::Update(float curtime, bool applyToObject)
       Main *bmain = KX_GetActiveEngine()->GetConverter()->GetMain();
       FOREACH_NODETREE_BEGIN (bmain, nodetree, id) {
         bool isRightAction = false;
-        isRightAction = (nodetree->adt && nodetree->adt->action->id.name == m_action->id.name);
+        isRightAction = (nodetree->adt && nodetree->adt->action == m_action);
         if (!isRightAction && nodetree->adt && nodetree->adt->nla_tracks.first) {
           LISTBASE_FOREACH (NlaTrack *, track, &nodetree->adt->nla_tracks) {
             LISTBASE_FOREACH (NlaStrip *, strip, &track->strips) {
-              if (strcmp(strip->name, m_action->id.name + 2) == 0) {
+              if (strip->act == m_action) {
                 isRightAction = true;
                 break;
               }
@@ -567,7 +567,7 @@ void BL_Action::Update(float curtime, bool applyToObject)
       Mesh *me = (Mesh *)ob->data;
       if (ob->type == OB_MESH && me) {
         const bool bHasShapeKey = me->key && me->key->type == KEY_RELATIVE;
-        if (bHasShapeKey && me->key->adt && me->key->adt->action->id.name == m_action->id.name) {
+        if (bHasShapeKey && me->key->adt && me->key->adt->action == m_action) {
           DEG_id_tag_update(&me->id, ID_RECALC_GEOMETRY);
           Key *key = me->key;
 

--- a/source/gameengine/Ketsji/BL_Action.cpp
+++ b/source/gameengine/Ketsji/BL_Action.cpp
@@ -323,7 +323,6 @@ static bool ActionMatchesModifier(bAction *action, ModifierData *md)
         /* Find a correspondance between ob->modifier and actuator action (m_action) */
         if (fcu_name.find(md_name) != std::string::npos) {
           return true;
-          break;
         }
       }
     }
@@ -342,7 +341,6 @@ static bool ActionMatchesModifier(bAction *action, GpencilModifierData *md)
         /* Find a correspondance between ob->modifier and actuator action (m_action) */
         if (fcu_name.find(md_name) != std::string::npos) {
           return true;
-          break;
         }
       }
     }

--- a/source/gameengine/Ketsji/BL_Action.cpp
+++ b/source/gameengine/Ketsji/BL_Action.cpp
@@ -33,7 +33,6 @@
 #include "BKE_node.h"
 #include "BKE_object.h"
 #include "BLI_listbase.h"
-#include "BLI_string.h"
 #include "DEG_depsgraph_query.h"
 #include "ED_node.h"
 #include "DNA_gpencil_modifier_types.h"


### PR DESCRIPTION
it is an attempt to fix https://github.com/UPBGE/upbge/issues/1445

There are 2 things:

- We compare directly action pointers instead of action names when we can.
- When it is not possible, for currently playable action "data types", we ensure that m_action (actuator's action) FCurve rna path contains the "data name" (constraint name, modifier name...) (if not the action is not played). The code is derived from BKE_modifier_uses_time and adapted.

BL_Action code can potentially be improved to support more action types but needs more investigations and can be done later.