### PR TITLE
Fix various typos

### DIFF
--- a/source/blenderplayer/CMakeLists.txt
+++ b/source/blenderplayer/CMakeLists.txt
@@ -107,7 +107,7 @@ if(WITH_BUILDINFO)
 
   # --------------------------------------------------------------------------
   # write header for values that change each build
-  # note, generaed file is in build dir's source/creator
+  # note, generated file is in build dir's source/creator
   #       except when used as an include path.
 
   add_definitions(-DWITH_BUILDINFO_HEADER)

--- a/source/gameengine/Converter/BL_ConvertControllers.cpp
+++ b/source/gameengine/Converter/BL_ConvertControllers.cpp
@@ -147,9 +147,9 @@ void BL_ConvertControllers(struct Object *blenderobject,
                   ->module); /* will be something like module.func so using it as the name is OK */
 
           if (pycont->flag & CONT_PY_DEBUG) {
-            CM_Warning("debuging \"" << pycont->module << "\", module for object "
-                                     << blenderobject->id.name + 2
-                                     << " expect worse performance.");
+            CM_Warning("debugging \"" << pycont->module << "\", module for object "
+                                      << blenderobject->id.name + 2
+                                      << " expect worse performance.");
             pyctrl->SetDebug(true);
           }
         }

--- a/source/gameengine/Ketsji/KX_GameObject.h
+++ b/source/gameengine/Ketsji/KX_GameObject.h
@@ -455,12 +455,12 @@ class KX_GameObject : public SCA_IObject {
     return false;
   }
 
-  /** Set the object's collison group
+  /** Set the object's collision group
    * \param filter The group bitfield
    */
   void SetCollisionGroup(unsigned short filter);
 
-  /** Set the object's collison mask
+  /** Set the object's collision mask
    * \param filter The mask bitfield
    */
   void SetCollisionMask(unsigned short mask);

--- a/source/gameengine/Ketsji/KX_KetsjiEngine.cpp
+++ b/source/gameengine/Ketsji/KX_KetsjiEngine.cpp
@@ -447,7 +447,7 @@ KX_KetsjiEngine::FrameTimes KX_KetsjiEngine::GetFrameTimes()
   //// Else in case of fixed framerate, try to sleep until the next frame.
   // else if (m_flags & FIXED_FRAMERATE) {
   //  const double sleeptime = timestep - dt - 1.0e-3;
-  //  /* If the remaining time is greather than 1ms (sleep resolution) sleep this thread.
+  //  /* If the remaining time is greater than 1ms (sleep resolution) sleep this thread.
   //   * The other 1ms will be busy wait.
   //   */
   //  if (sleeptime > 0.0) {
@@ -472,7 +472,7 @@ bool KX_KetsjiEngine::NextFrame()
 
   const FrameTimes times = GetFrameTimes();
 
-  // Exit if zero frame is sheduled.
+  // Exit if zero frame is scheduled.
   if (times.frames == 0) {
     // Start logging time spent outside main loop
     m_logger.StartLog(tc_outside);
@@ -1372,7 +1372,7 @@ void KX_KetsjiEngine::RemoveScene(const std::string &scenename)
 {
   /****************EEVEE INTEGRATION*****************/
   // DISABLE REMOVE SCENES FOR NOW
-  std::cout << "KX_KetsjiEngine::RemoveScene: Remove Scenes is temporarly disabled during eevee "
+  std::cout << "KX_KetsjiEngine::RemoveScene: Remove Scenes is temporarily disabled during eevee "
                "integration"
             << std::endl;
   return;
@@ -1426,7 +1426,7 @@ bool KX_KetsjiEngine::ReplaceScene(const std::string &oldscene, const std::strin
 {
   // Don't allow replacement if the new scene doesn't exist.
   // Allows smarter game design (used to have no check here).
-  // Note that it creates a small backward compatbility issue
+  // Note that it creates a small backward compatibility issue
   // for a game that did a replace followed by a lib load with the
   // new scene in the lib => it won't work anymore, the lib
   // must be loaded before doing the replace.

--- a/source/gameengine/Ketsji/KX_LodManager.h
+++ b/source/gameengine/Ketsji/KX_LodManager.h
@@ -98,7 +98,7 @@ class KX_LodManager : public EXP_Value {
    */
   KX_LodLevel *GetLevel(unsigned int index) const;
 
-  /** Get lod level cooresponding to distance and previous level.
+  /** Get lod level corresponding to distance and previous level.
    * \param scene Scene used to get default hysteresis.
    * \param previouslod Previous lod computed by this function before.
    *   Use -1 to disable the hysteresis when the lod manager has changed.

--- a/source/gameengine/Ketsji/KX_PythonInit.cpp
+++ b/source/gameengine/Ketsji/KX_PythonInit.cpp
@@ -715,7 +715,7 @@ static PyObject *gLibNew(PyObject *, PyObject *args)
         }
       }
       else {
-        PyErr_Clear(); /* wasnt a string, ignore for now */
+        PyErr_Clear(); /* wasn't a string, ignore for now */
       }
     }
 
@@ -865,7 +865,7 @@ static struct PyMethodDef game_methods[] = {
      METH_NOARGS,
      (const char *)"Get the last BGE render time. "
                    "The BGE render time is the simulated time corresponding to the next scene "
-                   "that will be renderered"},
+                   "that will be rendered"},
     {"setClockTime",
      (PyCFunction)gPySetClockTime,
      METH_VARARGS,
@@ -1795,7 +1795,7 @@ static void backupPySysObjects(void)
 
   if (bpy_sys_module_backup) {
     PyDict_Clear(sys_mods);
-    // Load a clean generated modules dict from the blender begining.
+    // Load a clean generated modules dict from the blender beginning.
     PyDict_Update(sys_mods, bpy_sys_module_backup);
   }
 }

--- a/source/gameengine/Ketsji/KX_Scene.cpp
+++ b/source/gameengine/Ketsji/KX_Scene.cpp
@@ -744,7 +744,7 @@ void KX_Scene::UpdateDepsgraph(Main *bmain,
 {
   if (m_collectionRemap) {
     /* check 68589a31ebfb79165f99a979357d237e5413e904 for potential issue or improvement? */
-    /* If problem with ReplicateBlenderObject, see other occurences of
+    /* If problem with ReplicateBlenderObject, see other occurrences of
      * BKE_collection_object_add_from*/
     BKE_main_collection_sync_remap(bmain);
     m_collectionRemap = false;
@@ -1910,7 +1910,7 @@ void KX_Scene::DupliGroupRecurse(KX_GameObject *groupobj, int level)
       if ((blenderobj->lay & groupobj->GetLayer()) == 0) {
         // Object is not visible in the 3D view, will not be instantiated. ??
         /* 3 remarks:
-         * - The comment souldn't be: "if blenderobj not in same layer than groupobj, don't convert
+         * - The comment shouldn't be: "if blenderobj not in same layer than groupobj, don't convert
          * it as gameobj"?
          * - The code was using blenderobj->lay & group->layer but group->layer is deprecated.
          * - Maybe it shouldn't be in an else statement. */
@@ -2217,7 +2217,7 @@ bool KX_Scene::NewRemoveObject(KX_GameObject *gameobj)
   }
 
   // if the object is the dupligroup proxy, you have to cleanup all m_pDupliGroupObject's in all
-  // instances refering to this group
+  // instances referring to this group
   if (gameobj->GetInstanceObjects()) {
     for (KX_GameObject *instance : gameobj->GetInstanceObjects()) {
       instance->RemoveDupliGroupObject();

--- a/source/gameengine/Physics/Common/PHY_IPhysicsEnvironment.h
+++ b/source/gameengine/Physics/Common/PHY_IPhysicsEnvironment.h
@@ -153,15 +153,15 @@ class PHY_IPhysicsEnvironment {
     return 0;
   }
   /// setDeactivationTime sets the minimum time that an objects has to stay within the velocity
-  /// tresholds until it gets fully deactivated
+  /// thresholds until it gets fully deactivated
   virtual void SetDeactivationTime(float dTime)
   {
   }
-  /// setDeactivationLinearTreshold sets the linear velocity treshold, see setDeactivationTime
+  /// setDeactivationLinearTreshold sets the linear velocity threshold, see setDeactivationTime
   virtual void SetDeactivationLinearTreshold(float linTresh)
   {
   }
-  /// setDeactivationAngularTreshold sets the angular velocity treshold, see setDeactivationTime
+  /// setDeactivationAngularTreshold sets the angular velocity threshold, see setDeactivationTime
   virtual void SetDeactivationAngularTreshold(float angTresh)
   {
   }
@@ -178,7 +178,7 @@ class PHY_IPhysicsEnvironment {
   virtual void SetCFM(float cfm)
   {
   }
-  /// setContactBreakingTreshold sets tresholds to do with contact point management
+  /// setContactBreakingTreshold sets thresholds to do with contact point management
   virtual void SetContactBreakingTreshold(float contactBreakingTreshold)
   {
   }
@@ -242,7 +242,7 @@ class PHY_IPhysicsEnvironment {
                                           float toZ) = 0;
 
   // culling based on physical broad phase
-  // the plane number must be set as follow: near, far, left, right, top, botton
+  // the plane number must be set as follow: near, far, left, right, top, bottom
   // the near plane must be the first one and must always be present, it is used to get the
   // direction of the view
   virtual bool CullingTest(PHY_CullingCallback callback,

--- a/source/gameengine/Rasterizer/RAS_Shader.h
+++ b/source/gameengine/Rasterizer/RAS_Shader.h
@@ -161,7 +161,7 @@ class RAS_Shader {
   void SetEnabled(bool enabled);
   bool GetEnabled() const;
 
-  // Apply methods : sets colected uniforms
+  // Apply methods : sets collected uniforms
   void ApplyShader();
   void UnloadShader();
   void DeleteShader();
@@ -180,7 +180,7 @@ class RAS_Shader {
 
   /** Return uniform location in the shader.
    * \param name The uniform name.
-   * \param debug Print message for unfound coresponding uniform name.
+   * \param debug Print message for unfound corresponding uniform name.
    */
   int GetUniformLocation(const std::string &name, bool debug = true);
 

--- a/source/gameengine/VideoTexture/blendVideoTex.cpp
+++ b/source/gameengine/VideoTexture/blendVideoTex.cpp
@@ -26,7 +26,7 @@ static PyObject *getMaterialID(PyObject *self, PyObject *args)
     return nullptr;
   // get material id
   short matID = getMaterialID(obj, matName);
-  // if material was not found, report errot
+  // if material was not found, report error
   if (matID < 0) {
     PyErr_SetString(
         PyExc_RuntimeError,
@@ -61,7 +61,7 @@ static PyObject *imageToArray(PyObject *self, PyObject *args)
   char *mode = nullptr;
   if (!PyArg_ParseTuple(args, "O|s:imageToArray", &pyImg, &mode) ||
       !pyImageTypes.in(Py_TYPE(pyImg))) {
-    // if object is incorect, report error
+    // if object is incorrect, report error
     PyErr_SetString(PyExc_TypeError,
                     "VideoTexture.imageToArray(image): The value must be a image source object");
     return nullptr;


### PR DESCRIPTION
Fix user-facing and non-user-facing typos  
Found via `codespell -D ../dictionary.txt -S "./locale,./intern,./extern" -L eiter,fiter,fpt,infront,inout,ot,parm,parms,poin,ptd,te source/gameengine/`


