### PR TITLE
UPBGE: Attempt to fix issues with Bricky Nodes

### DIFF
--- a/source/blender/editors/space_logic/logic_ops.c
+++ b/source/blender/editors/space_logic/logic_ops.c
@@ -920,7 +920,7 @@ static void LOGIC_OT_custom_object_register(wmOperatorType *ot)
   ot->poll = ED_operator_object_active_editable;
 
   /* flags */
-  ot->flag = 0;
+  ot->flag = OPTYPE_REGISTER;
 
   PropertyRNA *parm;
   parm = RNA_def_string(ot->srna,
@@ -944,7 +944,7 @@ static void LOGIC_OT_custom_object_create(wmOperatorType *ot)
   ot->poll = ED_operator_object_active_editable;
 
   /* flags */
-  ot->flag = 0;
+  ot->flag = OPTYPE_REGISTER;
 
   PropertyRNA *parm;
   parm = RNA_def_string(ot->srna,
@@ -993,7 +993,7 @@ static void LOGIC_OT_custom_object_remove(wmOperatorType *ot)
   ot->poll = remove_component_poll;
 
   /* flags */
-  ot->flag = 0;
+  ot->flag = OPTYPE_REGISTER;
 }
 
 static int custom_object_reload_exec(bContext *C, wmOperator *op)
@@ -1030,7 +1030,7 @@ static void LOGIC_OT_custom_object_reload(wmOperatorType *ot)
   ot->poll = ED_operator_object_active_editable;
 
   /* flags */
-  ot->flag = 0;
+  ot->flag = OPTYPE_REGISTER;
 }
 
 /* Component operators */
@@ -1098,7 +1098,7 @@ static void LOGIC_OT_python_component_register(wmOperatorType *ot)
   ot->poll = ED_operator_object_active_editable;
 
   /* flags */
-  ot->flag = 0;
+  ot->flag = OPTYPE_REGISTER;
 
   PropertyRNA *parm;
   parm = RNA_def_string(ot->srna,
@@ -1122,7 +1122,7 @@ static void LOGIC_OT_python_component_create(wmOperatorType *ot)
   ot->poll = ED_operator_object_active_editable;
 
   /* flags */
-  ot->flag = 0;
+  ot->flag = OPTYPE_REGISTER;
 
   PropertyRNA *parm;
   parm = RNA_def_string(ot->srna,
@@ -1172,7 +1172,7 @@ static void LOGIC_OT_python_component_remove(wmOperatorType *ot)
   ot->poll = remove_component_poll;
 
   /* flags */
-  ot->flag = 0;
+  ot->flag = OPTYPE_REGISTER;
 
   /* properties */
   RNA_def_int(ot->srna, "index", 0, 0, INT_MAX, "Index", "Component index to remove", 0, INT_MAX);
@@ -1241,7 +1241,7 @@ static void LOGIC_OT_python_component_move_up(wmOperatorType *ot)
   ot->poll = component_move_up_poll;
 
   /* flags */
-  ot->flag = 0;
+  ot->flag = OPTYPE_REGISTER;
 
   /* properties */
   RNA_def_int(ot->srna, "index", 0, 0, INT_MAX, "Index", "Component index to move", 0, INT_MAX);
@@ -1317,7 +1317,7 @@ static void LOGIC_OT_python_component_move_down(wmOperatorType *ot)
   ot->poll = component_move_down_poll;
 
   /* flags */
-  ot->flag = 0;
+  ot->flag = OPTYPE_REGISTER;
 
   /* properties */
   RNA_def_int(ot->srna, "index", 0, 0, INT_MAX, "Index", "Component index to move", 0, INT_MAX);
@@ -1366,7 +1366,7 @@ static void LOGIC_OT_python_component_reload(wmOperatorType *ot)
   ot->poll = ED_operator_object_active_editable;
 
   /* flags */
-  ot->flag = 0;
+  ot->flag = OPTYPE_REGISTER;
 
   /* properties */
   RNA_def_int(ot->srna, "index", 0, 0, INT_MAX, "Index", "Component index to reload", 0, INT_MAX);

--- a/source/blender/editors/space_logic/logic_ops.c
+++ b/source/blender/editors/space_logic/logic_ops.c
@@ -309,7 +309,7 @@ static void LOGIC_OT_sensor_remove(wmOperatorType *ot)
   ot->poll = edit_sensor_poll;
 
   /* flags */
-  ot->flag = 0;
+  ot->flag = OPTYPE_REGISTER | OPTYPE_INTERNAL;
   edit_sensor_properties(ot);
 }
 
@@ -369,7 +369,7 @@ static void LOGIC_OT_sensor_add(wmOperatorType *ot)
   ot->poll = ED_operator_object_active_editable;
 
   /* flags */
-  ot->flag = 0;
+  ot->flag = OPTYPE_REGISTER | OPTYPE_INTERNAL;
 
   /* properties */
   ot->prop = prop = RNA_def_enum(
@@ -422,7 +422,7 @@ static void LOGIC_OT_controller_remove(wmOperatorType *ot)
   ot->poll = edit_controller_poll;
 
   /* flags */
-  ot->flag = 0;
+  ot->flag = OPTYPE_REGISTER | OPTYPE_INTERNAL;
   edit_controller_properties(ot);
 }
 
@@ -501,7 +501,7 @@ static void LOGIC_OT_controller_add(wmOperatorType *ot)
   ot->poll = ED_operator_object_active_editable;
 
   /* flags */
-  ot->flag = 0;
+  ot->flag = OPTYPE_REGISTER | OPTYPE_INTERNAL;
 
   /* properties */
   ot->prop = RNA_def_enum(ot->srna,
@@ -557,7 +557,7 @@ static void LOGIC_OT_actuator_remove(wmOperatorType *ot)
   ot->poll = edit_actuator_poll;
 
   /* flags */
-  ot->flag = 0;
+  ot->flag = OPTYPE_REGISTER | OPTYPE_INTERNAL;
   edit_actuator_properties(ot);
 }
 
@@ -617,7 +617,7 @@ static void LOGIC_OT_actuator_add(wmOperatorType *ot)
   ot->poll = ED_operator_object_active_editable;
 
   /* flags */
-  ot->flag = 0;
+  ot->flag = OPTYPE_REGISTER | OPTYPE_INTERNAL;
 
   /* properties */
   ot->prop = prop = RNA_def_enum(
@@ -673,7 +673,7 @@ static void LOGIC_OT_sensor_move(wmOperatorType *ot)
   ot->poll = edit_sensor_poll;
 
   /* flags */
-  ot->flag = 0;
+  ot->flag = OPTYPE_REGISTER | OPTYPE_INTERNAL;
 
   /* properties */
   edit_sensor_properties(ot);
@@ -720,7 +720,7 @@ static void LOGIC_OT_controller_move(wmOperatorType *ot)
   ot->poll = edit_controller_poll;
 
   /* flags */
-  ot->flag = 0;
+  ot->flag = OPTYPE_REGISTER | OPTYPE_INTERNAL;
 
   /* properties */
   edit_controller_properties(ot);
@@ -767,7 +767,7 @@ static void LOGIC_OT_actuator_move(wmOperatorType *ot)
   ot->poll = edit_actuator_poll;
 
   /* flags */
-  ot->flag = 0;
+  ot->flag = OPTYPE_REGISTER | OPTYPE_INTERNAL;
 
   /* properties */
   edit_actuator_properties(ot);


### PR DESCRIPTION
There were reports here: https://github.com/UPBGE/upbge/issues/1718 and on discord about Bricky Nodes addon crashes.

I saw it was related to changes I did in logic_ops related to undo (to use old undo for logic operators).

It seems this code avoids some crashes, even if I don't know exactly what happens internally.

IzaZed and arch-sketch tested and confirmed it was better after this patch.
