### PR TITLE
Fix build problem due to missing metainfo.xml file

### DIFF
--- a/source/creator/CMakeLists.txt
+++ b/source/creator/CMakeLists.txt
@@ -810,7 +810,7 @@ file(REMOVE ${CMAKE_BINARY_DIR}/bin/lib/libglapi.so.0.0.0)\n
       DESTINATION "./share/applications"
     )
     install(
-      FILES ${CMAKE_SOURCE_DIR}/release/freedesktop/org.blender.Blender.metainfo.xml
+      FILES ${CMAKE_SOURCE_DIR}/release/freedesktop/org.upbge.UPBGE.metainfo.xml
       DESTINATION "./share/metainfo"
     )
     install(


### PR DESCRIPTION
Fix an invalid reference of a metainfo.xml file (changed by df563ed):

```
CMake Error at source/creator/cmake_install.cmake:270 (file):
  file INSTALL cannot find
  "/home/mysticfall/.cache/yay/upbge-git/src/upbge/release/freedesktop/org.blender.Blender.metainfo.xml":
  No such file or directory.
Call Stack (most recent call first):
  cmake_install.cmake:51 (include)


make: *** [Makefile:130: install] 오류 1
```
