### PR TITLE
Update platform_unix.cmake

### DIFF
--- a/build_files/cmake/platform/platform_unix.cmake
+++ b/build_files/cmake/platform/platform_unix.cmake
@@ -480,7 +480,7 @@ if(WITH_LLVM)
   endif()
   # Symbol conflicts with same UTF library used by OpenCollada
   if(EXISTS ${LIBDIR})
-    if(WITH_OPENCOLLADA AND (${LLVM_VERSION} VERSION_LESS "4.0.0"))
+    if(WITH_OPENCOLLADA AND LLVM_VERSION VERSION_LESS 4.0.0)
       list(REMOVE_ITEM OPENCOLLADA_LIBRARIES ${OPENCOLLADA_UTF_LIBRARY})
     endif()
   endif()


### PR DESCRIPTION
Doesn't need ${} to test llvm_version nor quotes around 4.0.0
This prevented compilation when using precompiled libraries.

