### PR TITLE
Optimizations for GPU Skinning

### DIFF
--- a/source/gameengine/Converter/BL_ArmatureObject.h
+++ b/source/gameengine/Converter/BL_ArmatureObject.h
@@ -75,8 +75,8 @@ class BL_ArmatureObject : public KX_GameObject {
   struct GPUStorageBuf *ssbo_in_idx;
   struct GPUStorageBuf *ssbo_in_wgt;
   struct GPUStorageBuf *ssbo_bone_pose_mat;
-  struct GPUStorageBuf *ssbo_premat;
-  struct GPUStorageBuf *ssbo_postmat;
+  struct GPUStorageBuf *ssbo_bone_normal_mat;
+  struct GPUStorageBuf *ssbo_prepost_mat;
   struct GPUStorageBuf *ssbo_rest_pose;
   struct GPUStorageBuf *ssbo_rest_normals;
 

--- a/source/gameengine/Converter/BL_ArmatureObject.h
+++ b/source/gameengine/Converter/BL_ArmatureObject.h
@@ -77,6 +77,7 @@ class BL_ArmatureObject : public KX_GameObject {
   struct GPUStorageBuf *ssbo_bone_pose_mat;
   struct GPUStorageBuf *ssbo_bone_normal_mat;
   struct GPUStorageBuf *ssbo_prepost_mat;
+  struct GPUStorageBuf *ssbo_prepost_normal_mat_packet;
   struct GPUStorageBuf *ssbo_rest_pose;
   struct GPUStorageBuf *ssbo_rest_normals;
 


### PR DESCRIPTION
Little skinning shader optimizations (around 10-15% improvement with my graphic card Nvidia 1660)

- Remove the need to calculate normal matrix = transpose(inverse(mat3(bone_pose_mat))) inside shader. Very cost as it
calculates it for each vertex&bone instead of each bone.

- combine pre/post matrices reducing memory consumption.

- Remove weight bifurcation as weight it is normalized previously out of shader. Also remove bifurcations if (w > 0.0) as it is better to do the multiplications with w = 0.0 instead of a bifurcation.

@youle31 could you test with your hardware? Perhaps the improvement will be minor since your hardware is better.