### PR TITLE
Fix module path problem on Python 3.10

### DIFF
--- a/source/gameengine/Ketsji/KX_PythonInit.cpp
+++ b/source/gameengine/Ketsji/KX_PythonInit.cpp
@@ -2309,6 +2309,8 @@ void initGamePythonScripting(Main *maggie, bContext *C, bool *audioDeviceIsIniti
     PyPreConfig preconfig;
     PyStatus status;
 
+    backupPySysObjects();
+
     if (BPY_python_get_use_system_env()) {
       PyPreConfig_InitPythonConfig(&preconfig);
     }


### PR DESCRIPTION
Due to a change of behaviour in Python 3.10, running a game in embedded mode once will now make Blender lose all system module paths like `/scripts/modules`, resulting in various problems.

Before 3.10, `Py_InitializeFromConfig` preserved `sys.path`, so backing up the environment after that point didn't cause much of a problem.

However, the behaviour seems to have changed in 3.10 (I couldn't find any reference in documentation or changelog, though) which results in loss of system module paths such as `scripts/modules` after running the game once in embedded mode.

This PR tries to fix the problem by taking a back before `Py_InitializeFromConfig` so that it can be correctly restored after the game finishes.

How to reproduce:

 * Launch UPBGE compiled with Python 3.10.
 * Open scripting console and write `import sys` and `print(sys.path)`.
 * Confirm that the printed output includes system module paths.
 * Run embedded start once and repeat the above process.
 * Confirm that `sys.path` gets reset as shown below:

![image](https://user-images.githubusercontent.com/2367032/147876562-7139940b-93c8-4712-8b2a-4789d267a5c2.png)
