### PR TITLE
UPBGE: Add extra settings for SMAA

### DIFF
--- a/release/scripts/startup/bl_ui/properties_render.py
+++ b/release/scripts/startup/bl_ui/properties_render.py
@@ -513,6 +513,10 @@ class RENDER_PT_eevee_sampling_smaa(RenderButtonsPanel, Panel):
         layout.active = props.use_eevee_smaa
         col = layout.column(align=True)
         col.prop(props, "smaa_quality", text="Quality")
+        row = layout.row()
+        row.prop(props, "smaa_predication_threshold", text="SMAA Threshold")
+        row = layout.row()
+        row.prop(props, "smaa_predication_scale", text="SMAA Scale")
 
 
 class RENDER_PT_eevee_indirect_lighting(RenderButtonsPanel, Panel):

--- a/source/blender/blenkernel/BKE_blender_version.h
+++ b/source/blender/blenkernel/BKE_blender_version.h
@@ -50,7 +50,7 @@ extern "C" {
 
 /* UPBGE file format version. */
 #define UPBGE_FILE_VERSION UPBGE_VERSION
-#define UPBGE_FILE_SUBVERSION 9
+#define UPBGE_FILE_SUBVERSION 10
 
 /* Minimum Blender version that supports reading file written with the current
  * version. Older Blender versions will test this and show a warning if the file

--- a/source/blender/blenloader/intern/versioning_upbge.c
+++ b/source/blender/blenloader/intern/versioning_upbge.c
@@ -375,4 +375,10 @@ void blo_do_versions_upbge(FileData *fd, Library *lib, Main *bmain)
       }
     }
   }
+  if (!MAIN_VERSION_UPBGE_ATLEAST(bmain, 30, 10)) {
+    LISTBASE_FOREACH (Scene *, scene, &bmain->scenes) {
+      scene->eevee.smaa_predication_threshold = 0.01f;
+      scene->eevee.smaa_predication_scale = 1.0f;
+    }
+  }
 }

--- a/source/blender/draw/engines/eevee/eevee_private.h
+++ b/source/blender/draw/engines/eevee/eevee_private.h
@@ -1576,7 +1576,11 @@ static const float cubefacemat[6][4][4] = {
 /* UPBGE */
 EEVEE_Data *EEVEE_engine_data_get(void);
 
-GPUShader *eevee_shader_antialiasing_get(int stage, int smaa_quality);
+GPUShader *eevee_shader_antialiasing_get(int stage,
+                                         int smaa_quality,
+                                         float smaa_predication_threshold,
+                                         float smaa_predication_scale,
+                                         bool recompile);
 int EEVEE_antialiasing_engine_init(EEVEE_Data *vedata);
 void EEVEE_antialiasing_cache_init(EEVEE_Data *vedata);
 void EEVEE_antialiasing_draw_pass(EEVEE_Data *vedata);

--- a/source/blender/makesdna/DNA_scene_defaults.h
+++ b/source/blender/makesdna/DNA_scene_defaults.h
@@ -242,8 +242,6 @@
     .sss_samples = 7, \
     .sss_jitter_threshold = 0.3f, \
  \
-    .smaa_quality = SCE_EEVEE_SMAA_PRESET_HIGH, \
- \
     .ssr_quality = 0.25f, \
     .ssr_max_roughness = 0.5f, \
     .ssr_thickness = 0.2f, \
@@ -291,6 +289,11 @@
     .flag = SCE_EEVEE_VOLUMETRIC_LIGHTS | SCE_EEVEE_GTAO_BENT_NORMALS | \
                     SCE_EEVEE_GTAO_BOUNCE | SCE_EEVEE_TAA_REPROJECTION | \
                     SCE_EEVEE_SSR_HALF_RESOLUTION | SCE_EEVEE_SHADOW_SOFT, \
+ \
+    .smaa_quality = SCE_EEVEE_SMAA_PRESET_HIGH, \
+    .smaa_predication_threshold = 0.01, \
+    .smaa_predication_scale = 1.0, \
+ \
   }
 
 #define _DNA_DEFAULT_Scene \

--- a/source/blender/makesdna/DNA_scene_types.h
+++ b/source/blender/makesdna/DNA_scene_types.h
@@ -1827,7 +1827,8 @@ typedef struct SceneEEVEE {
   float overscan;
   float light_threshold;
 
-  int smaa_quality, _pad[3];  // UPBGE
+  int smaa_quality;                                                // UPBGE
+  float smaa_predication_threshold, smaa_predication_scale, _pad;  // UPBGE
 
 } SceneEEVEE;
 

--- a/source/blender/makesrna/intern/rna_scene.c
+++ b/source/blender/makesrna/intern/rna_scene.c
@@ -7735,6 +7735,22 @@ static void rna_def_scene_eevee(BlenderRNA *brna)
                            "SMAA quality presets");
   RNA_def_property_override_flag(prop, PROPOVERRIDE_OVERRIDABLE_LIBRARY);
   RNA_def_property_update(prop, NC_SCENE | ND_RENDER_OPTIONS, NULL);
+
+  prop = RNA_def_property(srna, "smaa_predication_threshold", PROP_FLOAT, PROP_NONE);
+  RNA_def_property_ui_text(
+      prop, "SMAA Threshold", "SMAA Predication Threshold");
+  RNA_def_property_range(prop, 0.001f, 5.0f);
+  RNA_def_property_ui_range(prop, 0.001f, FLT_MAX, 5, 3);
+  RNA_def_property_override_flag(prop, PROPOVERRIDE_OVERRIDABLE_LIBRARY);
+  RNA_def_property_update(prop, NC_SCENE | ND_RENDER_OPTIONS, NULL);
+
+  prop = RNA_def_property(srna, "smaa_predication_scale", PROP_FLOAT, PROP_NONE);
+  RNA_def_property_ui_text(
+      prop, "SMAA Scale", "SMAA Predication Scale");
+  RNA_def_property_range(prop, 0.01f, 5.0f); // normally in range [1 - 5] but sometimes better with less than 1
+  RNA_def_property_ui_range(prop, 0.01f, 5.0, 5, 3);
+  RNA_def_property_override_flag(prop, PROPOVERRIDE_OVERRIDABLE_LIBRARY);
+  RNA_def_property_update(prop, NC_SCENE | ND_RENDER_OPTIONS, NULL);
   /* UPBGE */
 
   /* Screen Space Subsurface Scattering */


### PR DESCRIPTION
As noticed on discord, the default values for SMAA were not optimal.

As it is difficult to know which settings are the best for each situation, 2 new settings are added:

- SMAA predication threshold
- SMAA predication scale

Actually, it seems that the best results are when smaa predication scale is reduced. I don't really know how much it affects performances. The new default is 1.0 instead of 2.0. Normally, the doc says that this setting should be in range 1 - 5 , but i noticed better results with values less than 1.0, then I did not limit the min UI to 1.0.

On development side, a bug is fixed:

It seems SMAA quality was not updated correctly.

As the SMAA lib is using defines and not uniforms, the shader has to be recompiled when a value is changed.

To do that:

- We compare current setting value with previous value and if any value is changed, the shader is freed, then recompiled with new defines strings.
- A call to DRW_viewport_request_redraw is added to ensure the viewport is correctly updated.
