### PR TITLE
Fix a crash due to negative refcount when replicating a Python proxy

### DIFF
--- a/source/gameengine/Ketsji/KX_PythonComponent.cpp
+++ b/source/gameengine/Ketsji/KX_PythonComponent.cpp
@@ -55,9 +55,8 @@ KX_PythonProxy *KX_PythonComponent::NewInstance()
 void KX_PythonComponent::ProcessReplica()
 {
   KX_PythonProxy::ProcessReplica();
-  m_gameobj = nullptr;
 
-  Reset();
+  m_gameobj = nullptr;
 }
 
 KX_GameObject *KX_PythonComponent::GetGameObject() const

--- a/source/gameengine/Ketsji/KX_PythonProxy.cpp
+++ b/source/gameengine/Ketsji/KX_PythonProxy.cpp
@@ -42,7 +42,6 @@ KX_PythonProxy::KX_PythonProxy():
 KX_PythonProxy::~KX_PythonProxy()
 {
   Dispose();
-  Reset();
 }
 
 std::string KX_PythonProxy::GetName()
@@ -128,7 +127,10 @@ void KX_PythonProxy::ProcessReplica()
   EXP_Value::ProcessReplica();
 
   m_init = false;
-  ReleasePyRefs();
+
+  m_update = nullptr;
+  m_dispose = nullptr;
+  m_logger = nullptr;
 }
 
 void KX_PythonProxy::Dispose()
@@ -137,17 +139,6 @@ void KX_PythonProxy::Dispose()
     LogError("Failed to invoke the dispose callback.");
   }
 
-  ReleasePyRefs();
-}
-
-void KX_PythonProxy::Reset()
-{
-  m_init = false;
-  ReleasePyRefs();
-}
-
-void KX_PythonProxy::ReleasePyRefs()
-{
   Py_XDECREF(m_update);
   Py_XDECREF(m_dispose);
   Py_XDECREF(m_logger);

--- a/source/gameengine/Ketsji/KX_PythonProxy.h
+++ b/source/gameengine/Ketsji/KX_PythonProxy.h
@@ -39,8 +39,6 @@ class KX_PythonProxy : public EXP_Value {
 
   PyObject *m_logger;
 
-  void ReleasePyRefs();
-
  public:
   KX_PythonProxy();
 


### PR DESCRIPTION
Fix a crash due to negative ref count upon replicating a Python proxy. Only reproducible with a debug build of Python.