### PR TITLE
Make PythonComponent's properties overridable

### DIFF
--- a/source/blender/blenkernel/BKE_python_component.h
+++ b/source/blender/blenkernel/BKE_python_component.h
@@ -40,6 +40,9 @@ struct PythonComponent *BKE_python_component_create_file(char *import,
 void BKE_python_component_reload(struct PythonComponent *pc,
                                  struct ReportList *reports,
                                  struct bContext *context);
+
+struct PythonComponent *BKE_python_component_copy(PythonComponent *comp);
+
 void BKE_python_component_copy_list(struct ListBase *lbn, const struct ListBase *lbo);
 void BKE_python_component_free(struct PythonComponent *pc);
 void BKE_python_component_free_list(struct ListBase *base);

--- a/source/blender/blenkernel/intern/python_component.c
+++ b/source/blender/blenkernel/intern/python_component.c
@@ -726,7 +726,7 @@ void BKE_python_component_reload(PythonComponent *pc, ReportList *reports, bCont
   load_component(pc, reports, CTX_data_main(context));
 }
 
-static PythonComponent *copy_component(PythonComponent *comp)
+PythonComponent *BKE_python_component_copy(PythonComponent *comp)
 {
   PythonComponent *compn;
   PythonComponentProperty *cprop, *cpropn;
@@ -751,7 +751,7 @@ void BKE_python_component_copy_list(ListBase *lbn, const ListBase *lbo)
   lbn->first = lbn->last = NULL;
   comp = lbo->first;
   while (comp) {
-    compn = copy_component(comp);
+    compn = BKE_python_component_copy(comp);
     BLI_addtail(lbn, compn);
     comp = comp->next;
   }

--- a/source/blender/editors/space_logic/logic_ops.c
+++ b/source/blender/editors/space_logic/logic_ops.c
@@ -250,6 +250,24 @@ static int logicbricks_move_property_get(wmOperator *op)
     return false;
 }
 
+static bool remove_component_poll(bContext *C)
+{
+  PointerRNA ptr = CTX_data_pointer_get_type(C, "component", &RNA_PythonComponent);
+  Object *ob = (ptr.owner_id) ? (Object *)ptr.owner_id : ED_object_active_context(C);
+
+  if (!ob || ID_IS_LINKED(ob)) {
+    return false;
+  }
+
+  if (ID_IS_OVERRIDE_LIBRARY(ob)) {
+    CTX_wm_operator_poll_msg_set(
+        C, "Cannot remove components coming from linked data in a library override");
+    return false;
+  }
+
+  return true;
+}
+
 /* ************* Add/Remove Sensor Operator ************* */
 
 static int sensor_remove_exec(bContext *C, wmOperator *op)
@@ -945,7 +963,7 @@ static void LOGIC_OT_python_component_remove(wmOperatorType *ot)
 
   /* api callbacks */
   ot->exec = component_remove_exec;
-  ot->poll = ED_operator_object_active_editable;
+  ot->poll = remove_component_poll;
 
   /* flags */
   ot->flag = OPTYPE_REGISTER | OPTYPE_UNDO;

--- a/source/blender/makesrna/intern/rna_python_component.c
+++ b/source/blender/makesrna/intern/rna_python_component.c
@@ -129,6 +129,8 @@ static void rna_def_py_component(BlenderRNA *brna)
   RNA_def_property_clear_flag(prop, PROP_EDITABLE);
   RNA_def_property_update(prop, NC_LOGIC, NULL);
 
+  RNA_define_lib_overridable(true);
+
   prop = RNA_def_property(srna, "show_expanded", PROP_BOOLEAN, PROP_NONE);
   RNA_def_property_boolean_sdna(prop, NULL, "flag", COMPONENT_SHOW);
   RNA_def_property_ui_text(prop, "Expanded", "Set sensor expanded in the user interface");
@@ -139,6 +141,8 @@ static void rna_def_py_component(BlenderRNA *brna)
   RNA_def_property_collection_sdna(prop, NULL, "properties", NULL);
   RNA_def_property_struct_type(prop, "PythonComponentProperty");
   RNA_def_property_ui_text(prop, "Properties", "Component properties");
+
+  RNA_define_lib_overridable(false);
 }
 
 static void rna_def_py_component_property(BlenderRNA *brna)
@@ -147,6 +151,8 @@ static void rna_def_py_component_property(BlenderRNA *brna)
   PropertyRNA *prop;
 
   static EnumPropertyItem empty_items[] = {{0, "EMPTY", 0, "Empty", ""}, {0, NULL, 0, NULL, NULL}};
+
+  RNA_define_lib_overridable(true);
 
   /* Base Python Component Property */
   srna = RNA_def_struct(brna, "PythonComponentProperty", NULL);
@@ -299,6 +305,8 @@ static void rna_def_py_component_property(BlenderRNA *brna)
 
   POINTER_TYPES
 #  undef PT_DEF
+
+  RNA_define_lib_overridable(false);
 }
 
 void RNA_def_py_component(BlenderRNA *brna)


### PR DESCRIPTION
This will allow overriding the properties of a `KX_PythonComponent` which is attached to an object linked as a library.

However, it doesn't make components themselves overridable, or other properties of `GameObjectSettings` like sensors or actuators for that matter. I tried to make it work but haven't been successful so far.

If anyone has an idea what could be missing to make it work, please let me know. Thanks!