### PR TITLE
UPBGE: Improve GLSL uniform parser and replace legacy built-in variables with UBO access

### DIFF
--- a/doc/python_api/rst/bge_types/bge.types.KX_2DFilter.rst
+++ b/doc/python_api/rst/bge_types/bge.types.KX_2DFilter.rst
@@ -11,67 +11,86 @@ base class --- :class:`~bge.types.BL_Shader`
 
    .. note::
 
-     Following builtin uniforms are available:
+      Since version 0.5+, the following builtin uniforms are available via the UBO ``g_data`` (type ``bgl_Data``):
 
-       "bgl_RenderedTexture",        // RENDERED_TEXTURE_UNIFORM.
+         ``g_data.width``
+            Rendered texture width (float)
 
-       "bgl_DepthTexture",           // DEPTH_TEXTURE_UNIFORM.
+         ``g_data.height``
+            Rendered texture height (float)
 
-       "bgl_RenderedTextureWidth",   // RENDERED_TEXTURE_WIDTH_UNIFORM.
+         ``g_data.coo_offset[9]``
+            Texture coordinate offsets for 3x3 filters (vec4[9])
 
-       "bgl_RenderedTextureHeight",  // RENDERED_TEXTURE_HEIGHT_UNIFORM.
+      The following builtin samplers are available:
 
-       "bgl_TextureCoordinateOffset" // TEXTURE_COORDINATE_OFFSETS_UNIFORM.
+         ``bgl_RenderedTexture``
+            RENDERED_TEXTURE_UNIFORM
 
-     Following builtin attributes are available:
+         ``bgl_DepthTexture``
+            DEPTH_TEXTURE_UNIFORM
 
-       "bgl_TexCoord",               // texture coordinates / UV.
+      The following builtin attributes are available:
 
-       "fragColor"                   // returned result of 2D filter.
+         ``bgl_TexCoord``
+            texture coordinates / UV
 
-     Basic example:
+         ``fragColor``
+            returned result of 2D filter
 
-   .. code-block:: glsl
+Example:
 
-          void main()
-          {
-            fragColor = texture(bgl_RenderedTexture, bgl_TexCoord.xy) * vec4(0.0, 0.0, 1.0, 1.0); //will make the rendered image blueish
-          }
+.. code-block:: glsl
 
-   .. attribute:: mipmap
+   void main()
+   {
+     fragColor = texture(bgl_RenderedTexture, bgl_TexCoord.xy) * vec4(0.0, 0.0, 1.0, 1.0); // will make the rendered image blueish
+   }
 
-   Request mipmap generation of the render `bgl_RenderedTexture` texture.
+Example using offsets:
+
+.. code-block:: glsl
+
+   for (int i = 0; i < 9; i++) {
+     vec2 offset = g_data.coo_offset[i].xy;
+     vec4 sample = texture(bgl_RenderedTexture, bgl_TexCoord.xy + offset);
+     // ...
+   }
+
+.. attribute:: mipmap
+
+   Request mipmap generation of the render ``bgl_RenderedTexture`` texture.
 
    :type: boolean
 
-   .. attribute:: offScreen
+.. attribute:: offScreen
 
-      The custom off screen (framebuffer in 0.3+) the filter render to (read-only).
+   The custom off screen (framebuffer in 0.3+) the filter render to (read-only).
 
-      :type: :class:`~bge.types.KX_2DFilterFrameBuffer` or None
+   :type: :class:`~bge.types.KX_2DFilterFrameBuffer` or None
 
-   .. method:: setTexture(textureName="", gputexture)
+.. method:: setTexture(textureName="", gputexture)
 
-      Set specified GPUTexture as uniform for the 2D filter.
+   Set specified GPUTexture as uniform for the 2D filter.
 
-      :arg textureName: The name of the texture in the 2D filter code. For example if you declare:
-         uniform sampler2D myTexture;
-         you will have to call filter.setTexture("myTexture", gputex).
-      :type textureName: string
-      :arg gputexture: The gputexture (see gpu module documentation).
-      :type gputexture: :class:`~gpu.types.GPUTexture`
+   :arg textureName: The name of the texture in the 2D filter code. For example if you declare:
+      uniform sampler2D myTexture;
+      you will have to call filter.setTexture("myTexture", gputex).
+   :type textureName: string
+   :arg gputexture: The gputexture (see gpu module documentation).
+   :type gputexture: :class:`~gpu.types.GPUTexture`
 
-   .. method:: addOffScreen(width=None, height=None, mipmap=False)
+.. method:: addOffScreen(width=None, height=None, mipmap=False)
 
-      Register a custom off screen (framebuffer in 0.3+) to render the filter to.
+   Register a custom off screen (framebuffer in 0.3+) to render the filter to.
 
-      :arg width: In 0.3+, always canvas width (optional).
-      :type width: integer
-      :arg height: In 0.3+, always canvas height (optional).
-      :type height: integer
-      :arg mipmap: True if the color texture generate mipmap at the end of the filter rendering (optional).
-      :type mipmap: boolean
+   :arg width: In 0.3+, always canvas width (optional).
+   :type width: integer
+   :arg height: In 0.3+, always canvas height (optional).
+   :type height: integer
+   :arg mipmap: True if the color texture generate mipmap at the end of the filter rendering (optional).
+   :type mipmap: boolean
 
-   .. method:: removeOffScreen()
+.. method:: removeOffScreen()
 
-      Unregister the custom off screen (framebuffer in 0.3+) the filter render to.
+   Unregister the custom off screen (framebuffer in 0.3+) the filter render to.

--- a/source/gameengine/Rasterizer/RAS_OpenGLFilters/RAS_Blur2DFilter.glsl
+++ b/source/gameengine/Rasterizer/RAS_OpenGLFilters/RAS_Blur2DFilter.glsl
@@ -3,7 +3,7 @@ void main(void)
   vec4 samples[9];
 
   for (int i = 0; i < 9; i++) {
-    samples[i] = texture(bgl_RenderedTexture, bgl_TexCoord.xy + bgl_TextureCoordinateOffset[i]);
+    samples[i] = texture(bgl_RenderedTexture, bgl_TexCoord.xy + g_data.coo_offset[i].xy);
   }
 
   fragColor = (samples[0] + (2.0 * samples[1]) + samples[2] + (2.0 * samples[3]) + samples[4] +

--- a/source/gameengine/Rasterizer/RAS_OpenGLFilters/RAS_Dilation2DFilter.glsl
+++ b/source/gameengine/Rasterizer/RAS_OpenGLFilters/RAS_Dilation2DFilter.glsl
@@ -4,7 +4,7 @@ void main(void)
   vec4 maxValue = vec4(0.0);
 
   for (int i = 0; i < 9; i++) {
-    samples[i] = texture(bgl_RenderedTexture, bgl_TexCoord.xy + bgl_TextureCoordinateOffset[i]);
+    samples[i] = texture(bgl_RenderedTexture, bgl_TexCoord.xy + g_data.coo_offset[i].xy);
     maxValue = max(samples[i], maxValue);
   }
 

--- a/source/gameengine/Rasterizer/RAS_OpenGLFilters/RAS_Erosion2DFilter.glsl
+++ b/source/gameengine/Rasterizer/RAS_OpenGLFilters/RAS_Erosion2DFilter.glsl
@@ -4,7 +4,7 @@ void main(void)
   vec4 minValue = vec4(1.0);
 
   for (int i = 0; i < 9; i++) {
-    samples[i] = texture(bgl_RenderedTexture, bgl_TexCoord.xy + bgl_TextureCoordinateOffset[i]);
+    samples[i] = texture(bgl_RenderedTexture, bgl_TexCoord.xy + g_data.coo_offset[i].xy);
     minValue = min(samples[i], minValue);
   }
 

--- a/source/gameengine/Rasterizer/RAS_OpenGLFilters/RAS_Laplacian2DFilter.glsl
+++ b/source/gameengine/Rasterizer/RAS_OpenGLFilters/RAS_Laplacian2DFilter.glsl
@@ -3,7 +3,7 @@ void main(void)
   vec4 samples[9];
 
   for (int i = 0; i < 9; i++) {
-    samples[i] = texture(bgl_RenderedTexture, bgl_TexCoord.xy + bgl_TextureCoordinateOffset[i]);
+    samples[i] = texture(bgl_RenderedTexture, bgl_TexCoord.xy + g_data.coo_offset[i].xy);
   }
 
   fragColor = (samples[4] * 8.0) - (samples[0] + samples[1] + samples[2] + samples[3] +

--- a/source/gameengine/Rasterizer/RAS_OpenGLFilters/RAS_Prewitt2DFilter.glsl
+++ b/source/gameengine/Rasterizer/RAS_OpenGLFilters/RAS_Prewitt2DFilter.glsl
@@ -3,7 +3,7 @@ void main(void)
   vec4 samples[9];
 
   for (int i = 0; i < 9; i++) {
-    samples[i] = texture(bgl_RenderedTexture, bgl_TexCoord.xy + bgl_TextureCoordinateOffset[i]);
+    samples[i] = texture(bgl_RenderedTexture, bgl_TexCoord.xy + g_data.coo_offset[i].xy);
   }
 
   vec4 horizEdge = samples[2] + samples[5] + samples[8] - (samples[0] + samples[3] + samples[6]);

--- a/source/gameengine/Rasterizer/RAS_OpenGLFilters/RAS_Sharpen2DFilter.glsl
+++ b/source/gameengine/Rasterizer/RAS_OpenGLFilters/RAS_Sharpen2DFilter.glsl
@@ -3,7 +3,7 @@ void main(void)
   vec4 samples[9];
 
   for (int i = 0; i < 9; i++) {
-    samples[i] = texture(bgl_RenderedTexture, bgl_TexCoord.xy + bgl_TextureCoordinateOffset[i]);
+    samples[i] = texture(bgl_RenderedTexture, bgl_TexCoord.xy + g_data.coo_offset[i].xy);
   }
   fragColor = (samples[4] * 9.0) - (samples[0] + samples[1] + samples[2] + samples[3] +
                                     samples[5] + samples[6] + samples[7] + samples[8]);

--- a/source/gameengine/Rasterizer/RAS_OpenGLFilters/RAS_Sobel2DFilter.glsl
+++ b/source/gameengine/Rasterizer/RAS_OpenGLFilters/RAS_Sobel2DFilter.glsl
@@ -3,7 +3,7 @@ void main(void)
   vec4 samples[9];
 
   for (int i = 0; i < 9; i++) {
-    samples[i] = texture(bgl_RenderedTexture, bgl_TexCoord.xy + bgl_TextureCoordinateOffset[i]);
+    samples[i] = texture(bgl_RenderedTexture, bgl_TexCoord.xy + g_data.coo_offset[i].xy);
   }
 
   vec4 horizEdge = samples[2] + (2.0 * samples[5]) + samples[8] -

--- a/source/gameengine/Rasterizer/RAS_Shader.h
+++ b/source/gameengine/Rasterizer/RAS_Shader.h
@@ -8,6 +8,7 @@
 #include <string>
 #include <vector>
 
+#include "BLI_math_vector_types.hh"
 #include "../gpu/intern/gpu_shader_create_info.hh"
 
 #include "MT_Matrix4x4.h"
@@ -118,6 +119,14 @@ class RAS_Shader {
   // Stored uniform variables
   RAS_UniformVec m_uniforms;
   RAS_UniformVecDef m_preDef;
+  struct bgl_Data {
+    float width;
+    float height;
+    float _pad[2];
+    float coo_offset[9][4];
+  };
+  bgl_Data m_uboData;
+  GPUUniformBuf *m_ubo;
 
   std::vector<UniformConstant> m_constantUniforms;
   std::vector<std::pair<int, std::string>> m_samplerUniforms;


### PR DESCRIPTION
This PR improves the GLSL uniform parser in RAS_Shader::GetParsedProgram with the following changes:
•	Ignores user-declared uniforms for bgl_RenderedTexture and bgl_DepthTexture to avoid redeclaration errors (these are now handled internally).
•	Handles uniform arrays and multiple variable declarations on a single line (e.g. uniform float a, b[4], c;).
•	For each user uniform, registers a push constant (except for built-in ones).
•	Replaces legacy built-in variables in shader code:
•	bgl_TextureCoordinateOffset[...] → g_data.coo_offset[...]
•	bgl_RenderedTextureWidth → g_data.width
•	bgl_RenderedTextureHeight → g_data.height
•	Comments out all user uniform declarations in the final shader code to prevent GLSL errors.
•	The parser is robust to extra spaces and tabs between keywords, types, and variable names.
Motivation:
•	Ensures compatibility with the new UBO-based system for built-in variables.
•	Prevents redeclaration errors and makes user shader code cleaner and more future-proof.
•	Improves user experience by allowing more flexible uniform declarations.
Testing:

What is above was generated with IA. I tested with few builtin shaders + 2 custom filters and it sounds ok. As the parser has been improved (with IA), old syntax works.

UBO is here to leave more space for custom uniforms because we are limited to 128 bytes for push_constant