### PR TITLE
Fix compile problem due to missing avcodec header

### DIFF
--- a/source/gameengine/VideoTexture/VideoFFmpeg.h
+++ b/source/gameengine/VideoTexture/VideoFFmpeg.h
@@ -21,6 +21,7 @@
 
 extern "C" {
 #  include "ffmpeg_compat.h"
+#  include <libavcodec/avcodec.h>
 #  include <pthread.h>
 }
 


### PR DESCRIPTION
This fixes the building problem due to a missing include statement of `avcodec.h`.

I'm not entirely sure why it's only happening when building UPBGE on Linux with system dependencies or if it's the correct way to address the problem.

But it looks to solve the issue on my end so I'd appreciate if someone more knowledgeable (reads, either youle or ExxiL 😉) could verify the change.

Thanks!
