### PR TITLE
UPBGE: Fixing crash using volumetrics

### DIFF
--- a/source/blender/draw/intern/draw_manager.c
+++ b/source/blender/draw/intern/draw_manager.c
@@ -3437,10 +3437,14 @@ void DRW_game_render_loop(bContext *C,
 
   const int object_type_exclude_viewport = v3d->object_type_exclude_viewport;
 
-  DRW_hair_init();
+  /* Update UBO's */
+  DRW_globals_update();  
 
   /* Init engines */
   drw_engines_init();
+  DRW_curves_init();
+  DRW_volume_init(DST.vmempool);
+  DRW_smoke_init(DST.vmempool);
 
   drw_engines_cache_init();
   drw_engines_world_update(DST.draw_ctx.scene);
@@ -3502,7 +3506,7 @@ void DRW_game_render_loop(bContext *C,
 
   DRW_state_reset();
 
-  DRW_hair_update();
+  DRW_curves_update();
 
   drw_engines_draw_scene();
 
@@ -3511,6 +3515,8 @@ void DRW_game_render_loop(bContext *C,
 
   /* Fix 3D view being "laggy" on macos and win+nvidia. (See T56996, T61474) */
   GPU_flush();
+
+  DRW_smoke_exit(DST.vmempool);
 
   DRW_state_reset();
 

--- a/source/blender/draw/intern/draw_manager.c
+++ b/source/blender/draw/intern/draw_manager.c
@@ -3438,13 +3438,14 @@ void DRW_game_render_loop(bContext *C,
   const int object_type_exclude_viewport = v3d->object_type_exclude_viewport;
 
   /* Update UBO's */
-  DRW_globals_update();  
+  DRW_globals_update();
 
-  /* Init engines */
-  drw_engines_init();
   DRW_curves_init();
   DRW_volume_init(DST.vmempool);
   DRW_smoke_init(DST.vmempool);
+
+  /* Init engines */
+  drw_engines_init();
 
   drw_engines_cache_init();
   drw_engines_world_update(DST.draw_ctx.scene);
@@ -3498,7 +3499,6 @@ void DRW_game_render_loop(bContext *C,
   drw_engines_cache_finish();
 
   drw_task_graph_deinit();
-
   DRW_render_instance_buffer_finish();
 
   GPU_framebuffer_bind(DST.default_framebuffer);
@@ -3514,7 +3514,9 @@ void DRW_game_render_loop(bContext *C,
   GPU_framebuffer_clear_stencil(DST.default_framebuffer, 0xFF);
 
   /* Fix 3D view being "laggy" on macos and win+nvidia. (See T56996, T61474) */
-  GPU_flush();
+  if (GPU_type_matches_ex(GPU_DEVICE_ANY, GPU_OS_ANY, GPU_DRIVER_ANY, GPU_BACKEND_OPENGL)) {
+    GPU_flush();
+  }
 
   DRW_smoke_exit(DST.vmempool);
 


### PR DESCRIPTION
After last changes in curves, volumetrics and smoke we have to add new DRW initialization for these elements.
Curves initializes and update the hair methods now.

I have some doubts with DRW_globals_update() to update UBO's. This function was out of our DRW_game_render_loop function due to any specific reason?

I tested with a few files and they worked well.

[volumetric_crash.zip](https://github.com/UPBGE/upbge/files/8586684/volumetric_crash.zip)

