### PR TITLE
Fix build on Apple devices: `py_path_bundle` is not a C string

### DIFF
--- a/source/gameengine/Ketsji/KX_PythonInit.cpp
+++ b/source/gameengine/Ketsji/KX_PythonInit.cpp
@@ -2181,7 +2181,7 @@ void initGamePlayerPythonScripting(int argc, char **argv, bContext *C)
         /* Mac-OS allows file/directory names to contain `:` character
          * (represented as `/` in the Finder) but current Python lib (as of release 3.1.1)
          * doesn't handle these correctly. */
-        if (strchr(py_path_bundle, ':')) {
+        if (strchr(py_path_bundle->c_str(), ':')) {
           fprintf(stderr,
                   "Warning! Blender application is located in a path containing ':' or '/' chars\n"
                   "This may make python import function fail\n");
@@ -2424,7 +2424,7 @@ void initGamePythonScripting(Main *maggie, bContext *C, bool *audioDeviceIsIniti
         /* Mac-OS allows file/directory names to contain `:` character
          * (represented as `/` in the Finder) but current Python lib (as of release 3.1.1)
          * doesn't handle these correctly. */
-        if (strchr(py_path_bundle, ':')) {
+        if (strchr(py_path_bundle->c_str(), ':')) {
           fprintf(stderr,
                   "Warning! Blender application is located in a path containing ':' or '/' chars\n"
                   "This may make python import function fail\n");


### PR DESCRIPTION
Build was failing due to compile errors on macOS. It was trying to call strchr on py_path_bundle, but py_path_bundle was not a C string