### PR TITLE
UPBGE: Add a modifier for softbodies

### DIFF
--- a/source/blender/makesdna/DNA_modifier_defaults.h
+++ b/source/blender/makesdna/DNA_modifier_defaults.h
@@ -562,6 +562,11 @@
     .flag = 0, \
   }
 
+#define _DNA_DEFAULT_SimpleDeformModifierDataBGE \
+  { \
+    .vertcoos = NULL, \
+  }
+
 #define _DNA_DEFAULT_NodesModifierData \
   { \
     .bake_target = NODES_MODIFIER_BAKE_TARGET_PACKED, \

--- a/source/blender/makesdna/DNA_modifier_types.h
+++ b/source/blender/makesdna/DNA_modifier_types.h
@@ -129,6 +129,7 @@ typedef enum ModifierType {
   eModifierType_GreasePencilBuild = 84,
   eModifierType_GreasePencilSimplify = 85,
   eModifierType_GreasePencilTexture = 86,
+  eModifierType_SimpleDeformBGE = 87,
   NUM_MODIFIER_TYPES,
 } ModifierType;
 
@@ -1226,6 +1227,11 @@ typedef struct ShrinkwrapModifierData {
 
   char _pad[2];
 } ShrinkwrapModifierData;
+
+typedef struct SimpleDeformModifierDataBGE {
+  ModifierData modifier;
+  float (*vertcoos)[3];
+} SimpleDeformModifierDataBGE;
 
 typedef struct SimpleDeformModifierData {
   ModifierData modifier;

--- a/source/blender/makesdna/intern/dna_defaults.c
+++ b/source/blender/makesdna/intern/dna_defaults.c
@@ -294,6 +294,7 @@ SDNA_DEFAULT_DECL_STRUCT(ScrewModifierData);
 /* Shape key modifier has no items. */
 SDNA_DEFAULT_DECL_STRUCT(ShrinkwrapModifierData);
 SDNA_DEFAULT_DECL_STRUCT(SimpleDeformModifierData);
+SDNA_DEFAULT_DECL_STRUCT(SimpleDeformModifierDataBGE);
 SDNA_DEFAULT_DECL_STRUCT(NodesModifierData);
 SDNA_DEFAULT_DECL_STRUCT(SkinModifierData);
 SDNA_DEFAULT_DECL_STRUCT(SmoothModifierData);
@@ -584,6 +585,7 @@ const void *DNA_default_table[SDNA_TYPE_MAX] = {
     /* Shape key modifier has no items. */
     SDNA_DEFAULT_DECL(ShrinkwrapModifierData),
     SDNA_DEFAULT_DECL(SimpleDeformModifierData),
+    SDNA_DEFAULT_DECL(SimpleDeformModifierDataBGE),
     SDNA_DEFAULT_DECL(NodesModifierData),
     SDNA_DEFAULT_DECL(SkinModifierData),
     SDNA_DEFAULT_DECL(SmoothModifierData),

--- a/source/blender/modifiers/CMakeLists.txt
+++ b/source/blender/modifiers/CMakeLists.txt
@@ -31,6 +31,7 @@ set(SRC
   intern/MOD_curve.cc
   intern/MOD_datatransfer.cc
   intern/MOD_decimate.cc
+  intern/MOD_deform_bge.cc
   intern/MOD_displace.cc
   intern/MOD_dynamicpaint.cc
   intern/MOD_edgesplit.cc

--- a/source/blender/modifiers/MOD_modifiertypes.hh
+++ b/source/blender/modifiers/MOD_modifiertypes.hh
@@ -41,6 +41,7 @@ extern ModifierTypeInfo modifierType_Shrinkwrap;
 extern ModifierTypeInfo modifierType_Fluidsim;
 extern ModifierTypeInfo modifierType_Mask;
 extern ModifierTypeInfo modifierType_SimpleDeform;
+extern ModifierTypeInfo modifierType_SimpleDeformBGE;
 extern ModifierTypeInfo modifierType_Multires;
 extern ModifierTypeInfo modifierType_Surface;
 extern ModifierTypeInfo modifierType_Fluid;

--- a/source/blender/modifiers/intern/MOD_deform_bge.cc
+++ b/source/blender/modifiers/intern/MOD_deform_bge.cc
@@ -24,7 +24,11 @@
 static Mesh *modify_mesh(ModifierData *md, const ModifierEvalContext *ctx, Mesh *mesh)
 {
   SimpleDeformModifierDataBGE *smd = (SimpleDeformModifierDataBGE *)md;
-  Mesh *source = reinterpret_cast<Mesh *>(DEG_get_evaluated(ctx->depsgraph, &mesh->id));
+
+  if (smd->vertcoos == nullptr) {
+    return mesh;
+  }
+  Mesh *source = reinterpret_cast<Mesh *>(DEG_get_evaluated_id(ctx->depsgraph, &mesh->id));
   Mesh *result = BKE_mesh_copy_for_eval(*source);
 
   float(*positions)[3] = reinterpret_cast<float(*)[3]>(

--- a/source/blender/modifiers/intern/MOD_deform_bge.cc
+++ b/source/blender/modifiers/intern/MOD_deform_bge.cc
@@ -1,0 +1,99 @@
+/* SPDX-FileCopyrightText: 2005 Blender Authors
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later */
+
+/** \file
+ * \ingroup modifiers
+ */
+
+#include <algorithm>
+
+#include "BLI_math_matrix.h"
+#include "BLI_math_vector.h"
+#include "BLI_task.h"
+#include "BLI_utildefines.h"
+#include "BLT_translation.hh"
+
+#include "DEG_depsgraph_query.hh"
+
+#include "DNA_defaults.h"
+#include "DNA_object_types.h"
+#include "DNA_screen_types.h"
+
+#include "BKE_deform.hh"
+#include "BKE_mesh.hh"
+#include "BKE_mesh_runtime.hh"
+#include "BKE_modifier.hh"
+
+#include "UI_interface.hh"
+#include "UI_resources.hh"
+
+#include "RNA_access.hh"
+#include "RNA_prototypes.hh"
+
+#include "MOD_ui_common.hh"
+#include "MOD_util.hh"
+
+static Mesh *modify_mesh(ModifierData *md, const ModifierEvalContext *ctx, Mesh * /*mesh*/)
+{
+  SimpleDeformModifierDataBGE *smd = (SimpleDeformModifierDataBGE *)md;
+  Object *object_eval = DEG_get_evaluated(ctx->depsgraph, ctx->object);
+  Mesh *source = (Mesh *)object_eval->data;
+  Mesh *result = BKE_mesh_copy_for_eval(*source);
+
+  float(*positions)[3] = reinterpret_cast<float(*)[3]>(
+      result->vert_positions_for_write().data());
+
+  for (int i = 0; i < result->vert_positions().size(); i++) {
+    copy_v3_v3(positions[i], smd->vertcoos[i]);
+  }
+  result->tag_positions_changed();
+
+  return result;
+}
+
+/* SimpleDeform */
+static void init_data(ModifierData *md)
+{
+  SimpleDeformModifierDataBGE *smd = (SimpleDeformModifierDataBGE *)md;
+
+  BLI_assert(MEMCMP_STRUCT_AFTER_IS_ZERO(smd, modifier));
+
+  MEMCPY_STRUCT_AFTER(smd, DNA_struct_default_get(SimpleDeformModifierDataBGE), modifier);
+}
+
+ModifierTypeInfo modifierType_SimpleDeformBGE = {
+    /*idname*/ "SimpleDeformBGE",
+    /*name*/ N_("SimpleDeformBGE"),
+    /*struct_name*/ "SimpleDeformModifierDataBGE",
+    /*struct_size*/ sizeof(SimpleDeformModifierDataBGE),
+    /*srna*/ nullptr,
+    /*type*/ ModifierTypeType::Constructive,
+
+    /*flags*/ eModifierTypeFlag_AcceptsMesh | eModifierTypeFlag_SupportsMapping | eModifierTypeFlag_Single,
+    /*icon*/ ICON_MOD_SIMPLEDEFORM,
+
+    /*copy_data*/ BKE_modifier_copydata_generic,
+
+    /*deform_verts*/ nullptr,
+    /*deform_matrices*/ nullptr,
+    /*deform_verts_EM*/ nullptr,
+    /*deform_matrices_EM*/ nullptr,
+    /*modify_mesh*/ modify_mesh,
+    /*modify_geometry_set*/ nullptr,
+
+    /*init_data*/ init_data,
+    /*required_data_mask*/ nullptr,
+    /*free_data*/ nullptr,
+    /*is_disabled*/ nullptr,
+    /*update_depsgraph*/ nullptr,
+    /*depends_on_time*/ nullptr,
+    /*depends_on_normals*/ nullptr,
+    /*foreach_ID_link*/ nullptr,
+    /*foreach_tex_link*/ nullptr,
+    /*free_runtime_data*/ nullptr,
+    /*panel_register*/ nullptr,
+    /*blend_write*/ nullptr,
+    /*blend_read*/ nullptr,
+    /*foreach_cache*/ nullptr,
+};

--- a/source/blender/modifiers/intern/MOD_deform_bge.cc
+++ b/source/blender/modifiers/intern/MOD_deform_bge.cc
@@ -6,8 +6,6 @@
  * \ingroup modifiers
  */
 
-#include <algorithm>
-
 #include "BLI_math_vector.h"
 
 #include "BLT_translation.hh"

--- a/source/blender/modifiers/intern/MOD_deform_bge.cc
+++ b/source/blender/modifiers/intern/MOD_deform_bge.cc
@@ -28,18 +28,15 @@ static Mesh *modify_mesh(ModifierData *md, const ModifierEvalContext *ctx, Mesh 
   if (smd->vertcoos == nullptr) {
     return mesh;
   }
-  Mesh *source = reinterpret_cast<Mesh *>(DEG_get_evaluated_id(ctx->depsgraph, &mesh->id));
-  Mesh *result = BKE_mesh_copy_for_eval(*source);
 
-  float(*positions)[3] = reinterpret_cast<float(*)[3]>(
-      result->vert_positions_for_write().data());
+  float(*positions)[3] = reinterpret_cast<float(*)[3]>(mesh->vert_positions_for_write().data());
 
-  for (int i = 0; i < result->vert_positions().size(); i++) {
+  for (int i = 0; i < mesh->vert_positions().size(); i++) {
     copy_v3_v3(positions[i], smd->vertcoos[i]);
   }
-  result->tag_positions_changed();
+  mesh->tag_positions_changed();
 
-  return result;
+  return mesh;
 }
 
 /* SimpleDeform */

--- a/source/blender/modifiers/intern/MOD_deform_bge.cc
+++ b/source/blender/modifiers/intern/MOD_deform_bge.cc
@@ -8,37 +8,25 @@
 
 #include <algorithm>
 
-#include "BLI_math_matrix.h"
 #include "BLI_math_vector.h"
-#include "BLI_task.h"
-#include "BLI_utildefines.h"
+
 #include "BLT_translation.hh"
 
 #include "DEG_depsgraph_query.hh"
 
 #include "DNA_defaults.h"
 #include "DNA_object_types.h"
-#include "DNA_screen_types.h"
 
-#include "BKE_deform.hh"
 #include "BKE_mesh.hh"
-#include "BKE_mesh_runtime.hh"
-#include "BKE_modifier.hh"
 
 #include "UI_interface.hh"
-#include "UI_resources.hh"
 
-#include "RNA_access.hh"
-#include "RNA_prototypes.hh"
-
-#include "MOD_ui_common.hh"
 #include "MOD_util.hh"
 
-static Mesh *modify_mesh(ModifierData *md, const ModifierEvalContext *ctx, Mesh * /*mesh*/)
+static Mesh *modify_mesh(ModifierData *md, const ModifierEvalContext *ctx, Mesh *mesh)
 {
   SimpleDeformModifierDataBGE *smd = (SimpleDeformModifierDataBGE *)md;
-  Object *object_eval = DEG_get_evaluated(ctx->depsgraph, ctx->object);
-  Mesh *source = (Mesh *)object_eval->data;
+  Mesh *source = reinterpret_cast<Mesh *>(DEG_get_evaluated(ctx->depsgraph, &mesh->id));
   Mesh *result = BKE_mesh_copy_for_eval(*source);
 
   float(*positions)[3] = reinterpret_cast<float(*)[3]>(
@@ -70,7 +58,7 @@ ModifierTypeInfo modifierType_SimpleDeformBGE = {
     /*srna*/ nullptr,
     /*type*/ ModifierTypeType::Constructive,
 
-    /*flags*/ eModifierTypeFlag_AcceptsMesh | eModifierTypeFlag_SupportsMapping | eModifierTypeFlag_Single,
+    /*flags*/ eModifierTypeFlag_AcceptsMesh | eModifierTypeFlag_Single,
     /*icon*/ ICON_MOD_SIMPLEDEFORM,
 
     /*copy_data*/ BKE_modifier_copydata_generic,

--- a/source/blender/modifiers/intern/MOD_deform_bge.cc
+++ b/source/blender/modifiers/intern/MOD_deform_bge.cc
@@ -21,22 +21,15 @@
 
 #include "MOD_util.hh"
 
-static Mesh *modify_mesh(ModifierData *md, const ModifierEvalContext *ctx, Mesh *mesh)
+static void deform_verts(ModifierData *md,
+                         const ModifierEvalContext * /*ctx*/,
+                         Mesh * /*mesh*/,
+                         blender::MutableSpan<blender::float3> positions)
 {
   SimpleDeformModifierDataBGE *smd = (SimpleDeformModifierDataBGE *)md;
-
-  if (smd->vertcoos == nullptr) {
-    return mesh;
-  }
-
-  float(*positions)[3] = reinterpret_cast<float(*)[3]>(mesh->vert_positions_for_write().data());
-
-  for (int i = 0; i < mesh->vert_positions().size(); i++) {
+  for (int i = 0; i < positions.size(); i++) {
     copy_v3_v3(positions[i], smd->vertcoos[i]);
   }
-  mesh->tag_positions_changed();
-
-  return mesh;
 }
 
 /* SimpleDeform */
@@ -55,18 +48,18 @@ ModifierTypeInfo modifierType_SimpleDeformBGE = {
     /*struct_name*/ "SimpleDeformModifierDataBGE",
     /*struct_size*/ sizeof(SimpleDeformModifierDataBGE),
     /*srna*/ nullptr,
-    /*type*/ ModifierTypeType::Constructive,
+    /*type*/ ModifierTypeType::OnlyDeform,
 
     /*flags*/ eModifierTypeFlag_AcceptsMesh | eModifierTypeFlag_Single,
     /*icon*/ ICON_MOD_SIMPLEDEFORM,
 
     /*copy_data*/ BKE_modifier_copydata_generic,
 
-    /*deform_verts*/ nullptr,
+    /*deform_verts*/ deform_verts,
     /*deform_matrices*/ nullptr,
     /*deform_verts_EM*/ nullptr,
     /*deform_matrices_EM*/ nullptr,
-    /*modify_mesh*/ modify_mesh,
+    /*modify_mesh*/ nullptr,
     /*modify_geometry_set*/ nullptr,
 
     /*init_data*/ init_data,

--- a/source/blender/modifiers/intern/MOD_util.cc
+++ b/source/blender/modifiers/intern/MOD_util.cc
@@ -287,5 +287,6 @@ void modifier_type_init(ModifierTypeInfo *types[])
   INIT_TYPE(GreasePencilShrinkwrap);
   INIT_TYPE(GreasePencilBuild);
   INIT_TYPE(GreasePencilTexture);
+  INIT_TYPE(SimpleDeformBGE);
 #undef INIT_TYPE
 }

--- a/source/gameengine/Ketsji/KX_GameObject.cpp
+++ b/source/gameengine/Ketsji/KX_GameObject.cpp
@@ -152,10 +152,6 @@ KX_GameObject::~KX_GameObject()
     }
   }
 
-  if (m_pPhysicsController) {
-    delete m_pPhysicsController;
-  }
-
   if (m_pSGNode) {
     RemoveOrHideBlenderObject();
 
@@ -193,6 +189,10 @@ KX_GameObject::~KX_GameObject()
     m_pSGNode->SetSGClientObject(nullptr);
 
     /* m_pSGNode is freed in KX_Scene::RemoveNodeDestructObject */
+  }
+
+  if (m_pPhysicsController) {
+    delete m_pPhysicsController;
   }
 
   if (m_actionManager) {
@@ -393,6 +393,10 @@ void KX_GameObject::RemoveOrHideBlenderObject()
 {
   Object *ob = GetBlenderObject();
   if (ob) {
+    PHY_IPhysicsController *ctrl = GetPhysicsController();
+    if (ctrl) {
+      ctrl->RemoveSoftBodyModifier(ob);
+    }
     if (m_isReplica) {
       bContext *C = KX_GetActiveEngine()->GetContext();
       Main *bmain = CTX_data_main(C);

--- a/source/gameengine/Ketsji/KX_GameObject.cpp
+++ b/source/gameengine/Ketsji/KX_GameObject.cpp
@@ -152,6 +152,10 @@ KX_GameObject::~KX_GameObject()
     }
   }
 
+  if (m_pPhysicsController) {
+    delete m_pPhysicsController;
+  }
+
   if (m_pSGNode) {
     RemoveOrHideBlenderObject();
 
@@ -189,10 +193,6 @@ KX_GameObject::~KX_GameObject()
     m_pSGNode->SetSGClientObject(nullptr);
 
     /* m_pSGNode is freed in KX_Scene::RemoveNodeDestructObject */
-  }
-
-  if (m_pPhysicsController) {
-    delete m_pPhysicsController;
   }
 
   if (m_actionManager) {

--- a/source/gameengine/Physics/Bullet/CcdPhysicsController.cpp
+++ b/source/gameengine/Physics/Bullet/CcdPhysicsController.cpp
@@ -856,8 +856,8 @@ void CcdPhysicsController::UpdateSoftBody()
         bContext *C = KX_GetActiveEngine()->GetContext();
         Depsgraph *depsgraph = CTX_data_depsgraph_pointer(C);
         Object *ob = gameobj->GetBlenderObject();
-        Object *ob_eval = DEG_get_evaluated(depsgraph, gameobj->GetBlenderObject());
-        Mesh *me = (Mesh *)ob_eval->data;
+        Mesh *mesh_orig = BKE_mesh_from_object(ob);
+        Mesh *me = (Mesh *)DEG_get_evaluated_id(depsgraph, &mesh_orig->id);
         BKE_mesh_tessface_ensure(me);
 
         const int *index_mf_to_mpoly = (const int *)CustomData_get_layer(&me->fdata_legacy, CD_ORIGINDEX);
@@ -920,7 +920,7 @@ void CcdPhysicsController::UpdateSoftBody()
           m_sbModifier = (SimpleDeformModifierDataBGE *)BKE_modifier_new(
               eModifierType_SimpleDeformBGE);
           STRNCPY(m_sbModifier->modifier.name, "sbModifier");
-          BLI_addtail(&ob->modifiers, m_sbModifier);
+          BLI_addhead(&ob->modifiers, m_sbModifier);
           BKE_modifier_unique_name(&ob->modifiers, (ModifierData *)m_sbModifier);
           BKE_modifiers_persistent_uid_init(*ob, m_sbModifier->modifier);
         }

--- a/source/gameengine/Physics/Bullet/CcdPhysicsController.cpp
+++ b/source/gameengine/Physics/Bullet/CcdPhysicsController.cpp
@@ -884,7 +884,8 @@ void CcdPhysicsController::UpdateSoftBody()
 
         btSoftBody::tNodeArray &nodes(sb->m_nodes);
 
-        MT_Transform invtrans(&ob->world_to_object().ptr()[0][0]);
+        MT_Transform invtrans(gameobj->NodeGetWorldTransform());
+        invtrans.invert(invtrans);
 
         for (int p2 = 0; p2 < numpolys; p2++) {
           const MFace *face = &faces[p2];

--- a/source/gameengine/Physics/Bullet/CcdPhysicsController.cpp
+++ b/source/gameengine/Physics/Bullet/CcdPhysicsController.cpp
@@ -865,8 +865,11 @@ void CcdPhysicsController::UpdateSoftBody()
       if (rasMesh) {
         KX_GameObject *gameobj = KX_GameObject::GetClientObject(
             (KX_ClientObjectInfo *)GetNewClientInfo());
+        bContext *C = KX_GetActiveEngine()->GetContext();
+        Depsgraph *depsgraph = CTX_data_depsgraph_pointer(C);
         Object *ob = gameobj->GetBlenderObject();
-        Mesh *me = (Mesh *)ob->data;
+        Object *ob_eval = DEG_get_evaluated(depsgraph, gameobj->GetBlenderObject());
+        Mesh *me = (Mesh *)ob_eval->data;
         BKE_mesh_tessface_ensure(me);
 
         const int *index_mf_to_mpoly = (const int *)CustomData_get_layer(&me->fdata_legacy, CD_ORIGINDEX);
@@ -935,7 +938,7 @@ void CcdPhysicsController::UpdateSoftBody()
         }
         m_sbModifier->vertcoos = m_sbCoords;
 
-        //me->tag_positions_changed();
+        /* call this each frame to ensure MOD_deform_bge will be called */
         DEG_id_tag_update(&ob->id, ID_RECALC_GEOMETRY);
       }
     }

--- a/source/gameengine/Physics/Bullet/CcdPhysicsController.cpp
+++ b/source/gameengine/Physics/Bullet/CcdPhysicsController.cpp
@@ -739,18 +739,6 @@ bool CcdPhysicsController::ReplaceControllerShape(btCollisionShape *newShape)
 
 CcdPhysicsController::~CcdPhysicsController()
 {
-  KX_GameObject *gameobj = KX_GameObject::GetClientObject(
-      (KX_ClientObjectInfo *)GetNewClientInfo());
-  Object *ob = gameobj->GetBlenderObject();
-  if (m_sbCoords) {
-    MEM_freeN(m_sbCoords);
-    m_sbCoords = nullptr;
-  }
-  if (m_sbModifier) {
-    BLI_remlink(&ob->modifiers, m_sbModifier);
-    BKE_modifier_free((ModifierData *)m_sbModifier);
-    m_sbModifier = nullptr;
-  }
   // will be reference counted, due to sharing
   if (m_cci.m_physicsEnv)
     m_cci.m_physicsEnv->RemoveCcdPhysicsController(this, true);
@@ -949,6 +937,21 @@ void CcdPhysicsController::SetSoftBodyTransform(const MT_Vector3 &pos, const MT_
 {
   if (GetSoftBody()) {
     GetSoftBody()->transform(btTransform(ToBullet(ori), ToBullet(pos)));
+  }
+}
+
+void CcdPhysicsController::RemoveSoftBodyModifier(Object *ob)
+{
+  if (GetSoftBody()) {
+    if (m_sbCoords) {
+      MEM_freeN(m_sbCoords);
+      m_sbCoords = nullptr;
+    }
+    if (m_sbModifier) {
+      BLI_remlink(&ob->modifiers, m_sbModifier);
+      BKE_modifier_free((ModifierData *)m_sbModifier);
+      m_sbModifier = nullptr;
+    }
   }
 }
 

--- a/source/gameengine/Physics/Bullet/CcdPhysicsController.cpp
+++ b/source/gameengine/Physics/Bullet/CcdPhysicsController.cpp
@@ -884,6 +884,8 @@ void CcdPhysicsController::UpdateSoftBody()
 
         btSoftBody::tNodeArray &nodes(sb->m_nodes);
 
+        MT_Transform invtrans(&ob->world_to_object().ptr()[0][0]);
+
         for (int p2 = 0; p2 < numpolys; p2++) {
           const MFace *face = &faces[p2];
           const int origi = index_mf_to_mpoly ?
@@ -901,9 +903,9 @@ void CcdPhysicsController::UpdateSoftBody()
             int i2 = poly->GetVertexInfo(1).getSoftBodyIndex();
             int i3 = poly->GetVertexInfo(2).getSoftBodyIndex();
 
-            MT_Vector3 p1 = ToMoto(nodes.at(i1).m_x - sb->m_pose.m_com);
-            MT_Vector3 p2 = ToMoto(nodes.at(i2).m_x - sb->m_pose.m_com);
-            MT_Vector3 p3 = ToMoto(nodes.at(i3).m_x - sb->m_pose.m_com);
+            MT_Vector3 p1 = invtrans * ToMoto(nodes.at(i1).m_x);
+            MT_Vector3 p2 = invtrans * ToMoto(nodes.at(i2).m_x);
+            MT_Vector3 p3 = invtrans * ToMoto(nodes.at(i3).m_x);
 
             // Do we need object_to_world? maybe
             copy_v3_v3(v1, p1.getValue());
@@ -915,7 +917,7 @@ void CcdPhysicsController::UpdateSoftBody()
 
               int i4 = poly->GetVertexInfo(3).getSoftBodyIndex();
 
-              MT_Vector3 p4 = ToMoto(nodes.at(i4).m_x - sb->m_pose.m_com);
+              MT_Vector3 p4 = invtrans * ToMoto(nodes.at(i4).m_x);
 
               copy_v3_v3(v4, p4.getValue());
 

--- a/source/gameengine/Physics/Bullet/CcdPhysicsController.h
+++ b/source/gameengine/Physics/Bullet/CcdPhysicsController.h
@@ -562,6 +562,9 @@ class CcdPhysicsController : public PHY_IPhysicsController {
   btCollisionObject *m_object;
   CcdCharacter *m_characterController;
 
+  struct SimpleDeformModifierDataBGE *m_sbModifier;
+  float (*m_sbCoords)[3];
+
   class PHY_IMotionState *m_MotionState;
   btMotionState *m_bulletMotionState;
   class btCollisionShape *m_collisionShape;

--- a/source/gameengine/Physics/Bullet/CcdPhysicsController.h
+++ b/source/gameengine/Physics/Bullet/CcdPhysicsController.h
@@ -676,6 +676,7 @@ class CcdPhysicsController : public PHY_IPhysicsController {
 
   virtual void UpdateSoftBody();
   virtual void SetSoftBodyTransform(const MT_Vector3 &pos, const MT_Matrix3x3 &ori);
+  virtual void RemoveSoftBodyModifier(struct Object *ob);
 
   /**
    * Called for every physics simulation step. Use this method for

--- a/source/gameengine/Physics/Common/PHY_IPhysicsController.h
+++ b/source/gameengine/Physics/Common/PHY_IPhysicsController.h
@@ -60,6 +60,7 @@ class PHY_IPhysicsController : public PHY_IController {
 
   virtual void UpdateSoftBody() = 0;
   virtual void SetSoftBodyTransform(const MT_Vector3 &pos, const MT_Matrix3x3 &ori) = 0;
+  virtual void RemoveSoftBodyModifier(struct Object *ob) = 0;
   /**
    * WriteMotionStateToDynamics ynchronizes dynas, kinematic and deformable entities (and do 'late
    * binding')


### PR DESCRIPTION
It creates a simple basic OnlyDeform modifier.

This PR has several goals:

- Create an unique deformed shape for softbodies which have several mesh users
- Avoid deforming original mesh as it creates issues for example on scene restart
- Attempt to fix some transform issues (We still need to Apply Scale before bge start)

It doesn't solve all issues but I think it is a progress.
It has been tested with some of my files:


[Nouveau dossier.zip](https://github.com/user-attachments/files/20730340/Nouveau.dossier.zip)

