### PR TITLE
UPBGE: Add default UPBGE addons

### DIFF
--- a/release/datafiles/userdef/userdef_default.c
+++ b/release/datafiles/userdef/userdef_default.c
@@ -235,6 +235,9 @@ const UserDef U_default = {
 
     .sequencer_editor_flag = USER_SEQ_ED_CONNECT_STRIPS_BY_DEFAULT,
 
+    .upbgeversionfile = UPBGE_FILE_VERSION,
+    .upbgesubversionfile = UPBGE_FILE_SUBVERSION,
+
     .runtime =
         {
             .is_dirty = 0,

--- a/source/blender/blenkernel/BKE_blender_version.h
+++ b/source/blender/blenkernel/BKE_blender_version.h
@@ -38,7 +38,7 @@
 
 /* UPBGE file format version. */
 #define UPBGE_FILE_VERSION UPBGE_VERSION
-#define UPBGE_FILE_SUBVERSION 2
+#define UPBGE_FILE_SUBVERSION 3
 
 /* Minimum Blender version that supports reading file written with the current
  * version. Older Blender versions will test this and cancel loading the file, showing a warning to

--- a/source/blender/blenkernel/intern/blendfile.cc
+++ b/source/blender/blenkernel/intern/blendfile.cc
@@ -1515,6 +1515,9 @@ UserDef *BKE_blendfile_userdef_from_defaults()
         "cycles",
         "pose_library",
         "bl_pkg",
+        "bge_netlogic",
+        "bge_bricknodes",
+        "game_engine_save_as_runtime_eevee",
     };
     for (int i = 0; i < ARRAY_SIZE(addons); i++) {
       bAddon *addon = BKE_addon_new();

--- a/source/blender/blenloader/intern/versioning_upbge.cc
+++ b/source/blender/blenloader/intern/versioning_upbge.cc
@@ -444,4 +444,7 @@ void blo_do_versions_upbge(FileData *fd, Library */*lib*/, Main *bmain)
       }
     }
   }
+  /* Currently, UPBGE_FILE_SUBVERSION 3, check versioning_userdef.c. If you need
+   * to evolve the UPBGE_FILE_SUBVERSION, uses UPBGE_FILE_SUBVERSION 4 and remove
+   * this comment. */
 }

--- a/source/blender/blenloader/intern/versioning_userdef.cc
+++ b/source/blender/blenloader/intern/versioning_userdef.cc
@@ -765,6 +765,7 @@ void blo_do_versions_userdef(UserDef *userdef)
 {
 /* #UserDef & #Main happen to have the same struct member. */
 #define USER_VERSION_ATLEAST(ver, subver) MAIN_VERSION_FILE_ATLEAST(userdef, ver, subver)
+#define USER_UPBGE_VERSION_ATLEAST(ver, subver) MAIN_VERSION_UPBGE_ATLEAST(userdef, ver, subver)
 
   /* the UserDef struct is not corrected with do_versions() .... ugh! */
   if (userdef->menuthreshold1 == 0) {
@@ -1643,6 +1644,12 @@ void blo_do_versions_userdef(UserDef *userdef)
 
   if (!USER_VERSION_ATLEAST(500, 59)) {
     userdef->preferences_display_type = USER_TEMP_SPACE_DISPLAY_WINDOW;
+  }
+
+  if (!USER_UPBGE_VERSION_ATLEAST(50, 3)) {
+    BKE_addon_ensure(&userdef->addons, "bge_netlogic");
+    BKE_addon_ensure(&userdef->addons, "bge_bricknodes");
+    BKE_addon_ensure(&userdef->addons, "game_engine_save_as_runtime_eevee");
   }
 
   /**

--- a/source/blender/makesdna/DNA_userdef_types.h
+++ b/source/blender/makesdna/DNA_userdef_types.h
@@ -616,6 +616,10 @@ typedef struct UserDef {
 
   UserDef_Experimental experimental;
 
+  /** UPBGE */
+  /** UserDef has separate do-version handling, and can be read from other files. */
+  int upbgeversionfile, upbgesubversionfile;
+
   /** Runtime data (keep last). */
   UserDef_Runtime runtime;
 } UserDef;


### PR DESCRIPTION
We adopt the same system as in Blender to select the default UPBGE addons.

Currently, I have selected Logic nodes, Bricky nodes and Save as Runtime addons. 
We can discuss later if we add some additional ones.


