### PR TITLE
UPBGE: Recover Activity culling

### DIFF
--- a/doc/python_api/rst/bge_types/bge.types.KX_Camera.rst
+++ b/doc/python_api/rst/bge_types/bge.types.KX_Camera.rst
@@ -127,6 +127,12 @@ base class --- :class:`~bge.types.KX_GameObject`
 
       :type: boolean
 
+   .. attribute:: activityCulling
+
+      True if this camera is used to compute object distance for object activity culling.
+
+      :type: boolean
+
    .. method:: sphereInsideFrustum(centre, radius)
 
       Tests the given sphere against the view frustum.

--- a/doc/python_api/rst/bge_types/bge.types.KX_GameObject.rst
+++ b/doc/python_api/rst/bge_types/bge.types.KX_GameObject.rst
@@ -304,6 +304,32 @@ base class --- :class:`~bge.types.SCA_IObject`
 
       :type: :class:`mathutils.Vector`
 
+   .. attribute:: physicsCulling
+
+      True if the object suspends its physics depending on its nearest distance to any camera.
+
+      :type: boolean
+
+   .. attribute:: logicCulling
+
+      True if the object suspends its logic and animation depending on its nearest distance to any camera.
+
+      :type: boolean
+
+   .. attribute:: physicsCullingRadius
+
+      Suspend object's physics if this radius is smaller than its nearest distance to any camera
+      and :data:`physicsCulling` set to `True`.
+
+      :type: float
+
+   .. attribute:: logicCullingRadius
+
+      Suspend object's logic and animation if this radius is smaller than its nearest distance to any camera
+      and :data:`logicCulling` set to `True`.
+
+      :type: float
+
    .. attribute:: occlusion
 
       occlusion capability flag.

--- a/doc/python_api/rst/bge_types/bge.types.KX_Scene.rst
+++ b/doc/python_api/rst/bge_types/bge.types.KX_Scene.rst
@@ -122,17 +122,11 @@ base class --- :class:`~bge.types.EXP_PyObjectPlus`
 
       :type: boolean
 
-   .. attribute:: activity_culling
+   .. attribute:: activityCulling
 
-      True if the scene is activity culling.
+      True if the scene allow object activity culling.
 
       :type: boolean
-
-   .. attribute:: activity_culling_radius
-
-      The distance outside which to do activity culling. Measured in manhattan distance.
-
-      :type: float
 
    .. attribute:: dbvt_culling
 

--- a/release/scripts/startup/bl_ui/properties_data_camera.py
+++ b/release/scripts/startup/bl_ui/properties_data_camera.py
@@ -68,8 +68,8 @@ class DATA_PT_context_camera(CameraButtonsPanel, Panel):
             layout.template_ID(space, "pin_id")
 
 # Game engine transition
-class DATA_PT_game_overlay_mouse_control(CameraButtonsPanel, Panel):
-    bl_label = "Game Overlay Mouse Control"
+class DATA_PT_game_camera_settings(CameraButtonsPanel, Panel):
+    bl_label = "Game Camera Settings"
     COMPAT_ENGINES = {'BLENDER_RENDER', 'BLENDER_EEVEE', 'BLENDER_WORKBENCH'}
 
     def draw(self, context):
@@ -77,7 +77,13 @@ class DATA_PT_game_overlay_mouse_control(CameraButtonsPanel, Panel):
 
         cam = context.camera
 
-        layout.prop(cam, "use_overlay_mouse_control")
+        split = layout.split()
+        col = split.column()
+        col.label(text="Overlay Mouse Control:")
+        col.prop(cam, "use_overlay_mouse_control")
+        col = split.column()
+        col.label(text="Object Activity:")
+        col.prop(cam, "use_object_activity_culling")
 
 
 class DATA_PT_lens(CameraButtonsPanel, Panel):
@@ -541,7 +547,7 @@ classes = (
     CAMERA_PT_presets,
     SAFE_AREAS_PT_presets,
     DATA_PT_context_camera,
-    DATA_PT_game_overlay_mouse_control, # Game engine transition
+    DATA_PT_game_camera_settings, # UPBGE
     DATA_PT_lens,
     DATA_PT_camera_dof,
     DATA_PT_camera_dof_aperture,

--- a/release/scripts/startup/bl_ui/properties_data_camera.py
+++ b/release/scripts/startup/bl_ui/properties_data_camera.py
@@ -77,12 +77,9 @@ class DATA_PT_game_camera_settings(CameraButtonsPanel, Panel):
 
         cam = context.camera
 
-        split = layout.split()
-        col = split.column()
-        col.label(text="Overlay Mouse Control:")
+        col = layout.column()
         col.prop(cam, "use_overlay_mouse_control")
-        col = split.column()
-        col.label(text="Object Activity:")
+        col = layout.column()
         col.prop(cam, "use_object_activity_culling")
 
 

--- a/release/scripts/startup/bl_ui/properties_game.py
+++ b/release/scripts/startup/bl_ui/properties_game.py
@@ -569,6 +569,10 @@ class SCENE_PT_game_physics(SceneButtonsPanel, Panel):
             sub = col.row()
             sub.prop(gs, "deactivation_time", text="Time")
 
+            col = split.column()
+            col.label(text="Object Activity:")
+            col.prop(gs, "use_activity_culling")
+
             col = layout.column()
             col.label(text="Physics Joint Error Reduction:")
             sub = col.column(align=True)
@@ -728,6 +732,32 @@ class ObjectButtonsPanel:
     bl_region_type = 'WINDOW'
     bl_context = "object"
 
+class OBJECT_PT_activity_culling(ObjectButtonsPanel, Panel):
+    bl_label = "Activity Culling"
+    COMPAT_ENGINES = {'BLENDER_GAME'}
+
+    @classmethod
+    def poll(cls, context):
+        ob = context.object
+        return context.scene.render.engine in cls.COMPAT_ENGINES and ob.type not in {'CAMERA'}
+
+    def draw(self, context):
+        layout = self.layout
+        activity = context.object.game.activity_culling
+
+        split = layout.split()
+
+        col = split.column()
+        col.prop(activity, "use_physics", text="Physics")
+        sub = col.column()
+        sub.active = activity.use_physics
+        sub.prop(activity, "physics_radius")
+
+        col = split.column()
+        col.prop(activity, "use_logic", text="Logic")
+        sub = col.column()
+        sub.active = activity.use_logic
+        sub.prop(activity, "logic_radius")
 
 class OBJECT_MT_lod_tools(Menu):
     bl_label = "Level Of Detail Tools"
@@ -801,6 +831,7 @@ classes = (
     SCENE_PT_game_hysteresis,
     SCENE_PT_game_console,
     OBJECT_MT_lod_tools,
+    OBJECT_PT_activity_culling,
     OBJECT_PT_levels_of_detail,
 )
 

--- a/release/scripts/startup/bl_ui/properties_game.py
+++ b/release/scripts/startup/bl_ui/properties_game.py
@@ -569,16 +569,16 @@ class SCENE_PT_game_physics(SceneButtonsPanel, Panel):
             sub = col.row()
             sub.prop(gs, "deactivation_time", text="Time")
 
-            col = split.column()
-            col.label(text="Object Activity:")
-            col.prop(gs, "use_activity_culling")
-
             col = layout.column()
             col.label(text="Physics Joint Error Reduction:")
             sub = col.column(align=True)
             sub.prop(gs, "erp_parameter", text="ERP for Non Contact Constraints")
             sub.prop(gs, "erp2_parameter", text="ERP for Contact Constraints")
             sub.prop(gs, "cfm_parameter", text="CFM for Soft Constraints")
+
+            row = layout.row()
+            row.label(text="Object Activity:")
+            row.prop(gs, "use_activity_culling")
 
         else:
             split = layout.split()

--- a/release/scripts/startup/bl_ui/properties_game.py
+++ b/release/scripts/startup/bl_ui/properties_game.py
@@ -734,7 +734,7 @@ class ObjectButtonsPanel:
 
 class OBJECT_PT_activity_culling(ObjectButtonsPanel, Panel):
     bl_label = "Activity Culling"
-    COMPAT_ENGINES = {'BLENDER_GAME'}
+    COMPAT_ENGINES = {'BLENDER_EEVEE', 'BLENDER_WORKBENCH'}
 
     @classmethod
     def poll(cls, context):

--- a/source/blender/blenkernel/BKE_blender_version.h
+++ b/source/blender/blenkernel/BKE_blender_version.h
@@ -50,7 +50,7 @@ extern "C" {
 
 /* UPBGE file format version. */
 #define UPBGE_FILE_VERSION UPBGE_VERSION
-#define UPBGE_FILE_SUBVERSION 10
+#define UPBGE_FILE_SUBVERSION 11
 
 /* Minimum Blender version that supports reading file written with the current
  * version. Older Blender versions will test this and show a warning if the file

--- a/source/blender/blenloader/intern/versioning_280.c
+++ b/source/blender/blenloader/intern/versioning_280.c
@@ -3462,7 +3462,7 @@ void blo_do_versions_280(FileData *fd, Library *UNUSED(lib), Main *bmain)
     }
 
     for (World *world = bmain->worlds.first; world; world = world->id.next) {
-      world->flag &= ~(WO_MODE_UNUSED_1 | WO_MODE_UNUSED_2 | WO_MODE_UNUSED_3 | WO_MODE_UNUSED_4 |
+      world->flag &= ~(WO_MODE_UNUSED_1 | WO_MODE_UNUSED_2 | WO_MODE_UNUSED_4 |
                        WO_MODE_UNUSED_5 | WO_MODE_UNUSED_7);
     }
 

--- a/source/blender/blenloader/intern/versioning_defaults.c
+++ b/source/blender/blenloader/intern/versioning_defaults.c
@@ -48,6 +48,7 @@
 #include "DNA_userdef_types.h"
 #include "DNA_windowmanager_types.h"
 #include "DNA_workspace_types.h"
+#include "DNA_world_types.h" // UPBGE
 
 #include "BKE_appdir.h"
 #include "BKE_brush.h"
@@ -384,6 +385,7 @@ void BLO_update_defaults_startup_blend(Main *bmain, const char *app_template)
     sce->gm.depth = 32;
     sce->gm.gravity = 9.8f;
     sce->gm.physicsEngine = WOPHY_BULLET;
+    sce->gm.mode = WO_ACTIVITY_CULLING;
     sce->gm.occlusionRes = 128;
     sce->gm.ticrate = 60;
     sce->gm.maxlogicstep = 5;

--- a/source/blender/blenloader/intern/versioning_defaults.c
+++ b/source/blender/blenloader/intern/versioning_defaults.c
@@ -443,6 +443,10 @@ void BLO_update_defaults_startup_blend(Main *bmain, const char *app_template)
     ob->max_slope = M_PI_2;
     ob->col_group = 0x01;
     ob->col_mask = 0xffff;
+    if (ob->type == OB_CAMERA) {
+      Camera *cam = ob->data;
+      cam->gameflag |= GAME_CAM_OBJECT_ACTIVITY_CULLING;
+    }
   }
   /***********************End of UPBGE**********************/
 

--- a/source/blender/blenloader/intern/versioning_upbge.c
+++ b/source/blender/blenloader/intern/versioning_upbge.c
@@ -381,4 +381,11 @@ void blo_do_versions_upbge(FileData *fd, Library *lib, Main *bmain)
       scene->eevee.smaa_predication_scale = 1.0f;
     }
   }
+  if (!MAIN_VERSION_UPBGE_ATLEAST(bmain, 30, 11)) {
+    LISTBASE_FOREACH (Camera *, cam, &bmain->cameras) {
+      if (cam->flag & (1 << 11)) { // Game overlay mouse control moved from flag to gameflag
+        cam->gameflag |= GAME_CAM_OVERLAY_MOUSE_CONTROL;
+      }
+    }
+  }
 }

--- a/source/blender/makesdna/DNA_camera_defaults.h
+++ b/source/blender/makesdna/DNA_camera_defaults.h
@@ -54,6 +54,7 @@
     .flag = CAM_SHOWPASSEPARTOUT, \
     .passepartalpha = 0.5f, \
     .lodfactor = 1.0f, \
+    .gameflag = GAME_CAM_OBJECT_ACTIVITY_CULLING, \
  \
     .dof = _DNA_DEFAULT_CameraDOFSettings, \
  \

--- a/source/blender/makesdna/DNA_camera_types.h
+++ b/source/blender/makesdna/DNA_camera_types.h
@@ -103,7 +103,8 @@ typedef struct Camera {
   float lens, ortho_scale, drawsize;
   float sensor_x, sensor_y;
   float shiftx, shifty;
-  float lodfactor, _pad1[1]; /* UPBGE Transition */
+  float lodfactor; /* UPBGE */
+  int gameflag;    /* UPBGE */
   float dof_distance DNA_DEPRECATED;
 
   /** Old animation system, deprecated for 2.5. */
@@ -162,7 +163,12 @@ enum {
   CAM_SHOWSENSOR = (1 << 8),
   CAM_SHOW_SAFE_CENTER = (1 << 9),
   CAM_SHOW_BG_IMAGE = (1 << 10),
-  CAM_GAME_OVERLAY_MOUSE_CONTROL = (1 << 11),  // UPBGE
+};
+
+/* gameflag */
+enum {
+  GAME_CAM_OVERLAY_MOUSE_CONTROL = (1 << 1),
+  GAME_CAM_OBJECT_ACTIVITY_CULLING = (1 << 2),
 };
 
 /* Sensor fit */

--- a/source/blender/makesdna/DNA_camera_types.h
+++ b/source/blender/makesdna/DNA_camera_types.h
@@ -163,6 +163,7 @@ enum {
   CAM_SHOWSENSOR = (1 << 8),
   CAM_SHOW_SAFE_CENTER = (1 << 9),
   CAM_SHOW_BG_IMAGE = (1 << 10),
+  //(1 << 11) was CAM_GAME_OVERLAY_MOUSE_CONTROL
 };
 
 /* gameflag */

--- a/source/blender/makesdna/DNA_object_types.h
+++ b/source/blender/makesdna/DNA_object_types.h
@@ -121,6 +121,21 @@ typedef struct LodLevel {
   int obhysteresis;
 } LodLevel;
 
+typedef struct ObjectActivityCulling {
+  /* For game engine, values around active camera where physics or logic are suspended */
+  float physicsRadius;
+  float logicRadius;
+
+  int flags;
+  int _pad;
+} ObjectActivityCulling;
+
+/* object activity flags */
+enum {
+  OB_ACTIVITY_PHYSICS = (1 << 0),
+  OB_ACTIVITY_LOGIC = (1 << 1),
+};
+
 struct CustomData_MeshMasks;
 
 /* Not saved in file! */
@@ -504,6 +519,8 @@ typedef struct Object {
   ListBase controllers; /* game logic controllers */
   ListBase actuators;   /* game logic actuators */
   ListBase components;  /* python components */
+
+  struct ObjectActivityCulling activityCulling;
 
   float sf; /* sf is time-offset */
 

--- a/source/blender/makesdna/DNA_scene_defaults.h
+++ b/source/blender/makesdna/DNA_scene_defaults.h
@@ -204,6 +204,7 @@
     .depth = 32, \
     .gravity = 9.8f, \
     .physicsEngine = WOPHY_BULLET, \
+    .mode = WO_ACTIVITY_CULLING, \
     .occlusionRes = 128, \
     .ticrate = 60, \
     .maxlogicstep = 5, \

--- a/source/blender/makesdna/DNA_scene_types.h
+++ b/source/blender/makesdna/DNA_scene_types.h
@@ -872,7 +872,7 @@ typedef struct GameData {
   /*
    * Radius of the activity bubble, in Manhattan length. Objects
    * outside the box are activity-culled. */
-  float activityBoxRadius;
+  float _pad11;
 
   /*
    * bit 3: (gameengine): Activity culling is enabled.

--- a/source/blender/makesdna/DNA_world_types.h
+++ b/source/blender/makesdna/DNA_world_types.h
@@ -96,7 +96,7 @@ typedef struct World {
 #define WO_MIST (1 << 0)
 #define WO_MODE_UNUSED_1 (1 << 1) /* cleared */
 #define WO_MODE_UNUSED_2 (1 << 2) /* cleared */
-#define WO_MODE_UNUSED_3 (1 << 3) /* cleared */
+#define WO_ACTIVITY_CULLING (1 << 3)
 #define WO_MODE_UNUSED_4 (1 << 4) /* cleared */
 #define WO_MODE_UNUSED_5 (1 << 5) /* cleared */
 #define WO_AMB_OCC (1 << 6)

--- a/source/blender/makesrna/intern/rna_camera.c
+++ b/source/blender/makesrna/intern/rna_camera.c
@@ -628,6 +628,11 @@ void RNA_def_camera(BlenderRNA *brna)
   RNA_def_property_update(prop, NC_OBJECT | ND_DRAW, "rna_Camera_update");
 
   /* UPBGE */
+  prop = RNA_def_property(srna, "use_object_activity_culling", PROP_BOOLEAN, PROP_NONE);
+  RNA_def_property_boolean_sdna(prop, NULL, "gameflag", GAME_CAM_OBJECT_ACTIVITY_CULLING);
+  RNA_def_property_ui_text(
+      prop, "Activity Culling", "Enable object activity culling with this camera");
+
   prop = RNA_def_property(srna, "lod_factor", PROP_FLOAT, PROP_NONE);
   RNA_def_property_float_sdna(prop, NULL, "lodfactor");
   RNA_def_property_range(prop, 0.0f, FLT_MAX);
@@ -694,7 +699,7 @@ void RNA_def_camera(BlenderRNA *brna)
 
   /* UPBGE */
   prop = RNA_def_property(srna, "use_overlay_mouse_control", PROP_BOOLEAN, PROP_NONE);
-  RNA_def_property_boolean_sdna(prop, NULL, "flag", CAM_GAME_OVERLAY_MOUSE_CONTROL);
+  RNA_def_property_boolean_sdna(prop, NULL, "gameflag", GAME_CAM_OVERLAY_MOUSE_CONTROL);
   RNA_def_property_ui_text(prop,
                            "Game Overlay Mouse Control",
                            "If enabled and if the cam is an overlay cam,"

--- a/source/blender/makesrna/intern/rna_object.c
+++ b/source/blender/makesrna/intern/rna_object.c
@@ -2848,6 +2848,41 @@ static void rna_def_material_slot(BlenderRNA *brna)
   RNA_def_struct_path_func(srna, "rna_MaterialSlot_path");
 }
 
+static void rna_def_game_object_activity_culling(BlenderRNA *brna)
+{
+  StructRNA *srna;
+  PropertyRNA *prop;
+
+  srna = RNA_def_struct(brna, "ObjectActivityCulling", NULL);
+  RNA_def_struct_sdna(srna, "ObjectActivityCulling");
+  RNA_def_struct_nested(brna, srna, "Object");
+  RNA_def_struct_ui_text(srna, "Object Activity Culling", "Object activity culling info");
+
+  prop = RNA_def_property(srna, "physics_radius", PROP_FLOAT, PROP_DISTANCE);
+  RNA_def_property_float_sdna(prop, NULL, "physicsRadius");
+  RNA_def_property_range(prop, 0.0, FLT_MAX);
+  RNA_def_property_ui_text(
+      prop, "Physics Radius", "Distance to begin suspend physics of this object");
+
+  prop = RNA_def_property(srna, "logic_radius", PROP_FLOAT, PROP_DISTANCE);
+  RNA_def_property_float_sdna(prop, NULL, "logicRadius");
+  RNA_def_property_range(prop, 0.0, FLT_MAX);
+  RNA_def_property_ui_text(
+      prop, "Logic Radius", "Distance to begin suspend logic and animation of this object");
+
+  prop = RNA_def_property(srna, "use_physics", PROP_BOOLEAN, PROP_NONE);
+  RNA_def_property_boolean_sdna(prop, NULL, "flags", OB_ACTIVITY_PHYSICS);
+  RNA_def_property_ui_text(
+      prop, "Cull Physics", "Suspend physics of this object by its distance to nearest camera");
+
+  prop = RNA_def_property(srna, "use_logic", PROP_BOOLEAN, PROP_NONE);
+  RNA_def_property_boolean_sdna(prop, NULL, "flags", OB_ACTIVITY_LOGIC);
+  RNA_def_property_ui_text(
+      prop,
+      "Cull Logic",
+      "Suspend logic and animation of this object by its distance to nearest camera");
+}
+
 static void rna_def_object_game_settings(BlenderRNA *brna)
 {
   StructRNA *srna;
@@ -3258,6 +3293,15 @@ static void rna_def_object_game_settings(BlenderRNA *brna)
   RNA_def_property_boolean_sdna(prop, NULL, "scaflag", OB_SHOWSTATE);
   RNA_def_property_ui_text(prop, "States", "Show state panel");
   RNA_def_property_ui_icon(prop, ICON_DISCLOSURE_TRI_RIGHT, 1);
+
+  /* activity culling */
+  prop = RNA_def_property(srna, "activity_culling", PROP_POINTER, PROP_NONE);
+  RNA_def_property_flag(prop, PROP_NEVER_NULL);
+  RNA_def_property_pointer_sdna(prop, NULL, "activityCulling");
+  RNA_def_property_struct_type(prop, "ObjectActivityCulling");
+  RNA_def_property_ui_text(prop, "Object Activity Culling", "");
+
+  rna_def_game_object_activity_culling(brna);
 
   /* rigid body ccd settings */
   prop = RNA_def_property(srna, "use_ccd_rigid_body", PROP_BOOLEAN, PROP_NONE);

--- a/source/blender/makesrna/intern/rna_scene.c
+++ b/source/blender/makesrna/intern/rna_scene.c
@@ -5694,15 +5694,6 @@ static void rna_def_scene_game_data(BlenderRNA *brna)
       "increases");
   RNA_def_property_update(prop, NC_SCENE, NULL);
 
-  /* not used  */ /* deprecated !!!!!!!!!!!!! */
-  prop = RNA_def_property(srna, "activity_culling_box_radius", PROP_FLOAT, PROP_NONE);
-  RNA_def_property_float_sdna(prop, NULL, "activityBoxRadius");
-  RNA_def_property_range(prop, 0.0, 1000.0);
-  RNA_def_property_ui_text(prop,
-                           "Box Radius",
-                           "Radius of the activity bubble, in Manhattan length "
-                           "(objects outside the box are activity-culled)");
-
   /* booleans */
   prop = RNA_def_property(srna, "use_viewport_render", PROP_BOOLEAN, PROP_NONE);
   RNA_def_property_boolean_sdna(prop, NULL, "flag", GAME_USE_VIEWPORT_RENDER);
@@ -5712,6 +5703,11 @@ static void rna_def_scene_game_data(BlenderRNA *brna)
   prop = RNA_def_property(srna, "use_undo", PROP_BOOLEAN, PROP_NONE);
   RNA_def_property_boolean_sdna(prop, NULL, "flag", GAME_USE_UNDO);
   RNA_def_property_ui_text(prop, "Undo at Exit", "Undo bpy changes at game engine exit");
+
+  prop = RNA_def_property(srna, "use_activity_culling", PROP_BOOLEAN, PROP_NONE);
+  RNA_def_property_boolean_sdna(prop, NULL, "mode", WO_ACTIVITY_CULLING);
+  RNA_def_property_ui_text(
+      prop, "Activity Culling", "Enable object activity culling in this scene");
 
   prop = RNA_def_property(srna, "show_debug_properties", PROP_BOOLEAN, PROP_NONE);
   RNA_def_property_boolean_sdna(prop, NULL, "flag", GAME_SHOW_DEBUG_PROPS);

--- a/source/gameengine/GameLogic/SCA_IObject.cpp
+++ b/source/gameengine/GameLogic/SCA_IObject.cpp
@@ -249,6 +249,8 @@ void SCA_IObject::SuspendSensors()
       sensor->Suspend();
     }
     m_backupState = GetState();
+    /* Suspend sensors is not enough to stop logic activity
+     * then we change logic state to a state which is probably not used */
     SetState((1 << 30));
   }
 }

--- a/source/gameengine/GameLogic/SCA_IObject.cpp
+++ b/source/gameengine/GameLogic/SCA_IObject.cpp
@@ -41,6 +41,7 @@ SCA_IObject::SCA_IObject():
     m_suspended(false),
     m_initState(0),
     m_state(0),
+    m_backupState(0),
     m_firstState(nullptr)
 {
 }
@@ -247,6 +248,8 @@ void SCA_IObject::SuspendSensors()
     for (SCA_ISensor *sensor : m_sensors) {
       sensor->Suspend();
     }
+    m_backupState = GetState();
+    SetState((1 << 30));
   }
 }
 
@@ -258,6 +261,7 @@ void SCA_IObject::ResumeSensors(void)
     for (SCA_ISensor *sensor : m_sensors) {
       sensor->Resume();
     }
+    SetState(m_backupState);
   }
 }
 

--- a/source/gameengine/GameLogic/SCA_IObject.h
+++ b/source/gameengine/GameLogic/SCA_IObject.h
@@ -92,6 +92,8 @@ class SCA_IObject : public KX_PythonProxy {
   /// Current state = bit mask of state that are active.
   unsigned int m_state;
 
+  unsigned int m_backupState;
+
   /// Pointer inside state actuator list for sorting.
   SG_QList *m_firstState;
 

--- a/source/gameengine/GameLogic/SCA_IObject.h
+++ b/source/gameengine/GameLogic/SCA_IObject.h
@@ -92,6 +92,7 @@ class SCA_IObject : public KX_PythonProxy {
   /// Current state = bit mask of state that are active.
   unsigned int m_state;
 
+  /// State used to suspend/restore logic
   unsigned int m_backupState;
 
   /// Pointer inside state actuator list for sorting.

--- a/source/gameengine/GameLogic/SCA_MouseFocusSensor.cpp
+++ b/source/gameengine/GameLogic/SCA_MouseFocusSensor.cpp
@@ -105,7 +105,7 @@ bool SCA_MouseFocusSensor::Evaluate()
   if (overlayCam) {
     Object *obcam = overlayCam->GetBlenderObject();
     Camera *blCam = (Camera *)obcam->data;
-    if (blCam->flag & CAM_GAME_OVERLAY_MOUSE_CONTROL) {
+    if (blCam->flag & GAME_CAM_OVERLAY_MOUSE_CONTROL) {
       m_kxscene->SetActiveCamera(m_kxscene->GetOverlayCamera());
       restorePreviousCam = true;
     }

--- a/source/gameengine/Ketsji/BL_ActionManager.cpp
+++ b/source/gameengine/Ketsji/BL_ActionManager.cpp
@@ -31,7 +31,8 @@
 
 #define IS_TAGGED(_id) ((_id) && (((ID *)_id)->tag & LIB_TAG_DOIT))
 
-BL_ActionManager::BL_ActionManager(class KX_GameObject *obj) : m_obj(obj)
+BL_ActionManager::BL_ActionManager(class KX_GameObject *obj) :
+    m_obj(obj), m_suspended(false)
 {
 }
 
@@ -150,6 +151,21 @@ bool BL_ActionManager::IsActionDone(short layer)
   BL_Action *action = GetAction(layer);
 
   return action ? action->IsDone() : true;
+}
+
+void BL_ActionManager::Suspend()
+{
+  m_suspended = true;
+}
+
+void BL_ActionManager::Resume()
+{
+  m_suspended = false;
+}
+
+bool BL_ActionManager::IsSuspended() const
+{
+  return m_suspended;
 }
 
 void BL_ActionManager::Update(float curtime, bool applyToObject)

--- a/source/gameengine/Ketsji/BL_ActionManager.h
+++ b/source/gameengine/Ketsji/BL_ActionManager.h
@@ -46,6 +46,9 @@ class BL_ActionManager {
   class KX_GameObject *m_obj;
   BL_ActionMap m_layers;
 
+  // Suspend action update?
+  bool m_suspended;
+
   /**
    * Check if an action exists
    */
@@ -105,6 +108,10 @@ class BL_ActionManager {
    * Check if an action has finished playing
    */
   bool IsActionDone(short layer);
+
+  void Suspend();
+  void Resume();
+  bool IsSuspended() const;
 
   /**
    * Update any running actions

--- a/source/gameengine/Ketsji/KX_Camera.cpp
+++ b/source/gameengine/Ketsji/KX_Camera.cpp
@@ -47,6 +47,7 @@ KX_Camera::KX_Camera() : KX_GameObject(),
       m_normalized(false),
       m_set_projection_matrix(false),
       m_delete_node(false),
+      m_activityCulling(false),
       m_lodDistanceFactor(1.0f),
       m_showDebugCameraFrustum(false)
 {
@@ -85,6 +86,7 @@ void KX_Camera::SetBlenderObject(Object *obj)
 
   SetName(ca->id.name + 2);
   SetLodDistanceFactor(ca->lodfactor);
+  SetActivityCulling(ca->gameflag & GAME_CAM_OBJECT_ACTIVITY_CULLING);
 
   SetCameraData(camdata);
 }
@@ -268,6 +270,16 @@ float KX_Camera::GetLodDistanceFactor() const
 void KX_Camera::SetLodDistanceFactor(float lodfactor)
 {
   m_lodDistanceFactor = lodfactor;
+}
+
+bool KX_Camera::GetActivityCulling() const
+{
+  return m_activityCulling;
+}
+
+void KX_Camera::SetActivityCulling(bool enable)
+{
+  m_activityCulling = enable;
 }
 
 void KX_Camera::ExtractFrustum()

--- a/source/gameengine/Ketsji/KX_Camera.cpp
+++ b/source/gameengine/Ketsji/KX_Camera.cpp
@@ -384,6 +384,8 @@ PyAttributeDef KX_Camera::Attributes[] = {
     EXP_PYATTRIBUTE_RO_FUNCTION("camera_to_world", KX_Camera, pyattr_get_camera_to_world),
     EXP_PYATTRIBUTE_RO_FUNCTION("world_to_camera", KX_Camera, pyattr_get_world_to_camera),
 
+    EXP_PYATTRIBUTE_BOOL_RW("activityCulling", KX_Camera, m_activityCulling),
+
     /* Grrr, functions for constants? */
     EXP_PYATTRIBUTE_RO_FUNCTION("INSIDE", KX_Camera, pyattr_get_INSIDE),
     EXP_PYATTRIBUTE_RO_FUNCTION("OUTSIDE", KX_Camera, pyattr_get_OUTSIDE),

--- a/source/gameengine/Ketsji/KX_Camera.h
+++ b/source/gameengine/Ketsji/KX_Camera.h
@@ -107,6 +107,9 @@ class KX_Camera : public KX_GameObject {
    */
   bool m_delete_node;
 
+  /** Enable object activity culling for this camera. */
+  bool m_activityCulling;
+
   /** Distance factor for level of detail*/
   float m_lodDistanceFactor;
 
@@ -191,6 +194,9 @@ class KX_Camera : public KX_GameObject {
   float GetLodDistanceFactor() const;
   /** Set level of detail distance factor */
   void SetLodDistanceFactor(float lodfactor);
+
+  bool GetActivityCulling() const;
+  void SetActivityCulling(bool enable);
 
   const SG_Frustum &GetFrustum();
 

--- a/source/gameengine/Ketsji/KX_GameObject.cpp
+++ b/source/gameengine/Ketsji/KX_GameObject.cpp
@@ -2227,6 +2227,20 @@ PyAttributeDef KX_GameObject::Attributes[] = {
     EXP_PYATTRIBUTE_RW_FUNCTION("layer", KX_GameObject, pyattr_get_layer, pyattr_set_layer),
     EXP_PYATTRIBUTE_RW_FUNCTION("visible", KX_GameObject, pyattr_get_visible, pyattr_set_visible),
     EXP_PYATTRIBUTE_BOOL_RW("occlusion", KX_GameObject, m_bOccluder),
+
+    EXP_PYATTRIBUTE_RW_FUNCTION("physicsCullingRadius",
+                                KX_GameObject,
+                                pyattr_get_physicsCullingRadius,
+                                pyattr_set_physicsCullingRadius),
+    EXP_PYATTRIBUTE_RW_FUNCTION("logicCullingRadius",
+                                KX_GameObject,
+                                pyattr_get_logicCullingRadius,
+                                pyattr_set_logicCullingRadius),
+    EXP_PYATTRIBUTE_RW_FUNCTION(
+        "physicsCulling", KX_GameObject, pyattr_get_physicsCulling, pyattr_set_physicsCulling),
+    EXP_PYATTRIBUTE_RW_FUNCTION(
+        "logicCulling", KX_GameObject, pyattr_get_logicCulling, pyattr_set_logicCulling),
+
     EXP_PYATTRIBUTE_RW_FUNCTION(
         "position", KX_GameObject, pyattr_get_worldPosition, pyattr_set_localPosition),
     EXP_PYATTRIBUTE_RO_FUNCTION("localInertia", KX_GameObject, pyattr_get_localInertia),
@@ -3123,6 +3137,104 @@ int KX_GameObject::pyattr_set_visible(EXP_PyObjectPlus *self_v,
   }
 
   self->SetVisible(param, false);
+  return PY_SET_ATTR_SUCCESS;
+}
+
+PyObject *KX_GameObject::pyattr_get_physicsCulling(EXP_PyObjectPlus *self_v,
+                                                   const EXP_PYATTRIBUTE_DEF *attrdef)
+{
+  KX_GameObject *self = static_cast<KX_GameObject *>(self_v);
+  return PyBool_FromLong(self->GetActivityCullingInfo().m_flags &
+                         ActivityCullingInfo::ACTIVITY_PHYSICS);
+}
+
+int KX_GameObject::pyattr_set_physicsCulling(EXP_PyObjectPlus *self_v,
+                                             const EXP_PYATTRIBUTE_DEF *attrdef,
+                                             PyObject *value)
+{
+  KX_GameObject *self = static_cast<KX_GameObject *>(self_v);
+  int param = PyObject_IsTrue(value);
+  if (param == -1) {
+    PyErr_SetString(PyExc_AttributeError,
+                    "gameOb.physicsCulling = bool: KX_GameObject, expected True or False");
+    return PY_SET_ATTR_FAIL;
+  }
+
+  self->SetActivityCulling(ActivityCullingInfo::ACTIVITY_PHYSICS, param);
+  return PY_SET_ATTR_SUCCESS;
+}
+
+PyObject *KX_GameObject::pyattr_get_logicCulling(EXP_PyObjectPlus *self_v,
+                                                 const EXP_PYATTRIBUTE_DEF *attrdef)
+{
+  KX_GameObject *self = static_cast<KX_GameObject *>(self_v);
+  return PyBool_FromLong(self->GetActivityCullingInfo().m_flags &
+                         ActivityCullingInfo::ACTIVITY_LOGIC);
+}
+
+int KX_GameObject::pyattr_set_logicCulling(EXP_PyObjectPlus *self_v,
+                                           const EXP_PYATTRIBUTE_DEF *attrdef,
+                                           PyObject *value)
+{
+  KX_GameObject *self = static_cast<KX_GameObject *>(self_v);
+  int param = PyObject_IsTrue(value);
+  if (param == -1) {
+    PyErr_SetString(PyExc_AttributeError,
+                    "gameOb.logicCulling = bool: KX_GameObject, expected True or False");
+    return PY_SET_ATTR_FAIL;
+  }
+
+  self->SetActivityCulling(ActivityCullingInfo::ACTIVITY_LOGIC, param);
+  return PY_SET_ATTR_SUCCESS;
+}
+
+PyObject *KX_GameObject::pyattr_get_physicsCullingRadius(EXP_PyObjectPlus *self_v,
+                                                         const EXP_PYATTRIBUTE_DEF *attrdef)
+{
+  KX_GameObject *self = static_cast<KX_GameObject *>(self_v);
+  return PyFloat_FromDouble(std::sqrt(self->GetActivityCullingInfo().m_physicsRadius));
+}
+
+int KX_GameObject::pyattr_set_physicsCullingRadius(EXP_PyObjectPlus *self_v,
+                                                   const EXP_PYATTRIBUTE_DEF *attrdef,
+                                                   PyObject *value)
+{
+  KX_GameObject *self = static_cast<KX_GameObject *>(self_v);
+  const float val = PyFloat_AsDouble(value);
+  if (val < 0.0f) {  // Also accounts for non float.
+    PyErr_SetString(
+        PyExc_AttributeError,
+        "gameOb.physicsCullingRadius = float: KX_GameObject, expected a float zero or above");
+    return PY_SET_ATTR_FAIL;
+  }
+
+  self->GetActivityCullingInfo().m_physicsRadius = val * val;
+
+  return PY_SET_ATTR_SUCCESS;
+}
+
+PyObject *KX_GameObject::pyattr_get_logicCullingRadius(EXP_PyObjectPlus *self_v,
+                                                       const EXP_PYATTRIBUTE_DEF *attrdef)
+{
+  KX_GameObject *self = static_cast<KX_GameObject *>(self_v);
+  return PyFloat_FromDouble(std::sqrt(self->GetActivityCullingInfo().m_logicRadius));
+}
+
+int KX_GameObject::pyattr_set_logicCullingRadius(EXP_PyObjectPlus *self_v,
+                                                 const EXP_PYATTRIBUTE_DEF *attrdef,
+                                                 PyObject *value)
+{
+  KX_GameObject *self = static_cast<KX_GameObject *>(self_v);
+  const float val = PyFloat_AsDouble(value);
+  if (val < 0.0f) {  // Also accounts for non float.
+    PyErr_SetString(
+        PyExc_AttributeError,
+        "gameOb.logicCullingRadius = float: KX_GameObject, expected a float zero or above");
+    return PY_SET_ATTR_FAIL;
+  }
+
+  self->GetActivityCullingInfo().m_logicRadius = val * val;
+
   return PY_SET_ATTR_SUCCESS;
 }
 

--- a/source/gameengine/Ketsji/KX_GameObject.h
+++ b/source/gameengine/Ketsji/KX_GameObject.h
@@ -90,7 +90,6 @@ class KX_GameObject : public SCA_IObject {
  public :
 
   struct ActivityCullingInfo {
-    ActivityCullingInfo();
 
     enum Flag {
       ACTIVITY_NONE = 0,

--- a/source/gameengine/Ketsji/KX_GameObject.h
+++ b/source/gameengine/Ketsji/KX_GameObject.h
@@ -87,6 +87,23 @@ void KX_GameObject_Mathutils_Callback_Init(void);
 class KX_GameObject : public SCA_IObject {
   Py_Header
 
+ public :
+
+  struct ActivityCullingInfo {
+    ActivityCullingInfo();
+
+    enum Flag {
+      ACTIVITY_NONE = 0,
+      ACTIVITY_PHYSICS = (1 << 0),
+      ACTIVITY_LOGIC = (1 << 1)
+    } m_flags;
+
+    /// Squared physics culling radius.
+    float m_physicsRadius;
+    /// Squared logic culling radius.
+    float m_logicRadius;
+  };
+
  protected :
 
   /* EEVEE INTEGRATION */
@@ -118,6 +135,9 @@ class KX_GameObject : public SCA_IObject {
   // culled = while rendering, depending on camera
   bool m_bVisible;
   bool m_bOccluder;
+
+  // Object activity culling settings converted from blender objects.
+  ActivityCullingInfo m_activityCullingInfo;
 
   PHY_IPhysicsController *m_pPhysicsController;
   SG_Node *m_pSGNode;
@@ -304,6 +324,8 @@ class KX_GameObject : public SCA_IObject {
    * Check if an action has finished playing
    */
   bool IsActionDone(short layer);
+
+  bool IsActionsSuspended();
 
   /**
    * Kick the object's action manager
@@ -639,6 +661,11 @@ class KX_GameObject : public SCA_IObject {
    */
   void UpdateLod(const MT_Vector3 &cam_pos, float lodfactor);
 
+  /** Update the activity culling of the object.
+   * \param distance Squared nearest distance to the cameras of this object.
+   */
+  void UpdateActivity(float distance);
+
   /**
    * Pick out a mesh associated with the integer 'num'.
    */
@@ -701,6 +728,11 @@ class KX_GameObject : public SCA_IObject {
   {
     return m_bIsNegativeScaling;
   }
+
+  ActivityCullingInfo &GetActivityCullingInfo();
+  void SetActivityCullingInfo(const ActivityCullingInfo &cullingInfo);
+  /// Enable or disable a category of object activity culling.
+  void SetActivityCulling(ActivityCullingInfo::Flag flag, bool enable);
 
   /**
    * \section Logic bubbling methods.

--- a/source/gameengine/Ketsji/KX_GameObject.h
+++ b/source/gameengine/Ketsji/KX_GameObject.h
@@ -900,6 +900,28 @@ class KX_GameObject : public SCA_IObject {
   static int pyattr_set_visible(EXP_PyObjectPlus *self_v,
                                 const EXP_PYATTRIBUTE_DEF *attrdef,
                                 PyObject *value);
+
+  static PyObject *pyattr_get_physicsCulling(EXP_PyObjectPlus *self_v,
+                                             const EXP_PYATTRIBUTE_DEF *attrdef);
+  static int pyattr_set_physicsCulling(EXP_PyObjectPlus *self_v,
+                                       const EXP_PYATTRIBUTE_DEF *attrdef,
+                                       PyObject *value);
+  static PyObject *pyattr_get_logicCulling(EXP_PyObjectPlus *self_v,
+                                           const EXP_PYATTRIBUTE_DEF *attrdef);
+  static int pyattr_set_logicCulling(EXP_PyObjectPlus *self_v,
+                                     const EXP_PYATTRIBUTE_DEF *attrdef,
+                                     PyObject *value);
+  static PyObject *pyattr_get_physicsCullingRadius(EXP_PyObjectPlus *self_v,
+                                                   const EXP_PYATTRIBUTE_DEF *attrdef);
+  static int pyattr_set_physicsCullingRadius(EXP_PyObjectPlus *self_v,
+                                             const EXP_PYATTRIBUTE_DEF *attrdef,
+                                             PyObject *value);
+  static PyObject *pyattr_get_logicCullingRadius(EXP_PyObjectPlus *self_v,
+                                                 const EXP_PYATTRIBUTE_DEF *attrdef);
+  static int pyattr_set_logicCullingRadius(EXP_PyObjectPlus *self_v,
+                                           const EXP_PYATTRIBUTE_DEF *attrdef,
+                                           PyObject *value);
+
   static PyObject *pyattr_get_worldPosition(EXP_PyObjectPlus *self_v,
                                             const EXP_PYATTRIBUTE_DEF *attrdef);
   static int pyattr_set_worldPosition(EXP_PyObjectPlus *self_v,

--- a/source/gameengine/Ketsji/KX_KetsjiEngine.cpp
+++ b/source/gameengine/Ketsji/KX_KetsjiEngine.cpp
@@ -499,7 +499,9 @@ bool KX_KetsjiEngine::NextFrame()
        * update. */
       m_logger.StartLog(tc_logic);
 
-      scene->UpdateObjectActivity();
+      if (i == 0) { // No need to UpdateObjectActivity several times
+        scene->UpdateObjectActivity();
+      }
 
       m_logger.StartLog(tc_physics);
       // set Python hooks for each scene

--- a/source/gameengine/Ketsji/KX_Scene.cpp
+++ b/source/gameengine/Ketsji/KX_Scene.cpp
@@ -161,7 +161,7 @@ KX_Scene::KX_Scene(SCA_IInputDevice *inputDevice,
 
   m_dbvt_culling = false;
   m_dbvt_occlusion_res = 0;
-  m_activity_culling = false;
+  m_activityCulling = false;
   m_objectlist = new EXP_ListValue<KX_GameObject>();
   m_parentlist = new EXP_ListValue<KX_GameObject>();
   m_lightlist = new EXP_ListValue<KX_LightObject>();
@@ -1516,7 +1516,7 @@ const RAS_FrameSettings &KX_Scene::GetFramingType() const
 
 void KX_Scene::SetActivityCulling(bool b)
 {
-  m_activity_culling = b;
+  m_activityCulling = b;
 }
 
 void KX_Scene::AddObjectDebugProperties(class KX_GameObject *gameobj)
@@ -2366,7 +2366,9 @@ void KX_Scene::UpdateAnimations(double curtime)
   for (KX_GameObject *gameobj : m_animatedlist) {
     // BLI_task_pool_push(m_animationPool, update_anim_thread_func, gameobj, false,
     // TASK_PRIORITY_LOW);
-    gameobj->UpdateActionManager(curtime, true);
+    if (!gameobj->IsActionsSuspended()) {
+      gameobj->UpdateActionManager(curtime, true);
+    }
   }
 
   // BLI_task_pool_work_and_wait(m_animationPool);
@@ -2459,13 +2461,39 @@ int KX_Scene::GetLodHysteresisValue(void)
 
 void KX_Scene::UpdateObjectActivity(void)
 {
-}
+  if (!m_activityCulling) {
+    return;
+  }
 
-void KX_Scene::SetActivityCullingRadius(float f)
-{
-  if (f < 0.5f)
-    f = 0.5f;
-  m_activity_box_radius = f;
+  std::vector<MT_Vector3> camPositions;
+
+  for (KX_Camera *cam : m_cameralist) {
+    if (cam->GetActivityCulling()) {
+      camPositions.push_back(cam->NodeGetWorldPosition());
+    }
+  }
+
+  // None cameras are using object activity culling?
+  if (camPositions.size() == 0) {
+    return;
+  }
+
+  for (KX_GameObject *gameobj : m_objectlist) {
+    // If the object doesn't manage activity culling we don't compute distance.
+    if (gameobj->GetActivityCullingInfo().m_flags ==
+        KX_GameObject::ActivityCullingInfo::ACTIVITY_NONE) {
+      continue;
+    }
+
+    // For each camera compute the distance to objects and keep the minimum distance.
+    const MT_Vector3 &obpos = gameobj->NodeGetWorldPosition();
+    float dist = FLT_MAX;
+    for (const MT_Vector3 &campos : camPositions) {
+      // Keep the minimum distance.
+      dist = min_ff((obpos - campos).length2(), dist);
+    }
+    gameobj->UpdateActivity(dist);
+  }
 }
 
 KX_NetworkMessageScene *KX_Scene::GetNetworkMessageScene()
@@ -3130,9 +3158,7 @@ PyAttributeDef KX_Scene::Attributes[] = {
     EXP_PYATTRIBUTE_RW_FUNCTION(
         "pre_draw_setup", KX_Scene, pyattr_get_drawing_callback, pyattr_set_drawing_callback),
     EXP_PYATTRIBUTE_RW_FUNCTION("gravity", KX_Scene, pyattr_get_gravity, pyattr_set_gravity),
-    EXP_PYATTRIBUTE_BOOL_RO("activity_culling", KX_Scene, m_activity_culling),
-    EXP_PYATTRIBUTE_FLOAT_RW(
-        "activity_culling_radius", 0.5f, FLT_MAX, KX_Scene, m_activity_box_radius),
+    EXP_PYATTRIBUTE_BOOL_RO("activityCulling", KX_Scene, m_activityCulling),
     EXP_PYATTRIBUTE_BOOL_RO("dbvt_culling", KX_Scene, m_dbvt_culling),
     EXP_PYATTRIBUTE_RO_FUNCTION("logger", KX_Scene, KX_PythonProxy::pyattr_get_logger),
     EXP_PYATTRIBUTE_RO_FUNCTION("loggerName", KX_Scene, KX_PythonProxy::pyattr_get_logger_name),

--- a/source/gameengine/Ketsji/KX_Scene.h
+++ b/source/gameengine/Ketsji/KX_Scene.h
@@ -270,14 +270,9 @@ class KX_Scene : public KX_PythonProxy, public SCA_IScene {
   int m_ueberExecutionPriority;
 
   /**
-   * Radius in Manhattan distance of the box for activity culling.
-   */
-  float m_activity_box_radius;
-
-  /**
    * Toggle to enable or disable activity culling.
    */
-  bool m_activity_culling;
+  bool m_activityCulling;
 
   /**
    * Toggle to enable or disable culling via DBVT broadphase of Bullet.
@@ -514,8 +509,6 @@ class KX_Scene : public KX_PythonProxy, public SCA_IScene {
   // Enable/disable activity culling.
   void SetActivityCulling(bool b);
 
-  // Set the radius of the activity culling box.
-  void SetActivityCullingRadius(float f);
   // use of DBVT tree for camera culling
   void SetDbvtCulling(bool b)
   {


### PR DESCRIPTION
I think it works as excpected but SuspendLogic doesn't work properly (it is not related to activity_culling patch and there is the same issue in 0.2.5).

Physics and Actions are correctly suspended/restored.

test file:

[activity_culling_test.zip](https://github.com/UPBGE/upbge/files/7114273/activity_culling_test.zip)


