### PR TITLE
add GetColorTexture and GetDepthTexture to KX_FilterFrameBuffer

### DIFF
--- a/doc/python_api/rst/bge_types/bge.types.KX_2DFilterFrameBuffer.rst
+++ b/doc/python_api/rst/bge_types/bge.types.KX_2DFilterFrameBuffer.rst
@@ -36,3 +36,17 @@ base class --- :class:`~bge.types.EXP_Value`
       .. warning:: If the off screen can be resized dynamically (:data:`width` of :data:`height` equal to -1), the bind code may change.
 
       :type: integer
+
+   .. method:: getColorTexture(slot=0)
+      Returns the color buffer as texture.
+
+      :arg slot: index of the slot (0-7).
+      :type vect: integer
+      :return: Texture object.
+      :rtype: :class:`~gpu.types.GPUTexture`
+
+   .. method:: getDepthTexture()
+      Returns the depth buffer as texture.
+
+      :return: Texture object.
+      :rtype: :class:`~gpu.types.GPUTexture`

--- a/doc/python_api/rst/bge_types/bge.types.KX_2DFilterFrameBuffer.rst
+++ b/doc/python_api/rst/bge_types/bge.types.KX_2DFilterFrameBuffer.rst
@@ -41,7 +41,7 @@ base class --- :class:`~bge.types.EXP_Value`
       Returns the color buffer as texture.
 
       :arg slot: index of the slot (0-7).
-      :type vect: integer
+      :type slot: integer
       :return: Texture object.
       :rtype: :class:`~gpu.types.GPUTexture`
 

--- a/source/gameengine/Ketsji/KX_2DFilterFrameBuffer.cpp
+++ b/source/gameengine/Ketsji/KX_2DFilterFrameBuffer.cpp
@@ -27,6 +27,7 @@
 #include "KX_2DFilterFrameBuffer.h"
 
 #include "EXP_ListWrapper.h"
+#include "../../blender/python/gpu/gpu_py_texture.h"
 
 KX_2DFilterFrameBuffer::KX_2DFilterFrameBuffer(unsigned short colorSlots,
                                                Flag flag,
@@ -87,9 +88,10 @@ PyTypeObject KX_2DFilterFrameBuffer::Type = {
     py_base_new};
 
 PyMethodDef KX_2DFilterFrameBuffer::Methods[] = {
+    {"getColorTexture", (PyCFunction)KX_2DFilterFrameBuffer::sPyGetColorTexture, METH_VARARGS},
+    {"getDepthTexture", (PyCFunction)KX_2DFilterFrameBuffer::sPyGetDepthTexture, METH_VARARGS},
     {nullptr, nullptr}  // Sentinel
 };
-
 PyAttributeDef KX_2DFilterFrameBuffer::Attributes[] = {
     EXP_PYATTRIBUTE_RO_FUNCTION("width", KX_2DFilterFrameBuffer, pyattr_get_width),
     EXP_PYATTRIBUTE_RO_FUNCTION("height", KX_2DFilterFrameBuffer, pyattr_get_height),
@@ -145,5 +147,27 @@ PyObject *KX_2DFilterFrameBuffer::pyattr_get_depthBindCode(EXP_PyObjectPlus *sel
   KX_2DFilterFrameBuffer *self = static_cast<KX_2DFilterFrameBuffer *>(self_v);
   return PyLong_FromLong(self->GetDepthBindCode());
 }
+
+PyObject *KX_2DFilterFrameBuffer::PyGetColorTexture(PyObject *args)
+{
+  int slot = 0;
+  if (PyArg_ParseTuple(args, "|i:getColorTexture", &slot)) {
+    GPUTexture *tex = GetColorTexture(slot);
+    if (tex) {
+      return BPyGPUTexture_CreatePyObject(tex, true);
+    }
+  }
+  Py_RETURN_NONE;
+}
+
+PyObject *KX_2DFilterFrameBuffer::PyGetDepthTexture(PyObject *args)
+{
+  GPUTexture *tex = GetDepthTexture();
+  if (tex) {
+    return BPyGPUTexture_CreatePyObject(tex, true);
+  }
+  Py_RETURN_NONE;
+}
+
 
 #endif  // WITH_PYTHON

--- a/source/gameengine/Ketsji/KX_2DFilterFrameBuffer.cpp
+++ b/source/gameengine/Ketsji/KX_2DFilterFrameBuffer.cpp
@@ -92,6 +92,7 @@ PyMethodDef KX_2DFilterFrameBuffer::Methods[] = {
     {"getDepthTexture", (PyCFunction)KX_2DFilterFrameBuffer::sPyGetDepthTexture, METH_VARARGS},
     {nullptr, nullptr}  // Sentinel
 };
+
 PyAttributeDef KX_2DFilterFrameBuffer::Attributes[] = {
     EXP_PYATTRIBUTE_RO_FUNCTION("width", KX_2DFilterFrameBuffer, pyattr_get_width),
     EXP_PYATTRIBUTE_RO_FUNCTION("height", KX_2DFilterFrameBuffer, pyattr_get_height),

--- a/source/gameengine/Ketsji/KX_2DFilterFrameBuffer.h
+++ b/source/gameengine/Ketsji/KX_2DFilterFrameBuffer.h
@@ -40,6 +40,8 @@ class KX_2DFilterFrameBuffer : public EXP_Value, public RAS_2DFilterFrameBuffer 
 
 #ifdef WITH_PYTHON
 
+  EXP_PYMETHOD_VARARGS(KX_2DFilterFrameBuffer, GetColorTexture);
+  EXP_PYMETHOD_VARARGS(KX_2DFilterFrameBuffer, GetDepthTexture);
   static PyObject *pyattr_get_width(EXP_PyObjectPlus *self_v, const EXP_PYATTRIBUTE_DEF *attrdef);
   static PyObject *pyattr_get_height(EXP_PyObjectPlus *self_v, const EXP_PYATTRIBUTE_DEF *attrdef);
   static PyObject *pyattr_get_colorBindCodes(EXP_PyObjectPlus *self_v,

--- a/source/gameengine/Rasterizer/RAS_2DFilterFrameBuffer.cpp
+++ b/source/gameengine/Rasterizer/RAS_2DFilterFrameBuffer.cpp
@@ -155,6 +155,24 @@ int RAS_2DFilterFrameBuffer::GetDepthBindCode() const
   return GPU_texture_opengl_bindcode(m_depthTexture);
 }
 
+GPUTexture *RAS_2DFilterFrameBuffer::GetColorTexture(int slot)
+{
+  if (!m_colorTextures[slot]) {
+    return nullptr;
+  }
+  GPUTexture *texture = m_colorTextures[slot];
+  return texture;
+}
+
+GPUTexture *RAS_2DFilterFrameBuffer::GetDepthTexture()
+{
+  if (!m_depthTexture) {
+    return nullptr;
+  }
+  GPUTexture *texture = m_depthTexture;
+  return texture;
+}
+
 unsigned int RAS_2DFilterFrameBuffer::GetWidth() const
 {
   return m_width;

--- a/source/gameengine/Rasterizer/RAS_2DFilterFrameBuffer.h
+++ b/source/gameengine/Rasterizer/RAS_2DFilterFrameBuffer.h
@@ -82,6 +82,8 @@ class RAS_2DFilterFrameBuffer {
 
   int GetColorBindCode(unsigned short index) const;
   int GetDepthBindCode() const;
+  GPUTexture *GetColorTexture(int slot = 0);
+  GPUTexture *GetDepthTexture();
 
   unsigned int GetWidth() const;
   unsigned int GetHeight() const;


### PR DESCRIPTION
This feature allows `KX_FilterFrameBuffer` to provide a `GPUTexture` object when added as offscreen buffer. This texture can then be used in other shaders and the gpu module draw calls.

Usage:
```python
filter = bge.logic.getCurrentScene().filterManager.addFilter(0, 12, glsl)
filter.addOffScreen(0)
```
and then to get the texture (and use it as `uniform sampler custom_framebuffer` in glsl):
```python
texture_object = filter.offScreen.getColorTexture()
shader = GPUShader(...., ....)
shader.uniform_sampler('custom_framebuffer', texture_object)
```

Test File:
[Test04.zip](https://github.com/UPBGE/upbge/files/14284286/Test04.zip)
