### PR TITLE
UPBGE: Missing errors reports + python controller module reload

### DIFF
--- a/source/blender/blenkernel/intern/python_proxy.c
+++ b/source/blender/blenkernel/intern/python_proxy.c
@@ -511,6 +511,7 @@ static bool load_class(PythonProxy *pp,
       } \
       Py_DECREF(pypath); \
     } \
+    bpy_import_main_set(NULL); \
     PyGILState_Release(state); \
     return value;
 

--- a/source/blender/python/generic/bpy_internal_import.c
+++ b/source/blender/python/generic/bpy_internal_import.c
@@ -108,6 +108,18 @@ struct Main *bpy_import_main_get(void)
 void bpy_import_main_set(struct Main *maggie)
 {
   bpy_import_main = maggie;
+
+  /* Also restores original blender reload method backed up in bpy_import_init at ge exit */
+  if (maggie == NULL) {
+    if (imp_reload_orig) {
+      PyObject *mod = PyImport_ImportModuleLevel("importlib", NULL, NULL, NULL, 0);
+      PyObject *mod_dict = PyModule_GetDict(mod);
+      PyDict_SetItemString(mod_dict, "reload", imp_reload_orig);
+      Py_DECREF(mod);
+      Py_DECREF(imp_reload_orig);
+      imp_reload_orig = NULL;
+    }
+  }
 }
 
 void bpy_import_main_extra_add(struct Main *maggie)

--- a/source/blender/python/generic/bpy_internal_import.c
+++ b/source/blender/python/generic/bpy_internal_import.c
@@ -48,6 +48,8 @@ static Main *bpy_import_main = NULL;
 static ListBase bpy_import_main_list;
 
 static PyMethodDef bpy_import_meth;
+static PyMethodDef bpy_reload_meth;
+static PyObject *imp_reload_orig = NULL;
 
 /* 'builtins' is most likely PyEval_GetBuiltins() */
 
@@ -66,9 +68,28 @@ static PyMethodDef bpy_import_meth;
 void bpy_import_init(PyObject *builtins)
 {
   PyObject *item;
+  PyObject *mod;
 
   PyDict_SetItemString(builtins, "__import__", item = PyCFunction_New(&bpy_import_meth, NULL));
   Py_DECREF(item);
+
+  /* move reload here
+   * XXX, use import hooks */
+  mod = PyImport_ImportModuleLevel("importlib", NULL, NULL, NULL, 0);
+  if (mod) {
+    PyObject *mod_dict = PyModule_GetDict(mod);
+
+    /* blender owns the function */
+    imp_reload_orig = PyDict_GetItemString(mod_dict, "reload");
+    Py_INCREF(imp_reload_orig);
+
+    PyDict_SetItemString(mod_dict, "reload", item = PyCFunction_New(&bpy_reload_meth, NULL));
+    Py_DECREF(item);
+    Py_DECREF(mod);
+  }
+  else {
+    BLI_assert(!"unable to load 'importlib' module.");
+  }
 }
 
 static void free_compiled_text(Text *text)
@@ -202,6 +223,61 @@ PyObject *bpy_text_import_name(const char *name, int *found)
   return bpy_text_import(text);
 }
 
+/*
+ * find in-memory module and recompile
+ */
+
+PyObject *bpy_text_reimport(PyObject *module, int *found)
+{
+  Text *text;
+  const char *name;
+  const char *filepath;
+  // XXX	Main *maggie = bpy_import_main ? bpy_import_main : G_MAIN;
+  Main *maggie = bpy_import_main;
+
+  if (!maggie) {
+    printf("ERROR: bpy_import_main_set() was not called before running python. this is a bug.\n");
+    return NULL;
+  }
+
+  *found = 0;
+
+  /* get name, filename from the module itself */
+  if ((name = PyModule_GetName(module)) == NULL) {
+    return NULL;
+  }
+
+  {
+    PyObject *module_file = PyModule_GetFilenameObject(module);
+    if (module_file == NULL) {
+      return NULL;
+    }
+    filepath = _PyUnicode_AsString(module_file);
+    Py_DECREF(module_file);
+    if (filepath == NULL) {
+      return NULL;
+    }
+  }
+
+  /* look up the text object */
+  text = BLI_findstring(&maggie->texts, BLI_path_basename(filepath), offsetof(ID, name) + 2);
+
+  /* uh-oh.... didn't find it */
+  if (!text) {
+    return NULL;
+  }
+  else {
+    *found = 1;
+  }
+
+  if (bpy_text_compile(text) == false) {
+    return NULL;
+  }
+
+  /* make into a module */
+  return PyImport_ExecCodeModule(name, text->compiled);
+}
+
 static PyObject *blender_import(PyObject *UNUSED(self), PyObject *args, PyObject *kw)
 {
   PyObject *exception, *err, *tb;
@@ -257,8 +333,57 @@ static PyObject *blender_import(PyObject *UNUSED(self), PyObject *args, PyObject
   return newmodule;
 }
 
+/*
+ * our reload() module, to handle reloading in-memory scripts
+ */
+
+static PyObject *blender_reload(PyObject *UNUSED(self), PyObject *module)
+{
+  PyObject *exception, *err, *tb;
+  PyObject *newmodule = NULL;
+  int found = 0;
+
+  /* try reimporting from file */
+
+  /* in Py3.3 this just calls imp.reload() which we overwrite, causing recursive calls */
+  // newmodule = PyImport_ReloadModule(module);
+
+  newmodule = PyObject_CallFunctionObjArgs(imp_reload_orig, module, NULL);
+
+  if (newmodule) {
+    return newmodule;
+  }
+
+  /* no file, try importing from memory */
+  PyErr_Fetch(&exception, &err, &tb); /*restore for probable later use */
+
+  newmodule = bpy_text_reimport(module, &found);
+  if (newmodule) { /* found module as blender text, ignore above exception */
+    PyErr_Clear();
+    Py_XDECREF(exception);
+    Py_XDECREF(err);
+    Py_XDECREF(tb);
+    /* printf("imported from text buffer...\n"); */
+  }
+  else if (found ==
+           1) { /* blender text module failed to execute but was found, use its error message */
+    Py_XDECREF(exception);
+    Py_XDECREF(err);
+    Py_XDECREF(tb);
+    return NULL;
+  }
+  else {
+    /* no blender text was found that could import the module
+     * reuse the original error from PyImport_ImportModuleEx */
+    PyErr_Restore(exception, err, tb);
+  }
+
+  return newmodule;
+}
 
 static PyMethodDef bpy_import_meth = {"bpy_import_meth",
                                       (PyCFunction)blender_import,
                                       METH_VARARGS | METH_KEYWORDS,
                                       "blenders import"};
+static PyMethodDef bpy_reload_meth = {
+    "bpy_reload_meth", (PyCFunction)blender_reload, METH_O, "blenders reload"};

--- a/source/blender/python/generic/bpy_internal_import.h
+++ b/source/blender/python/generic/bpy_internal_import.h
@@ -50,6 +50,7 @@ void bpy_text_filename_get(char *fn, size_t fn_len, struct Text *text);
 
 /* The game engine has its own Main struct, if this is set search this rather than G.main */
 struct Main *bpy_import_main_get(void);
+/* Also restores original blender reload method backed up in bpy_import_init at ge exit */
 void bpy_import_main_set(struct Main *maggie);
 
 /* This is used for importing text from dynamically loaded libraries in the game engine */


### PR DESCRIPTION
Since: https://github.com/UPBGE/upbge/commit/ccbf35bf672408e4406548266a352c4227ca508d
some errors which were reported in module mode in some cases were not
reported anymore. (was working in 0.2.5 for embedded Texts at least)

test file: 
[untitled.zip](https://github.com/UPBGE/upbge/files/8821136/untitled.zip)

In previous commit I reverted this and in this one I tried another
fix for the bug https://github.com/UPBGE/upbge/commit/ccbf35bf672408e4406548266a352c4227ca508d was fixing
about reloading scripts during runtime option on python controllers (D)

As I added a line in python_proxy.c and as it concerns 2 bugs, and as I'm not really comfortable with the code, I add all of you as reviewer if you can quickly test and/or review code if you want.

Thanks!

- Not reported errors test file: [untitled.zip](https://git
[untitled.zip](https://github.com/UPBGE/upbge/files/8821174/untitled.zip)


- Python Controller Debug option: 
[001_reloadme.zip](https://github.com/UPBGE/upbge/files/8821169/001_reloadme.zip)

EDIT: After this commit i'll also add an extra debug info for an error which is sometimes spawned for a reason I don't get (both in master and here when calling bpy_text_import_name: This message is sometimes spawned: ERROR: bpy_import_main_set() was not called before running python. this is a bug.)
I'll add the name of the module trying to be imported to try to understand why maggie is not set.