### PR TITLE
UPBGE: Fix few issues related to .blend loading/restart during runtime

### DIFF
--- a/source/blender/blenkernel/intern/sca.c
+++ b/source/blender/blenkernel/intern/sca.c
@@ -1072,34 +1072,34 @@ void BKE_sca_controllers_id_loop(ListBase *contlist, SCAControllerIDFunc func, v
     switch (controller->type) {
       case CONT_PYTHON: {
         bPythonCont *pc = controller->data;
-        if (strlen(pc->module)) {
-          if (!pc->module_script) {
-            char modulename[FILE_MAX];
-            BLI_strncpy(modulename, pc->module, sizeof(modulename));
-            char ext[FILE_MAX];
-            strcpy(ext, ".py");
-            char dest[FILE_MAX];
-            strcpy(dest, "");
-            char *classname;
-            char *pos = strrchr(modulename, '.');
-            if (pos) {
-              *pos = '\0';
-              classname = pos + 1;
-            }
-            strcat(dest, modulename);
-            strcat(dest, ext);
-            if (G_MAIN) {
-              LISTBASE_FOREACH (Text *, text, &G_MAIN->texts) {
-                if (strcmp(text->id.name + 2, dest) == 0) {
-                  if (text->filepath == NULL) {  // Means the script is embedded
-                    pc->module_script = text;
-                  }
-                  break;
-                }
-              }
-            }
-          }
-        }
+        //if (strlen(pc->module)) {
+        //  if (!pc->module_script) {
+        //    char modulename[FILE_MAX];
+        //    BLI_strncpy(modulename, pc->module, sizeof(modulename));
+        //    char ext[FILE_MAX];
+        //    strcpy(ext, ".py");
+        //    char dest[FILE_MAX];
+        //    strcpy(dest, "");
+        //    char *classname;
+        //    char *pos = strrchr(modulename, '.');
+        //    if (pos) {
+        //      *pos = '\0';
+        //      classname = pos + 1;
+        //    }
+        //    strcat(dest, modulename);
+        //    strcat(dest, ext);
+        //    if (G_MAIN /* && G.file_loaded */) { // FIXME: Need to wait file has been completely read
+        //      LISTBASE_FOREACH (Text *, text, &G_MAIN->texts) {
+        //        if (strcmp(text->id.name + 2, dest) == 0) {
+        //          if (text->filepath == NULL) {  // Means the script is embedded
+        //            pc->module_script = text;
+        //          }
+        //          break;
+        //        }
+        //      }
+        //    }
+        //  }
+        //}
 
         func(controller, (ID **)&pc->module_script, userdata, IDWALK_CB_USER);
         func(controller, (ID **)&pc->text, userdata, IDWALK_CB_USER);

--- a/source/gameengine/BlenderRoutines/BL_KetsjiEmbedStart.cpp
+++ b/source/gameengine/BlenderRoutines/BL_KetsjiEmbedStart.cpp
@@ -43,6 +43,7 @@
 #include "BLI_blenlib.h"
 #include "BLO_readfile.h"
 #include "DNA_space_types.h"
+#include "DNA_windowmanager_types.h"
 #include "ED_screen.h"
 #include "WM_api.h"
 #include "wm_window.h"
@@ -260,6 +261,11 @@ extern "C" void StartKetsjiShell(struct bContext *C,
         win->ghostwin = ghostwin_backup;
         win->gpuctx = gpuctx_backup;
         wm->message_bus = (wmMsgBus *)msgbus_backup;
+
+        wm->defaultconf = wm_backup->defaultconf;
+        wm->addonconf = wm_backup->addonconf;
+        wm->userconf = wm_backup->userconf;
+        wm->initialized |= WM_KEYCONFIG_IS_INIT;
 
         wm_window_ghostwindow_embedded_ensure(wm, win);
 

--- a/source/gameengine/Ketsji/KX_PythonInit.cpp
+++ b/source/gameengine/Ketsji/KX_PythonInit.cpp
@@ -2291,7 +2291,7 @@ void exitGamePlayerPythonScripting()
 /**
  * Python is already initialized.
  */
-void initGamePythonScripting(Main *maggie, bool *audioDeviceIsInitialized)
+void initGamePythonScripting(Main *maggie, bContext *C, bool *audioDeviceIsInitialized)
 {
   /* Yet another gotcha in the py api
    * Cant run PySys_SetArgv more than once because this adds the
@@ -2467,6 +2467,8 @@ void initGamePythonScripting(Main *maggie, bool *audioDeviceIsInitialized)
 
   first_time = false;
 
+  BPY_python_reset(C);
+
   EXP_PyObjectPlus::ClearDeprecationWarning();
 }
 
@@ -2507,7 +2509,7 @@ void setupGamePython(KX_KetsjiEngine *ketsjiengine,
   if (argv) /* player only */
     postInitGamePlayerPythonScripting(blenderdata, argc, argv, C, audioDeviceIsInitialized);
   else
-    initGamePythonScripting(blenderdata, audioDeviceIsInitialized);
+    initGamePythonScripting(blenderdata, C, audioDeviceIsInitialized);
 
   modules = PyImport_GetModuleDict();
 

--- a/source/gameengine/Ketsji/KX_PythonInit.h
+++ b/source/gameengine/Ketsji/KX_PythonInit.h
@@ -52,7 +52,7 @@ void postInitGamePlayerPythonScripting(struct Main *maggie,
                                        char **argv,
                                        struct bContext *C,
                                        bool *audioDeviceIsInitialized);
-void initGamePythonScripting(struct Main *maggie, bool *audioDeviceIsInitialized);
+void initGamePythonScripting(struct Main *maggie, struct bContext *C, bool *audioDeviceIsInitialized);
 
 // Add a python include path.
 void appendPythonPath(const std::string &path);


### PR DESCRIPTION
- Use the host window manager's keyconfs so that the embedded one won't create new keymaps which will get overwritten over the global operators and freed after the game ends otherwise, which may lead to a crash.

- Use BPY_python_reset(C) when switching filres in embedded to ensure right bpy context

- Comment problematic code when loading new .blend (it was the piece of code added to append python controller modules scripts in the same time than an Object. This code is disabled, but could be enabled again if we find a way to avoid to call it just when we are reading/loading the new .blend EDIT: It was crashing in ledi.blend after restarting several times in visual studio 2019 on windows in embedded in debug build)

test files:

[restart-load.zip](https://github.com/UPBGE/upbge/files/6941101/restart-load.zip)
