### PR TITLE
Add workflow to publish API docs and stubs

### DIFF
--- a/.github/workflows/publish-api-and-stubs.yml
+++ b/.github/workflows/publish-api-and-stubs.yml
@@ -1,0 +1,221 @@
+name: publish-api-and-stubs
+
+on:
+  push:
+    branches: [ master ]
+
+env:
+  PYTHON_VERSION: "3.9"
+
+jobs:
+  build:
+    name: Build UPBGE
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Install Tools
+      run: | 
+        sudo apt update && \
+        sudo apt install -y build-essential cmake libembree-dev \
+          libxi-dev libxxf86vm-dev libboost-dev libboost-locale-dev libgl1-mesa-dev \
+          libavformat-dev libtbb-dev libswscale-dev libavdevice-dev libblas3 \
+          libzstd-dev
+
+    - name: Install Python
+      uses: actions/setup-python@v2.2.2
+      with: 
+        python-version: "${{env.PYTHON_VERSION}}"
+
+    - name: Install Python Dependencies
+      run: | 
+        curl https://bootstrap.pypa.io/get-pip.py | python && \
+        python -m pip install numpy==1.17.4 requests
+
+    - name: Setup Python Path
+      run: |
+        sudo sh -c "echo '$pythonLocation/lib' >> /etc/ld.so.conf.d/python.conf" && \
+        sudo ldconfig
+
+    - name: Checkout sources
+      uses: actions/checkout@v2
+      with:
+        repository: "UPBGE/upbge"
+        ref: "master"
+        path: "upbge"
+
+    - name: Checkout addons
+      uses: actions/checkout@v2
+      with:
+        repository: "UPBGE/blender-addons"
+        ref: "master"
+        path: "blender-addons"
+
+    - name: Checkout addons-contrib
+      run: git clone --depth=1 git://git.blender.org/blender-addons-contrib.git
+
+    - name: Checkout translations
+      run: git clone --depth=1 git://git.blender.org/blender-translations.git
+
+    - name: Checkout dev-tools
+      run: git clone --depth=1 git://git.blender.org/blender-dev-tools.git
+
+    - name: Update Submodules
+      run: git -C upbge submodule update --init --recursive --remote
+
+    - name: Configure CMake
+      run: |
+        cmake -S upbge -B build \
+                 -C upbge/build_files/cmake/config/blender_release.cmake \
+                 -DWITH_GAMEENGINE=ON \
+                 -DWITH_PLAYER=OFF \
+                 -DCMAKE_BUILD_TYPE=Release \
+                 -DWITH_INSTALL_PORTABLE=ON \
+                 -DWITH_MOD_OCEANSIM=OFF \
+                 -DWITH_CYCLES=OFF \
+                 -DPYTHON_VERSION=${{env.PYTHON_VERSION}}
+
+    - name: Build UPBGE
+      run:  make -C build -j `nproc`
+
+    - name: Copy Release Scripts
+      run: make -C build install
+
+    - name: Archive Build
+      if: ${{ !env.ACT }}
+      run: tar zcvf build.tar.gz build
+
+    - name: Upload Build
+      if: ${{ !env.ACT }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: blender
+        path: build.tar.gz
+
+  publish_api:
+    name: Publish API Documentation
+    runs-on: ubuntu-latest
+    needs: [build]
+
+    steps:
+    - name: Download Build
+      if: ${{ !env.ACT }}
+      uses: actions/download-artifact@v2
+      with:
+        name: blender
+
+    - name: Extract Build
+      if: ${{ !env.ACT }}
+      run: tar zxvf build.tar.gz
+
+    - name: Install Tools
+      run: | 
+        sudo apt update && \
+        sudo apt install -y libtbb2 libxi6 libxxf86vm1 libxfixes3 libgl1 \
+          libavformat58 libavdevice58 libboost-locale1.71.0
+
+    - name: Install Python
+      uses: actions/setup-python@v2.2.2
+      with: 
+        python-version: "${{env.PYTHON_VERSION}}"
+
+    - name: Install Python Dependencies
+      run: | 
+        curl https://bootstrap.pypa.io/get-pip.py | python && \
+        python -m pip install sphinx sphinx-rtd-theme yapf tqdm numpy==1.17.4
+
+    - name: Setup Python Path
+      run: |
+        sudo sh -c "echo '$pythonLocation/lib' >> /etc/ld.so.conf.d/python.conf" && \
+        sudo ldconfig
+
+    - name: Checkout sources
+      uses: actions/checkout@v2
+      with:
+        repository: "UPBGE/upbge"
+        ref: "master"
+        path: "upbge"
+
+    - name: Prepare API Documentation
+      working-directory: build
+      run: | 
+        bin/blender --background -noaudio --factory-startup \
+                    --python ../upbge/doc/python_api/sphinx_doc_gen.py -- \
+                    --output "${{ github.workspace }}/python_api"
+
+    - name: Build API Documentation
+      working-directory: python_api
+      run: sphinx-build -b html -j auto sphinx-in sphinx-out && rm -Rf sphinx-out/.doctrees
+
+    - name: Publish to UPBGE
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        external_repository: UPBGE/UPBGE-API
+        publish_branch: master
+        publish_dir: python_api/sphinx-out
+        deploy_key: ${{ secrets.APIDOCS_DEPLOY_KEY }}
+
+    - name: Archive Documents
+      if: ${{ !env.ACT }}
+      run: tar zcvf apidocs.tar.gz python_api
+
+    - name: Upload Documents
+      if: ${{ !env.ACT }}
+      uses: actions/upload-artifact@v2
+      with:
+        name: apidocs
+        path: apidocs.tar.gz
+
+  publish_stubs:
+    name: Publish API Stubs
+    runs-on: ubuntu-latest
+    needs: [publish_api]
+
+    steps:
+    - name: Download Build
+      if: ${{ !env.ACT }}
+      uses: actions/download-artifact@v2
+      with:
+        name: blender
+
+    - name: Extract Build
+      if: ${{ !env.ACT }}
+      run: tar zxvf build.tar.gz
+
+    - name: Download Documents
+      if: ${{ !env.ACT }}
+      uses: actions/download-artifact@v2
+      with:
+        name: apidocs
+
+    - name: Extract Documents
+      if: ${{ !env.ACT }}
+      run: tar zxvf apidocs.tar.gz
+
+    - name: Install Python
+      uses: actions/setup-python@v2.2.2
+      with: 
+        python-version: "${{env.PYTHON_VERSION}}"
+
+    - name: Install Python Dependencies
+      run: | 
+        curl https://bootstrap.pypa.io/get-pip.py | python && \
+        python -m pip install bpystubgen
+
+    - name: Build API Stubs
+      working-directory: python_api
+      run: |
+        python -m bpystubgen --quiet --format sphinx-in upbge-stub && \
+        curl https://raw.githubusercontent.com/mysticfall/bpystubgen/main/package/setup.py -o upbge-stub/setup.py && \
+        curl https://raw.githubusercontent.com/mysticfall/bpystubgen/main/package/README.md -o upbge-stub/README.md
+
+    - name: Build Python Package
+      working-directory: python_api/upbge-stub
+      run: APP_NAME=upbge APP_VERSION=0.3 BUILD_NUMBER=${{github.run_id}} python setup.py sdist
+
+    - name: Publish to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        password: ${{ secrets.PYPI_TOKEN }}
+        packages_dir: python_api/upbge-stub/dist
+        skip_existing: true
+


### PR DESCRIPTION
This Github workflow generates and publishes API documentation and stubs to [UPBGE/UPBGE-API](https://github.com/UPBGE/UPBGE-API) and [PyPI repository](https://pypi.org/manage/project/upbge-stubs) respectively, whenever the master branch is updated.