### PR TITLE
UPBGE: Fix most of missing depsgraph notifiers for extra render passes

### DIFF
--- a/source/gameengine/Ketsji/BL_Action.cpp
+++ b/source/gameengine/Ketsji/BL_Action.cpp
@@ -34,8 +34,6 @@
 #include "BKE_object.h"
 #include "BLI_listbase.h"
 #include "BLI_string.h"
-#include "DEG_depsgraph_query.h"
-#include "ED_node.h"
 #include "DNA_gpencil_modifier_types.h"
 #include "DNA_key_types.h"
 #include "DNA_mesh_types.h"
@@ -436,7 +434,12 @@ void BL_Action::Update(float curtime, bool applyToObject)
                                                                                m_localframe);
 
   if (m_obj->GetGameObjectType() == SCA_IObject::OBJ_ARMATURE) {
-    DEG_id_tag_update(&ob->id, ID_RECALC_TRANSFORM);
+    if (ob->gameflag & OB_OVERLAY_COLLECTION) {
+      scene->AppendToExtraObjectsToUpdateInOverlayPass(ob, ID_RECALC_TRANSFORM);
+    }
+    else {
+      scene->AppendToExtraObjectsToUpdateInOtherRenderPass(ob, ID_RECALC_TRANSFORM);
+    }
 
     BL_ArmatureObject *obj = (BL_ArmatureObject *)m_obj;
 
@@ -524,7 +527,12 @@ void BL_Action::Update(float curtime, bool applyToObject)
           if (!scene->OrigObCanBeTransformedInRealtime(ob)) {
             break;
           }
-          DEG_id_tag_update(&ob->id, ID_RECALC_TRANSFORM);
+          if (ob->gameflag & OB_OVERLAY_COLLECTION) {
+            scene->AppendToExtraObjectsToUpdateInOverlayPass(ob, ID_RECALC_TRANSFORM);
+          }
+          else {
+            scene->AppendToExtraObjectsToUpdateInOtherRenderPass(ob, ID_RECALC_TRANSFORM);
+          }
           PointerRNA ptrrna;
           RNA_id_pointer_create(&ob->id, &ptrrna);
           animsys_evaluate_action(&ptrrna, m_action, &animEvalContext, false);
@@ -546,9 +554,12 @@ void BL_Action::Update(float curtime, bool applyToObject)
             continue;
           }
           if (ActionMatchesName(m_action, prop->name, ACT_TYPE_IDPROP)) {
-            DEG_id_tag_update(
-                &ob->id,
-                ID_RECALC_TRANSFORM);  // a generic notifier which will update most of actions
+            if (ob->gameflag & OB_OVERLAY_COLLECTION) {
+              scene->AppendToExtraObjectsToUpdateInOverlayPass(ob, ID_RECALC_TRANSFORM);
+            }
+            else {
+              scene->AppendToExtraObjectsToUpdateInOtherRenderPass(ob, ID_RECALC_TRANSFORM);
+            }
             PointerRNA ptrrna;
             RNA_id_pointer_create(&ob->id, &ptrrna);
             animsys_evaluate_action(&ptrrna, m_action, &animEvalContext, false);
@@ -576,10 +587,10 @@ void BL_Action::Update(float curtime, bool applyToObject)
           }
         }
         if (isRightAction) {
+          scene->AppendToNodeTreesToUpdateInOterRenderPass(nodetree);
           PointerRNA ptrrna;
           RNA_id_pointer_create(&nodetree->id, &ptrrna);
           animsys_evaluate_action(&ptrrna, m_action, &animEvalContext, false);
-          ED_node_tag_update_nodetree(bmain, nodetree, nullptr);
           actionIsUpdated = true;
           break;
         }
@@ -593,7 +604,7 @@ void BL_Action::Update(float curtime, bool applyToObject)
       if (ob->type == OB_MESH && me) {
         const bool bHasShapeKey = me->key && me->key->type == KEY_RELATIVE;
         if (bHasShapeKey && me->key->adt && me->key->adt->action == m_action) {
-          DEG_id_tag_update(&me->id, ID_RECALC_GEOMETRY);
+          scene->AppendToMeshesToUpdateInOtherRenderPass(me, ID_RECALC_GEOMETRY);
           Key *key = me->key;
 
           PointerRNA ptrrna;

--- a/source/gameengine/Ketsji/BL_Action.cpp
+++ b/source/gameengine/Ketsji/BL_Action.cpp
@@ -484,7 +484,7 @@ void BL_Action::Update(float curtime, bool applyToObject)
           scene->AppendToExtraObjectsToUpdateInOverlayPass(ob, ID_RECALC_GEOMETRY);
         }
         else {
-          scene->AppendToExtraObjectsToUpdateInFirstRenderPass(ob, ID_RECALC_GEOMETRY);
+          scene->AppendToExtraObjectsToUpdateInOtherRenderPass(ob, ID_RECALC_GEOMETRY);
         }
         PointerRNA ptrrna;
         RNA_id_pointer_create(&ob->id, &ptrrna);
@@ -506,7 +506,7 @@ void BL_Action::Update(float curtime, bool applyToObject)
             scene->AppendToExtraObjectsToUpdateInOverlayPass(ob, ID_RECALC_GEOMETRY);
           }
           else {
-            scene->AppendToExtraObjectsToUpdateInFirstRenderPass(ob, ID_RECALC_GEOMETRY);
+            scene->AppendToExtraObjectsToUpdateInOtherRenderPass(ob, ID_RECALC_GEOMETRY);
           }
           PointerRNA ptrrna;
           RNA_id_pointer_create(&ob->id, &ptrrna);

--- a/source/gameengine/Ketsji/BL_Action.cpp
+++ b/source/gameengine/Ketsji/BL_Action.cpp
@@ -480,7 +480,12 @@ void BL_Action::Update(float curtime, bool applyToObject)
       bool isRightAction = ActionMatchesName(m_action, md->name, ACT_TYPE_MODIFIER);
       // TODO: We need to find the good notifier per action
       if (isRightAction && !BKE_modifier_is_non_geometrical(md)) {
-        scene->AppendToExtraObjectsToUpdate(ob, ID_RECALC_GEOMETRY);
+        if (ob->gameflag & OB_OVERLAY_COLLECTION) {
+          scene->AppendToExtraObjectsToUpdateInOverlayPass(ob, ID_RECALC_GEOMETRY);
+        }
+        else {
+          scene->AppendToExtraObjectsToUpdateInFirstRenderPass(ob, ID_RECALC_GEOMETRY);
+        }
         PointerRNA ptrrna;
         RNA_id_pointer_create(&ob->id, &ptrrna);
         animsys_evaluate_action(&ptrrna, m_action, &animEvalContext, false);
@@ -497,7 +502,12 @@ void BL_Action::Update(float curtime, bool applyToObject)
         // the Color ones)
         bool isRightAction = ActionMatchesName(m_action, gpmd->name, ACT_TYPE_GPMODIFIER);
         if (isRightAction) {
-          scene->AppendToExtraObjectsToUpdate(ob, ID_RECALC_GEOMETRY);
+          if (ob->gameflag & OB_OVERLAY_COLLECTION) {
+            scene->AppendToExtraObjectsToUpdateInOverlayPass(ob, ID_RECALC_GEOMETRY);
+          }
+          else {
+            scene->AppendToExtraObjectsToUpdateInFirstRenderPass(ob, ID_RECALC_GEOMETRY);
+          }
           PointerRNA ptrrna;
           RNA_id_pointer_create(&ob->id, &ptrrna);
           animsys_evaluate_action(&ptrrna, m_action, &animEvalContext, false);

--- a/source/gameengine/Ketsji/BL_Action.cpp
+++ b/source/gameengine/Ketsji/BL_Action.cpp
@@ -480,7 +480,7 @@ void BL_Action::Update(float curtime, bool applyToObject)
       bool isRightAction = ActionMatchesName(m_action, md->name, ACT_TYPE_MODIFIER);
       // TODO: We need to find the good notifier per action
       if (isRightAction && !BKE_modifier_is_non_geometrical(md)) {
-        DEG_id_tag_update(&ob->id, ID_RECALC_GEOMETRY);
+        scene->AppendToExtraObjectsToUpdate(ob, ID_RECALC_GEOMETRY);
         PointerRNA ptrrna;
         RNA_id_pointer_create(&ob->id, &ptrrna);
         animsys_evaluate_action(&ptrrna, m_action, &animEvalContext, false);
@@ -497,7 +497,7 @@ void BL_Action::Update(float curtime, bool applyToObject)
         // the Color ones)
         bool isRightAction = ActionMatchesName(m_action, gpmd->name, ACT_TYPE_GPMODIFIER);
         if (isRightAction) {
-          DEG_id_tag_update(&ob->id, ID_RECALC_GEOMETRY);
+          scene->AppendToExtraObjectsToUpdate(ob, ID_RECALC_GEOMETRY);
           PointerRNA ptrrna;
           RNA_id_pointer_create(&ob->id, &ptrrna);
           animsys_evaluate_action(&ptrrna, m_action, &animEvalContext, false);

--- a/source/gameengine/Ketsji/BL_Action.cpp
+++ b/source/gameengine/Ketsji/BL_Action.cpp
@@ -438,7 +438,7 @@ void BL_Action::Update(float curtime, bool applyToObject)
       scene->AppendToExtraObjectsToUpdateInOverlayPass(ob, ID_RECALC_TRANSFORM);
     }
     else {
-      scene->AppendToExtraObjectsToUpdateInOtherRenderPass(ob, ID_RECALC_TRANSFORM);
+      scene->AppendToExtraObjectsToUpdateInAllRenderPasses(ob, ID_RECALC_TRANSFORM);
     }
 
     BL_ArmatureObject *obj = (BL_ArmatureObject *)m_obj;
@@ -487,7 +487,7 @@ void BL_Action::Update(float curtime, bool applyToObject)
           scene->AppendToExtraObjectsToUpdateInOverlayPass(ob, ID_RECALC_GEOMETRY);
         }
         else {
-          scene->AppendToExtraObjectsToUpdateInOtherRenderPass(ob, ID_RECALC_GEOMETRY);
+          scene->AppendToExtraObjectsToUpdateInAllRenderPasses(ob, ID_RECALC_GEOMETRY);
         }
         PointerRNA ptrrna;
         RNA_id_pointer_create(&ob->id, &ptrrna);
@@ -509,7 +509,7 @@ void BL_Action::Update(float curtime, bool applyToObject)
             scene->AppendToExtraObjectsToUpdateInOverlayPass(ob, ID_RECALC_GEOMETRY);
           }
           else {
-            scene->AppendToExtraObjectsToUpdateInOtherRenderPass(ob, ID_RECALC_GEOMETRY);
+            scene->AppendToExtraObjectsToUpdateInAllRenderPasses(ob, ID_RECALC_GEOMETRY);
           }
           PointerRNA ptrrna;
           RNA_id_pointer_create(&ob->id, &ptrrna);
@@ -531,7 +531,7 @@ void BL_Action::Update(float curtime, bool applyToObject)
             scene->AppendToExtraObjectsToUpdateInOverlayPass(ob, ID_RECALC_TRANSFORM);
           }
           else {
-            scene->AppendToExtraObjectsToUpdateInOtherRenderPass(ob, ID_RECALC_TRANSFORM);
+            scene->AppendToExtraObjectsToUpdateInAllRenderPasses(ob, ID_RECALC_TRANSFORM);
           }
           PointerRNA ptrrna;
           RNA_id_pointer_create(&ob->id, &ptrrna);
@@ -558,7 +558,7 @@ void BL_Action::Update(float curtime, bool applyToObject)
               scene->AppendToExtraObjectsToUpdateInOverlayPass(ob, ID_RECALC_TRANSFORM);
             }
             else {
-              scene->AppendToExtraObjectsToUpdateInOtherRenderPass(ob, ID_RECALC_TRANSFORM);
+              scene->AppendToExtraObjectsToUpdateInAllRenderPasses(ob, ID_RECALC_TRANSFORM);
             }
             PointerRNA ptrrna;
             RNA_id_pointer_create(&ob->id, &ptrrna);
@@ -587,7 +587,7 @@ void BL_Action::Update(float curtime, bool applyToObject)
           }
         }
         if (isRightAction) {
-          scene->AppendToNodeTreesToUpdateInOterRenderPass(nodetree);
+          scene->AppendToNodeTreesToUpdateInAllRenderPasses(nodetree);
           PointerRNA ptrrna;
           RNA_id_pointer_create(&nodetree->id, &ptrrna);
           animsys_evaluate_action(&ptrrna, m_action, &animEvalContext, false);
@@ -604,7 +604,7 @@ void BL_Action::Update(float curtime, bool applyToObject)
       if (ob->type == OB_MESH && me) {
         const bool bHasShapeKey = me->key && me->key->type == KEY_RELATIVE;
         if (bHasShapeKey && me->key->adt && me->key->adt->action == m_action) {
-          scene->AppendToMeshesToUpdateInOtherRenderPass(me, ID_RECALC_GEOMETRY);
+          scene->AppendToMeshesToUpdateInAllRenderPasses(me, ID_RECALC_GEOMETRY);
           Key *key = me->key;
 
           PointerRNA ptrrna;

--- a/source/gameengine/Ketsji/KX_FontObject.cpp
+++ b/source/gameengine/Ketsji/KX_FontObject.cpp
@@ -32,7 +32,6 @@
 #include "KX_FontObject.h"
 
 #include "BLI_blenlib.h"
-#include "DEG_depsgraph.h"
 #include "DNA_curve_types.h"
 #include "MEM_guardedalloc.h"
 

--- a/source/gameengine/Ketsji/KX_FontObject.cpp
+++ b/source/gameengine/Ketsji/KX_FontObject.cpp
@@ -110,8 +110,7 @@ void KX_FontObject::UpdateCurveText(std::string newText)  // eevee
   cu->str = (char *)MEM_mallocN(cu->len + sizeof(wchar_t), "str");
   BLI_strncpy(cu->str, newText.c_str(), FILE_MAX);
 
-  DEG_id_tag_update(&ob->id, ID_RECALC_GEOMETRY);
-  DEG_id_tag_update(&ob->id, ID_RECALC_COPY_ON_WRITE);
+  GetScene()->AppendToExtraObjectsToUpdate(ob, ID_RECALC_GEOMETRY);
 }
 
 void KX_FontObject::UpdateTextFromProperty()

--- a/source/gameengine/Ketsji/KX_FontObject.cpp
+++ b/source/gameengine/Ketsji/KX_FontObject.cpp
@@ -113,7 +113,7 @@ void KX_FontObject::UpdateCurveText(std::string newText)  // eevee
     GetScene()->AppendToExtraObjectsToUpdateInOverlayPass(ob, ID_RECALC_GEOMETRY);
   }
   else {
-    GetScene()->AppendToExtraObjectsToUpdateInOtherRenderPass(ob, ID_RECALC_GEOMETRY);
+    GetScene()->AppendToExtraObjectsToUpdateInAllRenderPasses(ob, ID_RECALC_GEOMETRY);
   }
 }
 

--- a/source/gameengine/Ketsji/KX_FontObject.cpp
+++ b/source/gameengine/Ketsji/KX_FontObject.cpp
@@ -114,7 +114,7 @@ void KX_FontObject::UpdateCurveText(std::string newText)  // eevee
     GetScene()->AppendToExtraObjectsToUpdateInOverlayPass(ob, ID_RECALC_GEOMETRY);
   }
   else {
-    GetScene()->AppendToExtraObjectsToUpdateInFirstRenderPass(ob, ID_RECALC_GEOMETRY);
+    GetScene()->AppendToExtraObjectsToUpdateInOtherRenderPass(ob, ID_RECALC_GEOMETRY);
   }
 }
 

--- a/source/gameengine/Ketsji/KX_FontObject.cpp
+++ b/source/gameengine/Ketsji/KX_FontObject.cpp
@@ -110,7 +110,12 @@ void KX_FontObject::UpdateCurveText(std::string newText)  // eevee
   cu->str = (char *)MEM_mallocN(cu->len + sizeof(wchar_t), "str");
   BLI_strncpy(cu->str, newText.c_str(), FILE_MAX);
 
-  GetScene()->AppendToExtraObjectsToUpdate(ob, ID_RECALC_GEOMETRY);
+  if (ob->gameflag & OB_OVERLAY_COLLECTION) {
+    GetScene()->AppendToExtraObjectsToUpdateInOverlayPass(ob, ID_RECALC_GEOMETRY);
+  }
+  else {
+    GetScene()->AppendToExtraObjectsToUpdateInFirstRenderPass(ob, ID_RECALC_GEOMETRY);
+  }
 }
 
 void KX_FontObject::UpdateTextFromProperty()

--- a/source/gameengine/Ketsji/KX_GameObject.cpp
+++ b/source/gameengine/Ketsji/KX_GameObject.cpp
@@ -254,7 +254,7 @@ void KX_GameObject::ForceIgnoreParentTx()
   m_forceIgnoreParentTx = true;
 }
 
-void KX_GameObject::TagForUpdate(bool is_last_render_pass)
+void KX_GameObject::TagForTransformUpdate(bool is_last_render_pass)
 {
   float obmat[4][4];
   NodeGetWorldTransform().getValue(&obmat[0][0]);
@@ -326,7 +326,7 @@ void KX_GameObject::TagForUpdate(bool is_last_render_pass)
   m_forceIgnoreParentTx = false;
 }
 
-void KX_GameObject::TagForUpdateEvaluated()
+void KX_GameObject::TagForTransformUpdateEvaluated()
 {
   float obmat[4][4];
   NodeGetWorldTransform().getValue(&obmat[0][0]);

--- a/source/gameengine/Ketsji/KX_GameObject.h
+++ b/source/gameengine/Ketsji/KX_GameObject.h
@@ -136,8 +136,8 @@ class KX_GameObject : public SCA_IObject {
  public:
   /* EEVEE INTEGRATION */
 
-  void TagForUpdate(bool is_last_render_pass);
-  void TagForUpdateEvaluated();
+  void TagForTransformUpdate(bool is_last_render_pass);
+  void TagForTransformUpdateEvaluated();
   void ReplicateBlenderObject();
   void HideOriginalObject();
   void RemoveReplicaObject();

--- a/source/gameengine/Ketsji/KX_Scene.cpp
+++ b/source/gameengine/Ketsji/KX_Scene.cpp
@@ -252,9 +252,9 @@ KX_Scene::KX_Scene(SCA_IInputDevice *inputDevice,
 
   m_overlay_collections = {};
   m_imageRenderCameraList = {};
-  m_extraObjectsToUpdateInOtherRenderPass = {};
-  m_meshesToUpdateInOtherRenderPass = {};
-  m_nodeTreesToUpdateInOtherRenderPass = {};
+  m_extraObjectsToUpdateInAllRenderPasses = {};
+  m_meshesToUpdateInAllRenderPasses = {};
+  m_nodeTreesToUpdateInAllRenderPasses = {};
   m_extraObjectsToUpdateInOverlayPass = {};
 
   /* To backup and restore obmat */
@@ -696,19 +696,19 @@ void KX_Scene::RenderAfterCameraSetup(KX_Camera *cam,
   }
 
   for (std::map<Object *, IDRecalcFlag>::iterator it =
-           m_extraObjectsToUpdateInOtherRenderPass.begin();
-       it != m_extraObjectsToUpdateInOtherRenderPass.end();
+           m_extraObjectsToUpdateInAllRenderPasses.begin();
+       it != m_extraObjectsToUpdateInAllRenderPasses.end();
        it++) {
     DEG_id_tag_update(&it->first->id, it->second);
   }
 
-  for (std::map<Mesh *, IDRecalcFlag>::iterator it = m_meshesToUpdateInOtherRenderPass.begin();
-       it != m_meshesToUpdateInOtherRenderPass.end();
+  for (std::map<Mesh *, IDRecalcFlag>::iterator it = m_meshesToUpdateInAllRenderPasses.begin();
+       it != m_meshesToUpdateInAllRenderPasses.end();
        it++) {
     DEG_id_tag_update(&it->first->id, it->second);
   }
 
-  for (bNodeTree *ntree : m_nodeTreesToUpdateInOtherRenderPass) {
+  for (bNodeTree *ntree : m_nodeTreesToUpdateInAllRenderPasses) {
     ED_node_tag_update_nodetree(bmain, ntree, nullptr);
   }
 
@@ -723,9 +723,9 @@ void KX_Scene::RenderAfterCameraSetup(KX_Camera *cam,
   }
 
   if (is_last_render_pass) {
-    m_extraObjectsToUpdateInOtherRenderPass.clear();
-    m_meshesToUpdateInOtherRenderPass.clear();
-    m_nodeTreesToUpdateInOtherRenderPass.clear();
+    m_extraObjectsToUpdateInAllRenderPasses.clear();
+    m_meshesToUpdateInAllRenderPasses.clear();
+    m_nodeTreesToUpdateInAllRenderPasses.clear();
   }
 
   /* We need the changes to be flushed before each draw loop! */
@@ -1301,19 +1301,19 @@ bool KX_Scene::SomethingIsMoving()
   return false;
 }
 
-void KX_Scene::AppendToExtraObjectsToUpdateInOtherRenderPass(Object *ob, IDRecalcFlag flag)
+void KX_Scene::AppendToExtraObjectsToUpdateInAllRenderPasses(Object *ob, IDRecalcFlag flag)
 {
-  m_extraObjectsToUpdateInOtherRenderPass.insert({ob, flag});
+  m_extraObjectsToUpdateInAllRenderPasses.insert({ob, flag});
 }
 
-void KX_Scene::AppendToMeshesToUpdateInOtherRenderPass(Mesh *me, IDRecalcFlag flag)
+void KX_Scene::AppendToMeshesToUpdateInAllRenderPasses(Mesh *me, IDRecalcFlag flag)
 {
-  m_meshesToUpdateInOtherRenderPass.insert({me, flag});
+  m_meshesToUpdateInAllRenderPasses.insert({me, flag});
 }
 
-void KX_Scene::AppendToNodeTreesToUpdateInOterRenderPass(bNodeTree *ntree)
+void KX_Scene::AppendToNodeTreesToUpdateInAllRenderPasses(bNodeTree *ntree)
 {
-  m_nodeTreesToUpdateInOtherRenderPass.push_back(ntree);
+  m_nodeTreesToUpdateInAllRenderPasses.push_back(ntree);
 }
 
 void KX_Scene::AppendToExtraObjectsToUpdateInOverlayPass(Object *ob, IDRecalcFlag flag)

--- a/source/gameengine/Ketsji/KX_Scene.cpp
+++ b/source/gameengine/Ketsji/KX_Scene.cpp
@@ -250,7 +250,7 @@ KX_Scene::KX_Scene(SCA_IInputDevice *inputDevice,
 
   m_overlay_collections = {};
   m_imageRenderCameraList = {};
-  m_extraObjectsToUpdateInFirstRenderPass = {};
+  m_extraObjectsToUpdateInOtherRenderPass = {};
   m_extraObjectsToUpdateInOverlayPass = {};
 
   /* To backup and restore obmat */
@@ -693,12 +693,11 @@ void KX_Scene::RenderAfterCameraSetup(KX_Camera *cam,
 
   if (cam && cam != GetOverlayCamera()) {
     for (std::map<Object *, IDRecalcFlag>::iterator it =
-             m_extraObjectsToUpdateInFirstRenderPass.begin();
-         it != m_extraObjectsToUpdateInFirstRenderPass.end();
+             m_extraObjectsToUpdateInOtherRenderPass.begin();
+         it != m_extraObjectsToUpdateInOtherRenderPass.end();
          it++) {
       DEG_id_tag_update(&it->first->id, it->second);
     }
-    m_extraObjectsToUpdateInFirstRenderPass.clear();
   }
 
   if (cam && cam == GetOverlayCamera()) {
@@ -709,6 +708,10 @@ void KX_Scene::RenderAfterCameraSetup(KX_Camera *cam,
       DEG_id_tag_update(&it->first->id, it->second);
     }
     m_extraObjectsToUpdateInOverlayPass.clear();
+  }
+
+  if (is_last_render_pass) {
+    m_extraObjectsToUpdateInOtherRenderPass.clear();
   }
 
   /* We need the changes to be flushed before each draw loop! */
@@ -1284,9 +1287,9 @@ bool KX_Scene::SomethingIsMoving()
   return false;
 }
 
-void KX_Scene::AppendToExtraObjectsToUpdateInFirstRenderPass(Object *ob, IDRecalcFlag flag)
+void KX_Scene::AppendToExtraObjectsToUpdateInOtherRenderPass(Object *ob, IDRecalcFlag flag)
 {
-  m_extraObjectsToUpdateInFirstRenderPass.insert({ob, flag});
+  m_extraObjectsToUpdateInOtherRenderPass.insert({ob, flag});
 }
 
 void KX_Scene::AppendToExtraObjectsToUpdateInOverlayPass(Object *ob, IDRecalcFlag flag)

--- a/source/gameengine/Ketsji/KX_Scene.cpp
+++ b/source/gameengine/Ketsji/KX_Scene.cpp
@@ -689,6 +689,15 @@ void KX_Scene::RenderAfterCameraSetup(KX_Camera *cam,
     gameobj->TagForUpdate(is_last_render_pass);
   }
 
+  for (std::map<Object *, IDRecalcFlag>::iterator it = m_extraObjectsToUpdate.begin();
+       it != m_extraObjectsToUpdate.end(); it++) {
+    DEG_id_tag_update(&it->first->id, it->second);
+  }
+
+  if (is_last_render_pass) {
+    m_extraObjectsToUpdate.clear();
+  }
+
   /* We need the changes to be flushed before each draw loop! */
   BKE_scene_graph_update_tagged(depsgraph, bmain);
 
@@ -1260,6 +1269,11 @@ bool KX_Scene::SomethingIsMoving()
     }
   }
   return false;
+}
+
+void KX_Scene::AppendToExtraObjectsToUpdate(Object *ob, IDRecalcFlag flag)
+{
+  m_extraObjectsToUpdate.insert({ob, flag});
 }
 
 /******************End of EEVEE INTEGRATION****************************/

--- a/source/gameengine/Ketsji/KX_Scene.h
+++ b/source/gameengine/Ketsji/KX_Scene.h
@@ -35,6 +35,8 @@
 #include <set>
 #include <vector>
 
+#include "DNA_ID.h" // For IDRecalcFlag
+
 #include "EXP_PyObjectPlus.h"
 #include "EXP_Value.h"
 #include "KX_PhysicsEngineEnums.h"
@@ -141,6 +143,13 @@ class KX_Scene : public EXP_Value, public SCA_IScene {
   bool m_collectionRemap;
   std::vector<BackupObj *> m_backupObList;
   std::vector<Object *> m_potentialChildren;
+
+  /* Objects to update at each render pass */
+  /* Note: We could try to get the right render pass where
+   * we need to update these objects but it would make
+   * the code more complex.
+   */
+  std::map<Object *, IDRecalcFlag> m_extraObjectsToUpdate;
   /*************************************************/
 
   RAS_BucketManager *m_bucketmanager;
@@ -365,6 +374,7 @@ class KX_Scene : public EXP_Value, public SCA_IScene {
                          Object *ob,
                          std::vector<Object *> children);
   bool SomethingIsMoving();
+  void AppendToExtraObjectsToUpdate(Object *ob, IDRecalcFlag flag);
   /***************End of EEVEE INTEGRATION**********************/
 
   RAS_BucketManager *GetBucketManager() const;

--- a/source/gameengine/Ketsji/KX_Scene.h
+++ b/source/gameengine/Ketsji/KX_Scene.h
@@ -90,7 +90,9 @@ class KX_ObstacleSimulation;
 struct TaskPool;
 
 /*********EEVEE INTEGRATION************/
+struct bNodeTree;
 struct GPUTexture;
+struct Mesh;
 struct Object;
 /**************************************/
 
@@ -152,7 +154,9 @@ class KX_Scene : public EXP_Value, public SCA_IScene {
    * which need to be notified + flushed again.
    */
   std::map<Object *, IDRecalcFlag> m_extraObjectsToUpdateInOtherRenderPass;
+  std::map<Mesh *, IDRecalcFlag> m_meshesToUpdateInOtherRenderPass;
   std::map<Object *, IDRecalcFlag> m_extraObjectsToUpdateInOverlayPass;
+  std::vector<bNodeTree *> m_nodeTreesToUpdateInOtherRenderPass;
   /*************************************************/
 
   RAS_BucketManager *m_bucketmanager;
@@ -378,6 +382,8 @@ class KX_Scene : public EXP_Value, public SCA_IScene {
                          std::vector<Object *> children);
   bool SomethingIsMoving();
   void AppendToExtraObjectsToUpdateInOtherRenderPass(Object *ob, IDRecalcFlag flag);
+  void AppendToMeshesToUpdateInOtherRenderPass(Mesh *me, IDRecalcFlag flag);
+  void AppendToNodeTreesToUpdateInOterRenderPass(bNodeTree *ntree);
   void AppendToExtraObjectsToUpdateInOverlayPass(Object *ob, IDRecalcFlag flag);
   /***************End of EEVEE INTEGRATION**********************/
 

--- a/source/gameengine/Ketsji/KX_Scene.h
+++ b/source/gameengine/Ketsji/KX_Scene.h
@@ -153,10 +153,10 @@ class KX_Scene : public EXP_Value, public SCA_IScene {
    * because the other render pass can contain the same objects
    * which need to be notified + flushed again.
    */
-  std::map<Object *, IDRecalcFlag> m_extraObjectsToUpdateInOtherRenderPass;
-  std::map<Mesh *, IDRecalcFlag> m_meshesToUpdateInOtherRenderPass;
+  std::map<Object *, IDRecalcFlag> m_extraObjectsToUpdateInAllRenderPasses;
+  std::map<Mesh *, IDRecalcFlag> m_meshesToUpdateInAllRenderPasses;
   std::map<Object *, IDRecalcFlag> m_extraObjectsToUpdateInOverlayPass;
-  std::vector<bNodeTree *> m_nodeTreesToUpdateInOtherRenderPass;
+  std::vector<bNodeTree *> m_nodeTreesToUpdateInAllRenderPasses;
   /*************************************************/
 
   RAS_BucketManager *m_bucketmanager;
@@ -381,9 +381,9 @@ class KX_Scene : public EXP_Value, public SCA_IScene {
                          Object *ob,
                          std::vector<Object *> children);
   bool SomethingIsMoving();
-  void AppendToExtraObjectsToUpdateInOtherRenderPass(Object *ob, IDRecalcFlag flag);
-  void AppendToMeshesToUpdateInOtherRenderPass(Mesh *me, IDRecalcFlag flag);
-  void AppendToNodeTreesToUpdateInOterRenderPass(bNodeTree *ntree);
+  void AppendToExtraObjectsToUpdateInAllRenderPasses(Object *ob, IDRecalcFlag flag);
+  void AppendToMeshesToUpdateInAllRenderPasses(Mesh *me, IDRecalcFlag flag);
+  void AppendToNodeTreesToUpdateInAllRenderPasses(bNodeTree *ntree);
   void AppendToExtraObjectsToUpdateInOverlayPass(Object *ob, IDRecalcFlag flag);
   /***************End of EEVEE INTEGRATION**********************/
 

--- a/source/gameengine/Ketsji/KX_Scene.h
+++ b/source/gameengine/Ketsji/KX_Scene.h
@@ -153,9 +153,9 @@ class KX_Scene : public EXP_Value, public SCA_IScene {
    * because the other render pass can contain the same objects
    * which need to be notified + flushed again.
    */
-  std::map<Object *, IDRecalcFlag> m_extraObjectsToUpdateInAllRenderPasses;
-  std::map<Mesh *, IDRecalcFlag> m_meshesToUpdateInAllRenderPasses;
-  std::map<Object *, IDRecalcFlag> m_extraObjectsToUpdateInOverlayPass;
+  std::vector<std::pair<Object *, IDRecalcFlag>> m_extraObjectsToUpdateInAllRenderPasses;
+  std::vector<std::pair<Mesh *, IDRecalcFlag>> m_meshesToUpdateInAllRenderPasses;
+  std::vector<std::pair<Object *, IDRecalcFlag>> m_extraObjectsToUpdateInOverlayPass;
   std::vector<bNodeTree *> m_nodeTreesToUpdateInAllRenderPasses;
   /*************************************************/
 
@@ -385,6 +385,7 @@ class KX_Scene : public EXP_Value, public SCA_IScene {
   void AppendToMeshesToUpdateInAllRenderPasses(Mesh *me, IDRecalcFlag flag);
   void AppendToNodeTreesToUpdateInAllRenderPasses(bNodeTree *ntree);
   void AppendToExtraObjectsToUpdateInOverlayPass(Object *ob, IDRecalcFlag flag);
+  void TagForExtraObjectsUpdate(Main *bmain, KX_Camera *cam);
   /***************End of EEVEE INTEGRATION**********************/
 
   RAS_BucketManager *GetBucketManager() const;

--- a/source/gameengine/Ketsji/KX_Scene.h
+++ b/source/gameengine/Ketsji/KX_Scene.h
@@ -149,7 +149,8 @@ class KX_Scene : public EXP_Value, public SCA_IScene {
    * we need to update these objects but it would make
    * the code more complex.
    */
-  std::map<Object *, IDRecalcFlag> m_extraObjectsToUpdate;
+  std::map<Object *, IDRecalcFlag> m_extraObjectsToUpdateInFirstRenderPass;
+  std::map<Object *, IDRecalcFlag> m_extraObjectsToUpdateInOverlayPass;
   /*************************************************/
 
   RAS_BucketManager *m_bucketmanager;
@@ -374,7 +375,8 @@ class KX_Scene : public EXP_Value, public SCA_IScene {
                          Object *ob,
                          std::vector<Object *> children);
   bool SomethingIsMoving();
-  void AppendToExtraObjectsToUpdate(Object *ob, IDRecalcFlag flag);
+  void AppendToExtraObjectsToUpdateInFirstRenderPass(Object *ob, IDRecalcFlag flag);
+  void AppendToExtraObjectsToUpdateInOverlayPass(Object *ob, IDRecalcFlag flag);
   /***************End of EEVEE INTEGRATION**********************/
 
   RAS_BucketManager *GetBucketManager() const;

--- a/source/gameengine/Ketsji/KX_Scene.h
+++ b/source/gameengine/Ketsji/KX_Scene.h
@@ -147,9 +147,11 @@ class KX_Scene : public EXP_Value, public SCA_IScene {
   /* Objects to update at each render pass */
   /* Note: We could try to get the right render pass where
    * we need to update these objects but it would make
-   * the code more complex.
+   * the code more complex. We can only do that for overlay render pass
+   * because the other render pass can contain the same objects
+   * which need to be notified + flushed again.
    */
-  std::map<Object *, IDRecalcFlag> m_extraObjectsToUpdateInFirstRenderPass;
+  std::map<Object *, IDRecalcFlag> m_extraObjectsToUpdateInOtherRenderPass;
   std::map<Object *, IDRecalcFlag> m_extraObjectsToUpdateInOverlayPass;
   /*************************************************/
 
@@ -375,7 +377,7 @@ class KX_Scene : public EXP_Value, public SCA_IScene {
                          Object *ob,
                          std::vector<Object *> children);
   bool SomethingIsMoving();
-  void AppendToExtraObjectsToUpdateInFirstRenderPass(Object *ob, IDRecalcFlag flag);
+  void AppendToExtraObjectsToUpdateInOtherRenderPass(Object *ob, IDRecalcFlag flag);
   void AppendToExtraObjectsToUpdateInOverlayPass(Object *ob, IDRecalcFlag flag);
   /***************End of EEVEE INTEGRATION**********************/
 

--- a/source/gameengine/VideoTexture/ImageRender.cpp
+++ b/source/gameengine/VideoTexture/ImageRender.cpp
@@ -355,9 +355,11 @@ bool ImageRender::Render()
     /* Add a depsgraph notifier to trigger
      * DRW_notify_view_update on next draw loop. */
     DEG_id_tag_update(&m_camera->GetBlenderObject()->id, ID_RECALC_TRANSFORM);
-    /* We need the changes to be flushed before each draw loop! */
-    BKE_scene_graph_update_tagged(depsgraph, bmain);
   }
+
+  m_scene->TagForExtraObjectsUpdate(bmain, m_camera);
+  /* We need the changes to be flushed before each draw loop! */
+  BKE_scene_graph_update_tagged(depsgraph, bmain);
 
 #ifdef WITH_PYTHON
   RunPreDrawCallbacks();


### PR DESCRIPTION
There are remaining cases not handled (ImageRender + few other cases)... It would need to find a system for all occurrences of DEG_id_tag_update in ge code.

But I think it is fixing most of common cases. Maybe there is a simpler/better way than this patch to proceed.

It is to fix this: https://github.com/UPBGE/upbge/issues/1481 and other potential issues with extra render passes...