### PR TITLE
UPBGE: System to remap bone constraints targets after armature duplication

### DIFF
--- a/source/gameengine/Converter/BL_BlenderDataConversion.cpp
+++ b/source/gameengine/Converter/BL_BlenderDataConversion.cpp
@@ -1658,14 +1658,14 @@ void BL_ConvertBlenderObjects(struct Main *maggie,
                 if (listb.first) {
                   bConstraintTarget *target = (bConstraintTarget *)listb.first;
                   if (target->tar && child->GetBlenderObject() == target->tar) {
-                    child->SetIsBoneTarget();
+                    child->RegisterAsBoneConstraintTarget(pcon->name, false);
                   }
                   if (target->next != nullptr) {
                     // secondary target
                     target = target->next;
                   }
                   if (target->tar && child->GetBlenderObject() == target->tar) {
-                    child->SetIsBoneSubTarget();
+                    child->RegisterAsBoneConstraintTarget(pcon->name, true);
                   }
                 }
                 if (cti->flush_constraint_targets) {

--- a/source/gameengine/Converter/BL_BlenderDataConversion.cpp
+++ b/source/gameengine/Converter/BL_BlenderDataConversion.cpp
@@ -1645,7 +1645,7 @@ void BL_ConvertBlenderObjects(struct Main *maggie,
       navmesh->SetVisible(0, true);
     }
 
-    /* Mark armature constraint targets only if they are in armature children list */
+    /* Mark armature bone constraint targets only if they are in armature children list */
     if (blenderobject->type == OB_ARMATURE) {
       if (blenderobject->pose) {
         LISTBASE_FOREACH (bPoseChannel *, pchan, &blenderobject->pose->chanbase) {

--- a/source/gameengine/Converter/BL_BlenderDataConversion.cpp
+++ b/source/gameengine/Converter/BL_BlenderDataConversion.cpp
@@ -1668,6 +1668,9 @@ void BL_ConvertBlenderObjects(struct Main *maggie,
                     child->SetIsBoneSubTarget();
                   }
                 }
+                if (cti->flush_constraint_targets) {
+                  cti->flush_constraint_targets(pcon, &listb, 1);
+                }
               }
             }
           }

--- a/source/gameengine/Ketsji/KX_GameObject.cpp
+++ b/source/gameengine/Ketsji/KX_GameObject.cpp
@@ -89,6 +89,7 @@ KX_GameObject::KX_GameObject()
       m_forceIgnoreParentTx(false),    // eevee
       m_previousLodLevel(-1),          // eevee
       m_isBoneTarget(false),           // eevee
+      m_isBoneSubTarget(false),        // eevee
       m_layer(0),
       m_lodManager(nullptr),
       m_currentLodLevel(0),
@@ -443,6 +444,16 @@ void KX_GameObject::SetIsBoneTarget()
 bool KX_GameObject::IsBoneTarget()
 {
   return m_isBoneTarget;
+}
+
+void KX_GameObject::SetIsBoneSubTarget()
+{
+  m_isBoneSubTarget = true;
+}
+
+bool KX_GameObject::IsBoneSubTarget()
+{
+  return m_isBoneSubTarget;
 }
 
 void KX_GameObject::Dispose()

--- a/source/gameengine/Ketsji/KX_GameObject.cpp
+++ b/source/gameengine/Ketsji/KX_GameObject.cpp
@@ -373,6 +373,7 @@ void KX_GameObject::ReplicateBlenderObject()
     newob->visibility_flag &= ~OB_HIDE_VIEWPORT;
     GetScene()->TagForCollectionRemap();
 
+    /* Used for bone constraint targets remapping (See KX_Scene::RemapBoneConstraintTargets) */
     if (newob->type == OB_ARMATURE) {
       GetScene()->AppendToReplicaArmatures(this);
     }

--- a/source/gameengine/Ketsji/KX_GameObject.cpp
+++ b/source/gameengine/Ketsji/KX_GameObject.cpp
@@ -88,6 +88,7 @@ KX_GameObject::KX_GameObject()
       m_visibleAtGameStart(false),     // eevee
       m_forceIgnoreParentTx(false),    // eevee
       m_previousLodLevel(-1),          // eevee
+      m_isBoneTarget(false),           // eevee
       m_layer(0),
       m_lodManager(nullptr),
       m_currentLodLevel(0),
@@ -372,6 +373,10 @@ void KX_GameObject::ReplicateBlenderObject()
     newob->visibility_flag &= ~OB_HIDE_VIEWPORT;
     GetScene()->TagForCollectionRemap();
 
+    if (newob->type == OB_ARMATURE) {
+      GetScene()->AppendToReplicaArmatures(this);
+    }
+
     if (ob->parent) {
       if (GetScene()->GetLastReplicatedParentObject()) {
         newob->parent = GetScene()->GetLastReplicatedParentObject();
@@ -427,6 +432,16 @@ void KX_GameObject::HideOriginalObject()
       GetScene()->m_hiddenObjectsDuringRuntime.push_back(ob);
     }
   }
+}
+
+void KX_GameObject::SetIsBoneTarget()
+{
+  m_isBoneTarget = true;
+}
+
+bool KX_GameObject::IsBoneTarget()
+{
+  return m_isBoneTarget;
 }
 
 void KX_GameObject::Dispose()

--- a/source/gameengine/Ketsji/KX_GameObject.cpp
+++ b/source/gameengine/Ketsji/KX_GameObject.cpp
@@ -88,8 +88,6 @@ KX_GameObject::KX_GameObject()
       m_visibleAtGameStart(false),     // eevee
       m_forceIgnoreParentTx(false),    // eevee
       m_previousLodLevel(-1),          // eevee
-      m_isBoneTarget(false),           // eevee
-      m_isBoneSubTarget(false),        // eevee
       m_layer(0),
       m_lodManager(nullptr),
       m_currentLodLevel(0),
@@ -113,6 +111,8 @@ KX_GameObject::KX_GameObject()
 #endif
 {
   m_pClient_info = new KX_ClientObjectInfo(this, KX_ClientObjectInfo::ACTOR);
+
+  m_boneConstraintTargetIdentifier = {};
 
   unit_m4(m_prevObmat);  // eevee
 };
@@ -436,24 +436,14 @@ void KX_GameObject::HideOriginalObject()
   }
 }
 
-void KX_GameObject::SetIsBoneTarget()
+void KX_GameObject::RegisterAsBoneConstraintTarget(char *constraintName, bool isSubTarget)
 {
-  m_isBoneTarget = true;
+  m_boneConstraintTargetIdentifier = {constraintName, isSubTarget};
 }
 
-bool KX_GameObject::IsBoneTarget()
+std::pair<char *, bool> KX_GameObject::GetBoneConstraintTargetIdentifier()
 {
-  return m_isBoneTarget;
-}
-
-void KX_GameObject::SetIsBoneSubTarget()
-{
-  m_isBoneSubTarget = true;
-}
-
-bool KX_GameObject::IsBoneSubTarget()
-{
-  return m_isBoneSubTarget;
+  return m_boneConstraintTargetIdentifier;
 }
 
 void KX_GameObject::Dispose()

--- a/source/gameengine/Ketsji/KX_GameObject.h
+++ b/source/gameengine/Ketsji/KX_GameObject.h
@@ -111,8 +111,7 @@ class KX_GameObject : public SCA_IObject {
   bool m_visibleAtGameStart;
   bool m_forceIgnoreParentTx;
   short m_previousLodLevel;
-  bool m_isBoneTarget;
-  bool m_isBoneSubTarget;
+  std::pair<char *, bool> m_boneConstraintTargetIdentifier;
   /* END OF EEVEE INTEGRATION */
 
   KX_ClientObjectInfo *m_pClient_info;
@@ -175,10 +174,8 @@ class KX_GameObject : public SCA_IObject {
   void SetIsReplicaObject();
   float *GetPrevObmat();
   BL_ActionManager *GetActionManagerNoCreate();
-  void SetIsBoneTarget();
-  bool IsBoneTarget();
-  void SetIsBoneSubTarget();
-  bool IsBoneSubTarget();
+  void RegisterAsBoneConstraintTarget(char *constraintName, bool isSubTarget);
+  std::pair<char *, bool> GetBoneConstraintTargetIdentifier();
   /* END OF EEVEE INTEGRATION */
 
   /**

--- a/source/gameengine/Ketsji/KX_GameObject.h
+++ b/source/gameengine/Ketsji/KX_GameObject.h
@@ -112,6 +112,7 @@ class KX_GameObject : public SCA_IObject {
   bool m_forceIgnoreParentTx;
   short m_previousLodLevel;
   bool m_isBoneTarget;
+  bool m_isBoneSubTarget;
   /* END OF EEVEE INTEGRATION */
 
   KX_ClientObjectInfo *m_pClient_info;
@@ -176,6 +177,8 @@ class KX_GameObject : public SCA_IObject {
   BL_ActionManager *GetActionManagerNoCreate();
   void SetIsBoneTarget();
   bool IsBoneTarget();
+  void SetIsBoneSubTarget();
+  bool IsBoneSubTarget();
   /* END OF EEVEE INTEGRATION */
 
   /**

--- a/source/gameengine/Ketsji/KX_GameObject.h
+++ b/source/gameengine/Ketsji/KX_GameObject.h
@@ -111,6 +111,7 @@ class KX_GameObject : public SCA_IObject {
   bool m_visibleAtGameStart;
   bool m_forceIgnoreParentTx;
   short m_previousLodLevel;
+  bool m_isBoneTarget;
   /* END OF EEVEE INTEGRATION */
 
   KX_ClientObjectInfo *m_pClient_info;
@@ -173,6 +174,8 @@ class KX_GameObject : public SCA_IObject {
   void SetIsReplicaObject();
   float *GetPrevObmat();
   BL_ActionManager *GetActionManagerNoCreate();
+  void SetIsBoneTarget();
+  bool IsBoneTarget();
   /* END OF EEVEE INTEGRATION */
 
   /**

--- a/source/gameengine/Ketsji/KX_Scene.cpp
+++ b/source/gameengine/Ketsji/KX_Scene.cpp
@@ -1493,7 +1493,7 @@ void KX_Scene::RemapBoneConstraintTargets()
 {
   for (KX_GameObject *gameobj : m_replicaArmatureList) {
     for (KX_GameObject *child : gameobj->GetChildren()) {
-      if (child->IsBoneTarget()) {
+      if (child->IsBoneTarget() || child->IsBoneSubTarget()) {
         Object *blenderobject = gameobj->GetBlenderObject();
         if (blenderobject->pose) {
           LISTBASE_FOREACH (bPoseChannel *, pchan, &blenderobject->pose->chanbase) {
@@ -1504,14 +1504,14 @@ void KX_Scene::RemapBoneConstraintTargets()
                 cti->get_constraint_targets(pcon, &listb);
                 if (listb.first) {
                   bConstraintTarget *target = (bConstraintTarget *)listb.first;
-                  if (target->tar) {
+                  if (target->tar && child->IsBoneTarget()) {
                     target->tar = child->GetBlenderObject();
                   }
                   if (target->next != nullptr) {
                     // secondary target
                     target = target->next;
                   }
-                  if (target->tar) { // if subtarget
+                  if (target->tar && child->IsBoneSubTarget()) { // if subtarget
                     target->tar = child->GetBlenderObject();
                   }
                 }

--- a/source/gameengine/Ketsji/KX_Scene.cpp
+++ b/source/gameengine/Ketsji/KX_Scene.cpp
@@ -1487,7 +1487,9 @@ void KX_Scene::AppendToReplicaArmatures(KX_GameObject *gameobj)
   m_replicaArmatureList.push_back(gameobj);
 }
 
-void KX_Scene::RemapArmatureConstraintTarget()
+/* Do an automatic bone constraints targets remapping
+ * only when targets are children of Armature */
+void KX_Scene::RemapBoneConstraintTargets()
 {
   for (KX_GameObject *gameobj : m_replicaArmatureList) {
     for (KX_GameObject *child : gameobj->GetChildren()) {
@@ -1509,7 +1511,7 @@ void KX_Scene::RemapArmatureConstraintTarget()
                     // secondary target
                     target = target->next;
                   }
-                  if (target->tar) {
+                  if (target->tar) { // if subtarget
                     target->tar = child->GetBlenderObject();
                   }
                 }
@@ -2485,7 +2487,7 @@ void KX_Scene::LogicEndFrame()
 {
   m_logicmgr->EndFrame();
 
-  RemapArmatureConstraintTarget();
+  RemapBoneConstraintTargets();
 
   /* Don't remove the objects from the euthanasy list here as the child objects of a deleted
    * parent object are destructed directly from the sgnode in the same time the parent

--- a/source/gameengine/Ketsji/KX_Scene.cpp
+++ b/source/gameengine/Ketsji/KX_Scene.cpp
@@ -1489,7 +1489,6 @@ void KX_Scene::AppendToReplicaArmatures(KX_GameObject *gameobj)
 
 void KX_Scene::RemapArmatureConstraintTarget()
 {
-  bContext *C = KX_GetActiveEngine()->GetContext();
   for (KX_GameObject *gameobj : m_replicaArmatureList) {
     for (KX_GameObject *child : gameobj->GetChildren()) {
       if (child->IsBoneTarget()) {
@@ -1505,8 +1504,6 @@ void KX_Scene::RemapArmatureConstraintTarget()
                   bConstraintTarget *target = (bConstraintTarget *)listb.first;
                   if (target->tar) {
                     target->tar = child->GetBlenderObject();
-                    std::cout << blenderobject->id.name + 2 << std::endl;
-                    std::cout << target->tar->id.name + 2 << std::endl;
                   }
                   if (target->next != nullptr) {
                     // secondary target
@@ -1515,6 +1512,9 @@ void KX_Scene::RemapArmatureConstraintTarget()
                   if (target->tar) {
                     target->tar = child->GetBlenderObject();
                   }
+                }
+                if (cti->flush_constraint_targets) {
+                  cti->flush_constraint_targets(pcon, &listb, 0);
                 }
               }
             }

--- a/source/gameengine/Ketsji/KX_Scene.cpp
+++ b/source/gameengine/Ketsji/KX_Scene.cpp
@@ -1493,7 +1493,7 @@ void KX_Scene::RemapBoneConstraintTargets()
 {
   for (KX_GameObject *gameobj : m_replicaArmatureList) {
     for (KX_GameObject *child : gameobj->GetChildren()) {
-      if (child->IsBoneTarget() || child->IsBoneSubTarget()) {
+      if (child->GetBoneConstraintTargetIdentifier().first != nullptr) {
         Object *blenderobject = gameobj->GetBlenderObject();
         if (blenderobject->pose) {
           LISTBASE_FOREACH (bPoseChannel *, pchan, &blenderobject->pose->chanbase) {
@@ -1504,14 +1504,17 @@ void KX_Scene::RemapBoneConstraintTargets()
                 cti->get_constraint_targets(pcon, &listb);
                 if (listb.first) {
                   bConstraintTarget *target = (bConstraintTarget *)listb.first;
-                  if (target->tar && child->IsBoneTarget()) {
+                  bool constraintNameMatch = strcmp(child->GetBoneConstraintTargetIdentifier().first,
+                                                   pcon->name) == 0;
+                  bool isSubTarget = child->GetBoneConstraintTargetIdentifier().second;
+                  if (target->tar && constraintNameMatch && !isSubTarget) {
                     target->tar = child->GetBlenderObject();
                   }
                   if (target->next != nullptr) {
                     // secondary target
                     target = target->next;
                   }
-                  if (target->tar && child->IsBoneSubTarget()) { // if subtarget
+                  if (target->tar && constraintNameMatch && isSubTarget) { // if subtarget
                     target->tar = child->GetBlenderObject();
                   }
                 }

--- a/source/gameengine/Ketsji/KX_Scene.h
+++ b/source/gameengine/Ketsji/KX_Scene.h
@@ -159,6 +159,8 @@ class KX_Scene : public KX_PythonProxy, public SCA_IScene {
   std::vector<std::pair<Mesh *, IDRecalcFlag>> m_meshesToUpdateInAllRenderPasses;
   std::vector<std::pair<Object *, IDRecalcFlag>> m_extraObjectsToUpdateInOverlayPass;
   std::vector<bNodeTree *> m_nodeTreesToUpdateInAllRenderPasses;
+
+  std::vector<KX_GameObject *> m_replicaArmatureList;
   /*************************************************/
 
   RAS_BucketManager *m_bucketmanager;
@@ -384,6 +386,8 @@ class KX_Scene : public KX_PythonProxy, public SCA_IScene {
   void TagForExtraObjectsUpdate(Main *bmain, KX_Camera *cam);
   KX_GameObject *AddDuplicaObject(KX_GameObject *gameobj, KX_GameObject *reference, float lifespan);
   void OverlayPassDisableEffects(struct Depsgraph *depsgraph, KX_Camera *kxcam, bool isOverlayPass);
+  void RemapArmatureConstraintTarget();
+  void AppendToReplicaArmatures(KX_GameObject *gameobj);
   /***************End of EEVEE INTEGRATION**********************/
 
   RAS_BucketManager *GetBucketManager() const;

--- a/source/gameengine/Ketsji/KX_Scene.h
+++ b/source/gameengine/Ketsji/KX_Scene.h
@@ -160,6 +160,7 @@ class KX_Scene : public KX_PythonProxy, public SCA_IScene {
   std::vector<std::pair<Object *, IDRecalcFlag>> m_extraObjectsToUpdateInOverlayPass;
   std::vector<bNodeTree *> m_nodeTreesToUpdateInAllRenderPasses;
 
+  /* For bone constraint targets remapping */
   std::vector<KX_GameObject *> m_replicaArmatureList;
   /*************************************************/
 
@@ -386,7 +387,9 @@ class KX_Scene : public KX_PythonProxy, public SCA_IScene {
   void TagForExtraObjectsUpdate(Main *bmain, KX_Camera *cam);
   KX_GameObject *AddDuplicaObject(KX_GameObject *gameobj, KX_GameObject *reference, float lifespan);
   void OverlayPassDisableEffects(struct Depsgraph *depsgraph, KX_Camera *kxcam, bool isOverlayPass);
-  void RemapArmatureConstraintTarget();
+
+  /* For bone constraint targets remapping */
+  void RemapBoneConstraintTargets();
   void AppendToReplicaArmatures(KX_GameObject *gameobj);
   /***************End of EEVEE INTEGRATION**********************/
 


### PR DESCRIPTION
It is if we decide to not rework armature sensor/actuator.

It is doing an automatic remapping only if "targets" are children of Armature.

EDIT: It is because we know that "targets" are duplicated if they are children of Armature (as children are spawned with parent).

After we did an armature duplication, if one of his children is a "bone constraint target", this child becomes the new armature bone constraint target.

EDIT: Actually, i'm not sure about the logic if there are several constraints with several targets/subtargets... would maybe need to find a more solid system...

Test file:
[constraintRemapTest.zip](https://github.com/UPBGE/upbge/files/7274624/constraintRemapTest.zip)

EDIT: I'll change this later to take into account bone

