### PR TITLE
UPBGE: Use old undo only at bge exit but new undo in viewport

### DIFF
--- a/source/blender/blenkernel/BKE_global.h
+++ b/source/blender/blenkernel/BKE_global.h
@@ -144,6 +144,8 @@ typedef struct Global {
    */
   int fileflags;
 
+  bool is_undo_at_exit; // UPBGE
+
   /**
    * Message to show when loading a `.blend` file attempts to execute
    * a Python script or driver-expression when doing so is disallowed.

--- a/source/blender/editors/undo/memfile_undo.c
+++ b/source/blender/editors/undo/memfile_undo.c
@@ -35,6 +35,7 @@
 
 #include "BKE_blender_undo.h"
 #include "BKE_context.h"
+#include "BKE_global.h" //UPBGE
 #include "BKE_icons.h"
 #include "BKE_lib_id.h"
 #include "BKE_lib_query.h"
@@ -192,8 +193,8 @@ static void memfile_undosys_step_decode(struct bContext *C,
       use_old_bmain_data = false;
     }
   }
-  /* UPBGE (we force undo legacy while we try to fix new fast undo for UPBGE */
-  else if (true) {
+  /* UPBGE (we force undo legacy at bge exit only (while we try to fix new fast undo for) UPBGE */
+  else if (G.is_undo_at_exit == true) {
     use_old_bmain_data = false;
   }
   /* End UPBGE */

--- a/source/gameengine/BlenderRoutines/BL_KetsjiEmbedStart.cpp
+++ b/source/gameengine/BlenderRoutines/BL_KetsjiEmbedStart.cpp
@@ -194,6 +194,11 @@ extern "C" void StartKetsjiShell(struct bContext *C,
     BKE_undosys_step_push(CTX_wm_manager(C)->undo_stack, C, "pre");
   }
 
+  /* Make sure we'll use old undo at bge exit to properly restore scene
+   * See memfile_undo.c and search for keyword UPBGE
+   */
+  G.is_undo_at_exit = true;
+
   wmWindowManager *wm_backup = CTX_wm_manager(C);
   wmWindow *win_backup = CTX_wm_window(C);
   void *msgbus_backup = wm_backup->message_bus;
@@ -417,6 +422,9 @@ extern "C" void StartKetsjiShell(struct bContext *C,
       BKE_undosys_step_undo(CTX_wm_manager(C)->undo_stack, C);
     }
   }
+
+  /* Make sure we'll use new undo in viewport because faster */
+  G.is_undo_at_exit = false;
 
 #ifdef WITH_PYTHON
 


### PR DESCRIPTION
I used a new Global ... idk if it is good
