### PR TITLE
Fix build problem with Python 3.10 due to internal API references

### DIFF
--- a/source/gameengine/Expressions/intern/PyObjectPlus.cpp
+++ b/source/gameengine/Expressions/intern/PyObjectPlus.cpp
@@ -1049,7 +1049,7 @@ int EXP_PyObjectPlus::py_set_attrdef(PyObject *self_py,
       case EXP_PYATTRIBUTE_TYPE_CHAR: {
         if (PyUnicode_Check(value)) {
           Py_ssize_t val_size;
-          const char *val = _PyUnicode_AsStringAndSize(value, &val_size);
+          const char *val = PyUnicode_AsUTF8AndSize(value, &val_size);
           strncpy(ptr, val, attrdef->m_size);
           ptr[attrdef->m_size - 1] = 0;
         }
@@ -1064,7 +1064,7 @@ int EXP_PyObjectPlus::py_set_attrdef(PyObject *self_py,
         std::string *var = reinterpret_cast<std::string *>(ptr);
         if (PyUnicode_Check(value)) {
           Py_ssize_t val_len;
-          const char *val = _PyUnicode_AsStringAndSize(
+          const char *val = PyUnicode_AsUTF8AndSize(
               value, &val_len); /* XXX, should be 'const' but we do a silly trick to have a shorter
                                    string */
           if (attrdef->m_clamp) {

--- a/source/gameengine/Ketsji/KX_PythonInit.cpp
+++ b/source/gameengine/Ketsji/KX_PythonInit.cpp
@@ -2543,8 +2543,7 @@ void createPythonConsole()
   BLI_strncpy(filepath, BKE_appdir_folder_id(BLENDER_SYSTEM_SCRIPTS, "bge"), sizeof(filepath));
   BLI_path_append(filepath, sizeof(filepath), "interpreter.py");
 
-  // Use _Py_fopen to make sure we use the same fopen function as python use.
-  FILE *fp = _Py_fopen(filepath, "r+");
+  FILE *fp = fopen(filepath, "r+");
   // Execute the file in python.
   PyRun_SimpleFile(fp, filepath);
 }


### PR DESCRIPTION
This change will fix build errors on Python 3.10 caused by using its internal API (i.e. functions prefixed by `_`).

List below are issues dealing with similar problems:

* https://developer.blender.org/T85573
* https://bugzilla.redhat.com/show_bug.cgi?id=1912903