### PR TITLE
Vehicle wrapper wheels orientation fix

### DIFF
--- a/extern/bullet2/src/BulletDynamics/Vehicle/btRaycastVehicle.cpp
+++ b/extern/bullet2/src/BulletDynamics/Vehicle/btRaycastVehicle.cpp
@@ -110,9 +110,9 @@ void btRaycastVehicle::updateWheelTransform(int wheelIndex, bool interpolatedTra
 	btMatrix3x3 rotatingMat(rotatingOrn);
 
 	btMatrix3x3 basis2;
-	basis2[0][m_indexRightAxis] = -right[0];
-	basis2[1][m_indexRightAxis] = -right[1];
-	basis2[2][m_indexRightAxis] = -right[2];
+	basis2[0][m_indexRightAxis] = right[0];
+	basis2[1][m_indexRightAxis] = right[1];
+	basis2[2][m_indexRightAxis] = right[2];
 
 	basis2[0][m_indexUpAxis] = up[0];
 	basis2[1][m_indexUpAxis] = up[1];


### PR DESCRIPTION
Orientation on wheels was mirrored due this sign. 

The attached blend was made by Musikai and stated the problem here:
https://blenderartists.org/t/vehicle-loose-wheels/1520846
[Vehicle_Loose_Wheels_279.zip](https://github.com/UPBGE/upbge/files/15284356/Vehicle_Loose_Wheels_279.zip)
