### PR TITLE
UPBGE: improve text properties conversion

### DIFF
--- a/source/gameengine/Converter/BL_ConvertProperties.cpp
+++ b/source/gameengine/Converter/BL_ConvertProperties.cpp
@@ -196,7 +196,9 @@ void BL_ConvertTextProperty(Object *object,
       break;
     }
     case GPROP_STRING: {
-      propval = new EXP_StringValue(str, "");
+      std::string textprop;
+      stream >> textprop;
+      propval = new EXP_StringValue(str, textprop.c_str());
       break;
     }
     case GPROP_TIME: {
@@ -219,8 +221,9 @@ void BL_ConvertTextProperty(Object *object,
     }
   }
 
-  if (stream.fail() || stream.bad()) {
-    CM_Error("failed convert font property \"Text\"");
+  /* check stream integrity */
+  if (stream.bad()) {
+    CM_Error("Failed to convert font property \"Text\"");
   }
 
   if (propval) {


### PR DESCRIPTION
Instead of passing an empty string for String property creation we pass the stream data.

Additionally, we remove the stream fail check as the conversion is well done but we mantain the bad check to check the stream integrity. This way we avoid the console error message that it is not very useful for the user (as the conversion is really done).

Previously, the console error message was visible when we use, for example, a font with the text "hello" but we set the string property as integer.