### PR TITLE
Fix typos in doc/ subdirectory

### DIFF
--- a/doc/python_api/examples/bge.texture.2.py
+++ b/doc/python_api/examples/bge.texture.2.py
@@ -7,7 +7,7 @@ cover all common video capture cases.
 
 This file reflects the current video transfer method implemented in the Decklink module:
 whenever possible the video images are transferred as float texture because this is more
-compatible with GPUs. Of course, only the pixel formats that have a correspondant GL format
+compatible with GPUs. Of course, only the pixel formats that have a correspondent GL format
 can be transferred as float. Look for fg_shaders in this file for an exhaustive list.
 
 Other pixel formats will be transferred as 32 bits integer red-channel texture but this
@@ -184,7 +184,7 @@ FragmentShader_v210 = """
 """
 
 # The exhausitve list of pixel formats that are transferred as float texture
-# Only use those for greater efficiency and compatiblity.
+# Only use those for greater efficiency and compatibility.
 #
 fg_shaders = {
     '2vuy'       :FragmentShader_2vuy,

--- a/doc/python_api/examples/bpy.types.Operator.py
+++ b/doc/python_api/examples/bpy.types.Operator.py
@@ -9,7 +9,7 @@ user input.
 
 The function should return ``{'FINISHED'}`` or ``{'CANCELLED'}``, the latter
 meaning that operator execution was aborted without making any changes, and
-saving an undo entry isn't neccesary. If an error is detected after some changes
+saving an undo entry isn't necessary. If an error is detected after some changes
 have already been made, use the ``{'FINISHED'}`` return code, or the behavior
 of undo will be confusing for the user.
 

--- a/doc/python_api/examples/bpy.types.USDHook.py
+++ b/doc/python_api/examples/bpy.types.USDHook.py
@@ -3,7 +3,7 @@ USD Hook Example
 ++++++++++++++++
 
 This example shows an implementation of ``USDHook`` to extend USD
-export functionalty.
+export functionality.
 
 One may optionally define one or both of the following callback functions
 in the ``USDHook`` subclass.
@@ -35,7 +35,7 @@ The hook functions should return ``True`` on success or ``False`` if the operati
 otherwise failed to complete.  Exceptions raised by these functions will be reported in Blender, with
 the exception details printed to the console.
 
-The ``USDHookExample`` class in this example impements an ``on_export()`` function to add custom data to
+The ``USDHookExample`` class in this example implements an ``on_export()`` function to add custom data to
 the stage's root layer and an ``on_material_export()`` function to create a simple ``MaterialX`` shader
 on the USD material.
 

--- a/doc/python_api/examples/mathutils.Matrix.py
+++ b/doc/python_api/examples/mathutils.Matrix.py
@@ -4,7 +4,7 @@ import math
 # create a location matrix
 mat_loc = mathutils.Matrix.Translation((2.0, 3.0, 4.0))
 
-# create an identitiy matrix
+# create an identity matrix
 mat_sca = mathutils.Matrix.Scale(0.5, 4, (0.0, 0.0, 1.0))
 
 # create a rotation matrix

--- a/doc/python_api/rst/bge.constraints.rst
+++ b/doc/python_api/rst/bge.constraints.rst
@@ -340,7 +340,7 @@ Debug mode to be used with :func:`setDebugMode`.
 
 .. data:: DBG_ENABLESATCOMPARISION
 
-   Enable sat comparision in debug.
+   Enable sat comparison in debug.
 
    :type: integer
 
@@ -352,7 +352,7 @@ Debug mode to be used with :func:`setDebugMode`.
 
 .. data:: DBG_ENABLECCD
 
-   Enable Continous Collision Detection in debug.
+   Enable Continuous Collision Detection in debug.
 
    :type: integer
 

--- a/doc/python_api/rst/bge.logic.rst
+++ b/doc/python_api/rst/bge.logic.rst
@@ -352,7 +352,7 @@ General functions
    :return: The physics update frequency in Hz
    :rtype: float
    
-   .. warning: Not implimented yet
+   .. warning: Not implemented yet
 
 .. function:: setPhysicsTicRate(ticrate)
 
@@ -364,7 +364,7 @@ General functions
    :arg ticrate: The new update frequency (in Hz).
    :type ticrate: float
 
-   .. warning: Not implimented yet
+   .. warning: Not implemented yet
 
 .. function:: getExitKey()
 

--- a/doc/python_api/rst/bge.render.rst
+++ b/doc/python_api/rst/bge.render.rst
@@ -90,7 +90,7 @@ Constants
 
    Enables adaptive vsync if supported.
    Adaptive vsync enables vsync if the framerate is above the monitors refresh rate.
-   Otherwise, vsync is diabled if the framerate is too low.
+   Otherwise, vsync is disabled if the framerate is too low.
 
    :type: integer
 
@@ -244,7 +244,7 @@ Functions
 
    .. deprecated:: 0.3.0
 
-   Sets the eye separation for stereo mode. Usually Focal Length/30 provides a confortable value.
+   Sets the eye separation for stereo mode. Usually Focal Length/30 provides a comfortable value.
 
    :arg eyesep: The distance between the left and right eye.
    :type eyesep: float
@@ -361,7 +361,7 @@ Functions
 
    Enable the motion blur effect.
 
-   :arg factor: the ammount of motion blur to display.
+   :arg factor: the amount of motion blur to display.
    :type factor: float [0.0 - 1.0]
 
 

--- a/doc/python_api/rst/bge.texture.rst
+++ b/doc/python_api/rst/bge.texture.rst
@@ -464,7 +464,7 @@ Image classes
 
       .. deprecated:: 0.3.0
 
-      Choose to force shadow buffer update if there is a gap beetween image rendered and shadows.
+      Choose to force shadow buffer update if there is a gap between image rendered and shadows.
 
       :type: bool
 
@@ -722,7 +722,7 @@ Image classes
 
       .. deprecated:: 0.3.0
 
-      Choose to force shadow buffer update if there is a gap beetween image rendered and shadows.
+      Choose to force shadow buffer update if there is a gap between image rendered and shadows.
 
       :type: bool
 
@@ -1225,7 +1225,7 @@ Texture classes
       :type refresh_source: bool
       :arg timestamp: If the texture controls a VideoFFmpeg object:
          timestamp (in seconds from the start of the movie) of the frame to be loaded; this can be
-         used for video-sound synchonization by passing :attr:`~bge.types.KX_SoundActuator.time` to it. (optional)
+         used for video-sound synchronization by passing :attr:`~bge.types.KX_SoundActuator.time` to it. (optional)
       :type timestamp: float
 
    .. attribute:: source
@@ -1379,11 +1379,11 @@ Filter classes
    Filter for Blue Screen.
    The RGB channels of the color are left unchanged, while the output alpha is obtained as follows:
 
-   - if the square of the euclidian distance between the RGB color
+   - if the square of the euclidean distance between the RGB color
      and the filter's reference color is smaller than the filter's lower limit,
      the output alpha is set to 0;
    - if that square is bigger than the filter's upper limit, the output alpha is set to 255;
-   - otherwise the output alpha is linarly extrapoled between 0 and 255 in the interval of the limits.
+   - otherwise the output alpha is linearly extrapolated between 0 and 255 in the interval of the limits.
 
    .. attribute:: color
 
@@ -1470,7 +1470,7 @@ Filter classes
 
    * if it is bigger than its corresponding max value, it is set to 255;
 
-   * Otherwise it is linearly extrapoled between 0 and 255 in the (min, max) interval.
+   * Otherwise it is linearly extrapolated between 0 and 255 in the (min, max) interval.
 
    .. attribute:: levels
 

--- a/doc/python_api/rst/bge_types/bge.types.BL_ArmatureObject.rst
+++ b/doc/python_api/rst/bge_types/bge.types.BL_ArmatureObject.rst
@@ -28,9 +28,9 @@ base class --- :class:`~bge.types.KX_GameObject`
 
       Ensures that the armature will be updated on next graphic frame.
 
-      This action is unecessary if a KX_ArmatureActuator with mode run is active
+      This action is unnecessary if a KX_ArmatureActuator with mode run is active
       or if an action is playing. Use this function in other cases. It must be called
-      on each frame to ensure that the armature is updated continously.
+      on each frame to ensure that the armature is updated continuously.
 
    .. method:: draw()
 

--- a/doc/python_api/rst/bge_types/bge.types.EXP_ListValue.rst
+++ b/doc/python_api/rst/bge_types/bge.types.EXP_ListValue.rst
@@ -54,7 +54,7 @@ base class --- :class:`~bge.types.EXP_PropValue`
 
    .. method:: from_id(id)
 
-      This is a funtion especially for the game engine to return a value with a spesific id.
+      This is a function especially for the game engine to return a value with a specific id.
 
       Since object names are not always unique, the id of an object can be used to get an object from the CValueList.
 

--- a/doc/python_api/rst/bge_types/bge.types.KX_2DFilter.rst
+++ b/doc/python_api/rst/bge_types/bge.types.KX_2DFilter.rst
@@ -7,7 +7,7 @@ base class --- :class:`~bge.types.BL_Shader`
 
 .. class:: KX_2DFilter
 
-   2D filter shader object. Can be alterated with :class:`~bge.types.BL_Shader`'s functions.
+   2D filter shader object. Can be alternated with :class:`~bge.types.BL_Shader`'s functions.
 
    .. warning::
 

--- a/doc/python_api/rst/bge_types/bge.types.KX_ConstraintWrapper.rst
+++ b/doc/python_api/rst/bge_types/bge.types.KX_ConstraintWrapper.rst
@@ -11,14 +11,14 @@ base class --- :class:`~bge.types.EXP_PyObjectPlus`
 
    .. method:: getConstraintId(val)
 
-      Returns the contraint ID
+      Returns the constraint ID
 
       :return: the constraint ID
       :rtype: integer
 
    .. method:: setParam(axis, value0, value1)
 
-      Set the contraint limits
+      Set the constraint limits
 
       :arg axis:
       :type axis: integer
@@ -101,7 +101,7 @@ base class --- :class:`~bge.types.EXP_PyObjectPlus`
 
    .. method:: getParam(axis)
 
-      Get the contraint position or euler angle of a generic 6DOF constraint
+      Get the constraint position or euler angle of a generic 6DOF constraint
 
       :arg axis:
       :type axis: integer
@@ -124,13 +124,13 @@ base class --- :class:`~bge.types.EXP_PyObjectPlus`
 
    .. attribute:: constraint_id
 
-      Returns the contraint ID  (read only)
+      Returns the constraint ID  (read only)
 
       :type: integer
 
    .. attribute:: constraint_type
 
-      Returns the contraint type (read only)
+      Returns the constraint type (read only)
 
       :type: integer
 

--- a/doc/python_api/rst/bge_types/bge.types.KX_GameObject.rst
+++ b/doc/python_api/rst/bge_types/bge.types.KX_GameObject.rst
@@ -528,7 +528,7 @@ base class --- :class:`~bge.types.SCA_IObject`
 
       .. note::
 
-         This attribute is experemental and may be removed (but probably wont be).
+         This attribute is experimental and may be removed (but probably wont be).
 
       .. note::
 
@@ -914,7 +914,7 @@ base class --- :class:`~bge.types.SCA_IObject`
 
    .. method:: setCcdSweptSphereRadius(ccd_swept_sphere_radius)
 
-      Sets :py:attr:`ccdSweptSphereRadius` that is the radius of the sphere that is used to check for possible collisions when ccd is actived.
+      Sets :py:attr:`ccdSweptSphereRadius` that is the radius of the sphere that is used to check for possible collisions when ccd is activated.
 
       :arg ccd_swept_sphere_radius: sphere radius.
       :type ccd_swept_sphere_radius: float ∈ [0, 10]

--- a/doc/python_api/rst/bge_types/bge.types.KX_MeshProxy.rst
+++ b/doc/python_api/rst/bge_types/bge.types.KX_MeshProxy.rst
@@ -93,7 +93,7 @@ base class --- :class:`~bge.types.EXP_Value`
 
       :arg matid: the specified material
       :type matid: integer
-      :return: the number of verticies in the vertex array.
+      :return: the number of vertices in the vertex array.
       :rtype: integer
 
    .. method:: getVertex(matid, index)

--- a/doc/python_api/rst/bge_types/bge.types.SCA_DelaySensor.rst
+++ b/doc/python_api/rst/bge_types/bge.types.SCA_DelaySensor.rst
@@ -13,7 +13,7 @@ base class --- :class:`~bge.types.SCA_ISensor`
    The duration parameter defines the length of the ON period following the OFF period.
    There is a negative trigger at the end of the ON period. If duration is 0, the sensor stays ON and there is no negative trigger.
 
-   The sensor runs the OFF-ON cycle once unless the repeat option is set: the OFF-ON cycle repeats indefinately (or the OFF cycle if duration is 0).
+   The sensor runs the OFF-ON cycle once unless the repeat option is set: the OFF-ON cycle repeats indefinitely (or the OFF cycle if duration is 0).
 
    Use :meth:`SCA_ISensor.reset <bge.types.SCA_ISensor.reset>` at any time to restart sensor.
 
@@ -33,6 +33,6 @@ base class --- :class:`~bge.types.SCA_ISensor`
 
    .. attribute:: repeat
 
-      1 if the OFF-ON cycle should be repeated indefinately, 0 if it should run once.
+      1 if the OFF-ON cycle should be repeated indefinitely, 0 if it should run once.
 
       :type: integer

--- a/doc/python_api/rst/bge_types/bge.types.SCA_ISensor.rst
+++ b/doc/python_api/rst/bge_types/bge.types.SCA_ISensor.rst
@@ -52,7 +52,7 @@ base class --- :class:`~bge.types.SCA_ILogicBrick`
 
       When enabled only sensors that are just activated will send a positive event,
       after this they will be detected as negative by the controllers.
-      This will make a key thats held act as if its only tapped for an instant.
+      This will make a key that's held act as if its only tapped for an instant.
       note: mutually exclusive with :attr:`level`, enabling will disable :attr:`level`.
 
       :type: boolean

--- a/doc/python_api/rst/bge_types/bge.types.SCA_JoystickSensor.rst
+++ b/doc/python_api/rst/bge_types/bge.types.SCA_JoystickSensor.rst
@@ -16,7 +16,7 @@ base class --- :class:`~bge.types.SCA_ISensor`
       :type: list of ints.
 
       Each specifying the value of an axis between -32767 and 32767 depending on how far the axis is pushed, 0 for nothing.
-      The first 2 values are used by most joysticks and gamepads for directional control. 3rd and 4th values are only on some joysticks and can be used for arbitary controls.
+      The first 2 values are used by most joysticks and gamepads for directional control. 3rd and 4th values are only on some joysticks and can be used for arbitrary controls.
 
       * left:[-32767, 0, ...]
       * right:[32767, 0, ...]

--- a/doc/python_api/rst/bge_types/bge.types.SCA_MouseFocusSensor.rst
+++ b/doc/python_api/rst/bge_types/bge.types.SCA_MouseFocusSensor.rst
@@ -38,7 +38,7 @@ base class --- :class:`~bge.types.SCA_MouseSensor`
 
    .. attribute:: hitPosition
 
-      The worldspace position of the ray intersecton.
+      The worldspace position of the ray intersection.
 
       :type: list (vector of 3 floats)
 

--- a/doc/python_api/rst/bge_types/bge.types.SCA_MouseSensor.rst
+++ b/doc/python_api/rst/bge_types/bge.types.SCA_MouseSensor.rst
@@ -13,7 +13,7 @@ base class --- :class:`~bge.types.SCA_ISensor`
 
       current [x, y] coordinates of the mouse, in frame coordinates (pixels).
 
-      :type: [integer, interger]
+      :type: [integer, integer]
 
    .. attribute:: mode
 

--- a/doc/python_api/rst/bge_types/bge.types.SCA_PythonController.rst
+++ b/doc/python_api/rst/bge_types/bge.types.SCA_PythonController.rst
@@ -18,10 +18,10 @@ base class --- :class:`~bge.types.SCA_IController`
 
    .. attribute:: script
 
-      The value of this variable depends on the execution methid.
+      The value of this variable depends on the execution method.
 
       * When 'Script' execution mode is set this value contains the entire python script as a single string (not the script name as you might expect) which can be modified to run different scripts.
-      * When 'Module' execution mode is set this value will contain a single line string - module name and function "module.func" or "package.modile.func" where the module names are python textblocks or external scripts.
+      * When 'Module' execution mode is set this value will contain a single line string - module name and function "module.func" or "package.module.func" where the module names are python textblocks or external scripts.
 
       :type: string
 

--- a/doc/python_api/rst/bge_types/bge.types.SCA_PythonJoystick.rst
+++ b/doc/python_api/rst/bge_types/bge.types.SCA_PythonJoystick.rst
@@ -30,7 +30,7 @@ base class --- :class:`~bge.types.EXP_PyObjectPlus`
       Each specifying the value of an axis between -1.0 and 1.0
       depending on how far the axis is pushed, 0 for nothing.
       The first 2 values are used by most joysticks and gamepads for directional control.
-      3rd and 4th values are only on some joysticks and can be used for arbitary controls.
+      3rd and 4th values are only on some joysticks and can be used for arbitrary controls.
 
       * left:[-1.0, 0.0, ...]
       * right:[1.0, 0.0, ...]

--- a/doc/python_api/rst/bge_types/bge.types.SCA_RandomActuator.rst
+++ b/doc/python_api/rst/bge_types/bge.types.SCA_RandomActuator.rst
@@ -90,7 +90,7 @@ base class --- :class:`~bge.types.SCA_IActuator`
       Generate a Poisson-distributed number.
 
       This performs a series of Bernouilli tests with parameter value.
-      It returns the number of tries needed to achieve succes.
+      It returns the number of tries needed to achieve success.
 
       :type value: float
 

--- a/doc/python_api/rst/bgui/widget.rst
+++ b/doc/python_api/rst/bgui/widget.rst
@@ -128,7 +128,7 @@ Mouse event states:
 
       Move a widget to a new position over a number of frames.
 
-      :arg positon: The new position
+      :arg position: The new position
       :arg time: The time in milliseconds to take doing the move
       :arg callback: An optional callback that is called when he animation is complete
 

--- a/doc/python_api/sphinx_changelog_gen.py
+++ b/doc/python_api/sphinx_changelog_gen.py
@@ -26,7 +26,7 @@ blender --background --factory-startup --python doc/python_api/sphinx_changelog_
 
 # Api comparison can also run without blender,
 # will by default generate changeloig between the last two available versions listed in the index,
-# unless input files are provided explicitely:
+# unless input files are provided explicitly:
 python doc/python_api/sphinx_changelog_gen.py -- \
         --indexpath="path/to/api/docs/api_dump_index.json" \
         changelog --filepath-in-from blender_api_2_63_0.json \


### PR DESCRIPTION
Found via `codespell -q 3 -S "*.diff,*.po,./AUTHORS,./extern" -L aci,alo,ans,bu,buildt,childs,ccompiler,clen,datas,dependees,eiter,espace,fiter,fpt,inout,inouts,lod,mata,mis,mot,nd,numer,ot,parm,parms,pinter,pixelx,poin,re-use,seh,te,thi,toi,ue`

Any chance this can be merged on projects.blender.org ?